### PR TITLE
fix: normalize OpenAI-compat base URL to include /v1 prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ fly.toml
 ios/AtomicMobile.xcodeproj/
 ios/DerivedData/
 ios/build/
+
+# Claude Code
+.claude/

--- a/crates/atomic-core/src/providers/openai_compat/mod.rs
+++ b/crates/atomic-core/src/providers/openai_compat/mod.rs
@@ -30,10 +30,19 @@ impl OpenAICompatProvider {
             .build()
             .unwrap_or_else(|_| Client::new());
 
+        // Normalize the base URL to always end with /v1 so callers can provide
+        // either "http://host:port" or "http://host:port/v1" and both work.
+        let trimmed = base_url.trim_end_matches('/').to_string();
+        let base_url = if trimmed.ends_with("/v1") {
+            trimmed
+        } else {
+            format!("{}/v1", trimmed)
+        };
+
         Self {
             client,
             api_key,
-            base_url: base_url.trim_end_matches('/').to_string(),
+            base_url,
         }
     }
 


### PR DESCRIPTION
Users configuring llama.cpp or other OpenAI-compatible servers would get 404s or wrong response formats if they set the base URL without /v1 (e.g. http://localhost:8090 instead of http://localhost:8090/v1). The provider now auto-appends /v1 when missing so both forms work.

Also adds .claude/ to .gitignore.