### PR TITLE
fix: swap proxy ports in docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   proxy:
     image: nginx:1.28-bookworm
     ports:
-      - "8080:80"
+      - "80:8080"
     volumes:
       - ./docker/nginx.conf:/etc/nginx/conf.d/atomic.conf:ro
     networks:


### PR DESCRIPTION
service.ports configuration is "hostport:dockerport". nginx-fly.conf listens on port 8080 inside the docker, and README.md says to use the URL `http://localhost` (with no port specifier) for access, so this brings the configuration in line with multiple other checkpoints.