### PR TITLE
feat: switch extension to activeTab-only permissions for Chrome Store

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -22,15 +22,8 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   }
 });
 
-// Extract content, injecting content script if needed
+// Extract content by injecting content script on demand (activeTab)
 async function extractFromTab(tabId, mode) {
-  try {
-    const result = await chrome.tabs.sendMessage(tabId, { action: 'extract', mode });
-    if (result && result.content) return result;
-  } catch (_) {
-    // Content script not loaded — fall back to programmatic injection
-  }
-
   await chrome.scripting.executeScript({
     target: { tabId },
     files: ['lib/readability.min.js', 'lib/turndown.min.js', 'content/content-script.js']

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,28 +13,12 @@
     "alarms"
   ],
 
-  "host_permissions": [
-    "<all_urls>"
-  ],
-
   "options_page": "options/options.html",
 
   "background": {
     "service_worker": "background/service-worker.js",
     "type": "module"
   },
-
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": [
-        "lib/readability.min.js",
-        "lib/turndown.min.js",
-        "content/content-script.js"
-      ],
-      "run_at": "document_idle"
-    }
-  ],
 
   "action": {
     "default_popup": "popup/popup.html",

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -80,17 +80,8 @@ async function getQueue() {
   return result[QUEUE_KEY] || [];
 }
 
-// Extract content by injecting the content script directly
+// Extract content by injecting content script on demand (activeTab)
 async function extractFromTab(tabId, mode) {
-  // Try messaging the existing content script first
-  try {
-    const result = await chrome.tabs.sendMessage(tabId, { action: 'extract', mode });
-    if (result && result.content) return result;
-  } catch (_) {
-    // Content script not loaded — fall back to programmatic injection
-  }
-
-  // Inject the libraries and content script, then run extraction
   await chrome.scripting.executeScript({
     target: { tabId },
     files: ['lib/readability.min.js', 'lib/turndown.min.js', 'content/content-script.js']


### PR DESCRIPTION
Remove <all_urls> host_permissions and auto-injected content scripts. Scripts are now injected on demand via activeTab + scripting when the user clicks the extension or context menu.