### PR TITLE
feat: add configurable Ollama timeout and improve error logging

### DIFF
--- a/crates/atomic-core/src/compaction.rs
+++ b/crates/atomic-core/src/compaction.rs
@@ -222,6 +222,10 @@ async fn get_merge_suggestions(
             }
             Err(e) => {
                 let err_str = e.to_string();
+                eprintln!("=== MERGE LLM ERROR (attempt {}/{}) ===", attempt + 1, 3);
+                eprintln!("Error: {}", err_str);
+                eprintln!("======================================");
+                
                 if e.is_retryable() {
                     last_error = err_str;
                     continue;

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -250,6 +250,10 @@ pub async fn extract_tags_from_content(
             }
             Err(e) => {
                 let err_str = e.to_string();
+                eprintln!("=== TAG EXTRACTION LLM ERROR (attempt {}/{}) ===", attempt + 1, 3);
+                eprintln!("Error: {}", err_str);
+                eprintln!("================================================");
+                
                 if e.is_retryable() {
                     last_error = err_str;
                     continue;
@@ -349,6 +353,10 @@ pub async fn extract_tags_from_chunk(
             }
             Err(e) => {
                 let err_str = e.to_string();
+                eprintln!("=== TAG EXTRACTION LLM ERROR (attempt {}/{}) ===", attempt + 1, 3);
+                eprintln!("Error: {}", err_str);
+                eprintln!("================================================");
+                
                 if e.is_retryable() {
                     last_error = err_str;
                     continue;
@@ -719,6 +727,10 @@ pub async fn consolidate_atom_tags(
             }
             Err(e) => {
                 let err_str = e.to_string();
+                eprintln!("=== TAG CONSOLIDATION LLM ERROR (attempt {}/{}) ===", attempt + 1, 3);
+                eprintln!("Error: {}", err_str);
+                eprintln!("======================================================");
+                
                 if e.is_retryable() {
                     last_error = err_str;
                     continue;

--- a/crates/atomic-core/src/providers/mod.rs
+++ b/crates/atomic-core/src/providers/mod.rs
@@ -52,6 +52,7 @@ pub struct ProviderConfig {
     pub ollama_embedding_model: String,
     pub ollama_llm_model: String,
     pub ollama_context_length: usize,
+    pub ollama_timeout_secs: u64,
     // OpenAI-compatible settings
     pub openai_compat_base_url: String,
     pub openai_compat_api_key: Option<String>,
@@ -90,6 +91,9 @@ impl ProviderConfig {
             ollama_context_length: settings.get("ollama_context_length")
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(65536),
+            ollama_timeout_secs: settings.get("ollama_timeout_secs")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(120), // Default 2 minutes
             openai_compat_base_url: settings.get("openai_compat_base_url")
                 .cloned()
                 .unwrap_or_default(),
@@ -190,7 +194,7 @@ pub fn create_embedding_provider(config: &ProviderConfig) -> Result<Arc<dyn Embe
             Ok(Arc::new(OpenRouterProvider::new(api_key)))
         }
         ProviderType::Ollama => {
-            Ok(Arc::new(OllamaProvider::new(Some(config.ollama_host.clone()))))
+            Ok(Arc::new(OllamaProvider::new(Some(config.ollama_host.clone()), Some(config.ollama_timeout_secs))))
         }
         ProviderType::OpenAICompat => {
             if config.openai_compat_base_url.is_empty() {
@@ -213,7 +217,7 @@ pub fn create_llm_provider(config: &ProviderConfig) -> Result<Arc<dyn LlmProvide
             Ok(Arc::new(OpenRouterProvider::new(api_key)))
         }
         ProviderType::Ollama => {
-            Ok(Arc::new(OllamaProvider::new(Some(config.ollama_host.clone()))))
+            Ok(Arc::new(OllamaProvider::new(Some(config.ollama_host.clone()), Some(config.ollama_timeout_secs))))
         }
         ProviderType::OpenAICompat => {
             if config.openai_compat_base_url.is_empty() {
@@ -236,7 +240,7 @@ pub fn create_streaming_llm_provider(config: &ProviderConfig) -> Result<Arc<dyn 
             Ok(Arc::new(OpenRouterProvider::new(api_key)))
         }
         ProviderType::Ollama => {
-            Ok(Arc::new(OllamaProvider::new(Some(config.ollama_host.clone()))))
+            Ok(Arc::new(OllamaProvider::new(Some(config.ollama_host.clone()), Some(config.ollama_timeout_secs))))
         }
         ProviderType::OpenAICompat => {
             if config.openai_compat_base_url.is_empty() {

--- a/crates/atomic-core/src/providers/ollama/llm.rs
+++ b/crates/atomic-core/src/providers/ollama/llm.rs
@@ -22,6 +22,8 @@ struct ChatRequest {
     format: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     options: Option<ChatOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    think: Option<bool>,
     stream: bool,
 }
 
@@ -193,12 +195,20 @@ pub async fn complete(
         None
     };
 
+    // Disable thinking for faster responses when minimize_reasoning is true
+    let think = if config.params.minimize_reasoning {
+        Some(false)
+    } else {
+        None
+    };
+
     let request = ChatRequest {
         model: config.model.clone(),
         messages: api_messages,
         tools: None,
         format,
         options,
+        think,
         stream: false,
     };
 
@@ -261,12 +271,20 @@ pub async fn complete_with_tools(
         None
     };
 
+    // Disable thinking for faster responses when minimize_reasoning is true
+    let think = if config.params.minimize_reasoning {
+        Some(false)
+    } else {
+        None
+    };
+
     let request = ChatRequest {
         model: config.model.clone(),
         messages: api_messages,
         tools: api_tools,
         format,
         options,
+        think,
         stream: false,
     };
 
@@ -326,12 +344,20 @@ pub async fn complete_streaming_with_tools(
         None
     };
 
+    // Disable thinking for faster responses when minimize_reasoning is true
+    let think = if config.params.minimize_reasoning {
+        Some(false)
+    } else {
+        None
+    };
+
     let request = ChatRequest {
         model: config.model.clone(),
         messages: api_messages,
         tools: api_tools,
         format: None, // Streaming doesn't support structured output
         options,
+        think,
         stream: true,
     };
 

--- a/crates/atomic-core/src/providers/ollama/mod.rs
+++ b/crates/atomic-core/src/providers/ollama/mod.rs
@@ -24,9 +24,10 @@ pub struct OllamaProvider {
 }
 
 impl OllamaProvider {
-    pub fn new(base_url: Option<String>) -> Self {
+    pub fn new(base_url: Option<String>, timeout_secs: Option<u64>) -> Self {
+        let timeout = Duration::from_secs(timeout_secs.unwrap_or(120));
         let client = Client::builder()
-            .timeout(Duration::from_secs(60))
+            .timeout(timeout)
             .build()
             .unwrap_or_else(|_| Client::new());
 

--- a/crates/atomic-core/src/settings.rs
+++ b/crates/atomic-core/src/settings.rs
@@ -15,6 +15,7 @@ pub const DEFAULT_SETTINGS: &[(&str, &str)] = &[
     ("ollama_host", DEFAULT_OLLAMA_HOST),
     ("ollama_embedding_model", "nomic-embed-text"),
     ("ollama_llm_model", "llama3.2"),
+    ("ollama_timeout_secs", "120"), // 2 minutes default for Ollama (local models can be slow)
     ("ollama_context_length", "65536"),
     ("openrouter_context_length", ""),
     ("embedding_model", "openai/text-embedding-3-small"),

--- a/src/components/onboarding/steps/AIProviderStep.tsx
+++ b/src/components/onboarding/steps/AIProviderStep.tsx
@@ -352,6 +352,25 @@ export function AIProviderStep({ state, dispatch }: AIProviderStepProps) {
                   ]}
                 />
               </div>
+
+              <div className="space-y-2">
+                <label className="block text-xs text-[var(--color-text-secondary)]">Request Timeout (seconds)</label>
+                <CustomSelect
+                  value={state.ollamaTimeoutSecs}
+                  onChange={(v) => dispatch({ type: 'SET_OLLAMA_TIMEOUT_SECS', value: v })}
+                  options={[
+                    { value: '30', label: '30 seconds' },
+                    { value: '60', label: '60 seconds' },
+                    { value: '120', label: '2 minutes' },
+                    { value: '180', label: '3 minutes' },
+                    { value: '300', label: '5 minutes' },
+                    { value: '600', label: '10 minutes' },
+                  ]}
+                />
+                <p className="text-[10px] text-[var(--color-text-tertiary)]">
+                  Maximum time to wait for Ollama to respond. Increase for slow models or large contexts.
+                </p>
+              </div>
             </div>
           )}
         </>

--- a/src/components/onboarding/useOnboardingState.ts
+++ b/src/components/onboarding/useOnboardingState.ts
@@ -37,6 +37,7 @@ export interface OnboardingState {
   ollamaModels: OllamaModel[];
   isLoadingOllamaModels: boolean;
   ollamaContextLength: string;
+  ollamaTimeoutSecs: string;
   // OpenAI Compatible
   openaiCompatBaseUrl: string;
   openaiCompatApiKey: string;
@@ -89,6 +90,7 @@ export type OnboardingAction =
   | { type: 'SET_OLLAMA_MODELS'; models: OllamaModel[] }
   | { type: 'SET_LOADING_OLLAMA_MODELS'; value: boolean }
   | { type: 'SET_OLLAMA_CONTEXT_LENGTH'; value: string }
+  | { type: 'SET_OLLAMA_TIMEOUT_SECS'; value: string }
   // OpenAI Compatible
   | { type: 'SET_OPENAI_COMPAT_BASE_URL'; value: string }
   | { type: 'SET_OPENAI_COMPAT_API_KEY'; value: string }
@@ -133,6 +135,7 @@ const initialState: OnboardingState = {
   ollamaModels: [],
   isLoadingOllamaModels: false,
   ollamaContextLength: '65536',
+  ollamaTimeoutSecs: '120',
   openaiCompatBaseUrl: '',
   openaiCompatApiKey: '',
   openaiCompatEmbeddingModel: '',
@@ -200,6 +203,8 @@ function reducer(state: OnboardingState, action: OnboardingAction): OnboardingSt
       return { ...state, isLoadingOllamaModels: action.value };
     case 'SET_OLLAMA_CONTEXT_LENGTH':
       return { ...state, ollamaContextLength: action.value };
+    case 'SET_OLLAMA_TIMEOUT_SECS':
+      return { ...state, ollamaTimeoutSecs: action.value };
     case 'SET_OPENAI_COMPAT_BASE_URL':
       return { ...state, openaiCompatBaseUrl: action.value };
     case 'SET_OPENAI_COMPAT_API_KEY':

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -273,6 +273,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const [ollamaEmbeddingModel, setOllamaEmbeddingModel] = useState('nomic-embed-text');
   const [ollamaLlmModel, setOllamaLlmModel] = useState('llama3.2');
   const [ollamaContextLength, setOllamaContextLength] = useState('65536');
+  const [ollamaTimeoutSecs, setOllamaTimeoutSecs] = useState('120');
   const [isLoadingOllamaModels, setIsLoadingOllamaModels] = useState(false);
 
   // Common settings
@@ -650,6 +651,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     setOllamaEmbeddingModel(settings.ollama_embedding_model || 'nomic-embed-text');
     setOllamaLlmModel(settings.ollama_llm_model || 'llama3.2');
     setOllamaContextLength(settings.ollama_context_length || '65536');
+    setOllamaTimeoutSecs(settings.ollama_timeout_secs || '120');
     setOpenaiCompatBaseUrl(settings.openai_compat_base_url || '');
     setOpenaiCompatApiKey(settings.openai_compat_api_key || '');
     setOpenaiCompatEmbeddingModel(settings.openai_compat_embedding_model || '');
@@ -1242,6 +1244,28 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                 { value: '131072', label: '128K' },
                                 { value: '262144', label: '256K' },
                                 { value: '1000000', label: '1M' },
+                              ]}
+                            />
+                          </div>
+
+                          {/* Timeout */}
+                          <div className="space-y-1">
+                            <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                              Request Timeout
+                            </label>
+                            <p className="text-xs text-[var(--color-text-secondary)]">
+                              Maximum time to wait for Ollama to respond
+                            </p>
+                            <CustomSelect
+                              value={ollamaTimeoutSecs}
+                              onChange={(v) => { setOllamaTimeoutSecs(v); autoSave('ollama_timeout_secs', v); }}
+                              options={[
+                                { value: '30', label: '30 seconds' },
+                                { value: '60', label: '60 seconds' },
+                                { value: '120', label: '2 minutes' },
+                                { value: '180', label: '3 minutes' },
+                                { value: '300', label: '5 minutes' },
+                                { value: '600', label: '10 minutes' },
                               ]}
                             />
                           </div>


### PR DESCRIPTION
## Summary

This PR addresses Ollama timeout issues for slow-running models by making the request timeout configurable via the UI, and adds detailed error logging to help diagnose API failures.
I was always getting 500s from my local Ollama, so I used Qwen35 to explore the code base, add logging, check how the timeout was set, then first add it to the setting. That worked, so I asked the model to also it to the settings page for Ollama.

Feel free to ask for changes (field ordering, configured timeouts, wording...)

## Changes

Backend (atomic-core)

1. Made Ollama timeout configurable (crates/atomic-core/src/settings.rs, providers/mod.rs, providers/ollama/mod.rs)
 - Added ollama_timeout_secs setting with a default of 120 seconds (2 minutes)
 - Updated ProviderConfig to include the timeout value
 - Modified OllamaProvider::new() to accept a configurable timeout parameter
 - Timeout is now read from settings and applied to the reqwest HTTP client

2. Added `think: false` for Ollama reasoning models (crates/atomic-core/src/providers/ollama/llm.rs)
 - Improves speed, especially with Qwen35 models (I wasn't able to turn off thinking in Ollama)
 - Added think field to Ollama's ChatRequest struct
 - Automatically sets "think": false when minimize_reasoning: true (already used for tag extraction and compaction)
 - Untested with vLLM/Lemonade/llama.cpp/LM Studio

4. Enhanced error logging (crates/atomic-core/src/extraction.rs, compaction.rs)
 - Added eprintln! statements when LLM calls fail
 - Shows attempt number, error message, and operation type
 - Helps diagnose timeout and API errors during development/debugging

Frontend (src/)

1. Added timeout selector to onboarding flow (components/onboarding/)
 - Updated useOnboardingState.ts with ollamaTimeoutSecs state
 - Added UI control in AIProviderStep.tsx with options: 30s, 60s, 2m, 3m, 5m, 10m
 - Includes helpful description text

2. Added timeout selector to settings modal (components/settings/SettingsModal.tsx)
 - Added ollamaTimeoutSecs state variable
 - Loads existing value from settings on open
 - Auto-saves changes to ollama_timeout_secs setting
 - Placed alongside Context Length in the Ollama configuration section

User Impact

Before:
 - Hardcoded 60-second timeout caused frequent 500 errors with slow Ollama models/on slow hardware.
 - No visibility into why Ollama calls failed
 - No way to configure timeout without code changes

After:
 - Default timeout doubled to 2 minutes
 - Users can configure timeout from 30 seconds to 10 minutes via UI
 - Error messages show what failed and when
 - Reasoning models skip unnecessary thinking for simple tasks (faster responses)

Testing

 - ✅ Frontend builds successfully with npm run tauri build
 - ✅ Timeout selector appears in settings modal
 - ✅ Setting persists to database and survives app restart

This should help in any timeout issues for users running:
 - Large context models
 - Slow local hardware
 - Models requiring extended reasoning time (when think: false isn't applicable)