### PR TITLE
feat: add "Re-embed All Atoms" button in settings

### DIFF
--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -915,6 +915,39 @@ impl AtomicCore {
         Ok(())
     }
 
+    /// Re-embed all atoms in the database
+    pub fn reembed_all_atoms<F>(&self, on_event: F) -> Result<i32, AtomicCoreError>
+    where
+        F: Fn(EmbeddingEvent) + Send + Sync + Clone + 'static,
+    {
+        let atoms = self.storage.claim_all_for_reembedding_sync()?;
+        let count = atoms.len() as i32;
+
+        if count > 0 {
+            let storage_clone = self.storage.clone();
+            let bg_settings = self.settings_for_background();
+            executor::spawn(async move {
+                match bg_settings {
+                    Some(s) => embedding::process_embedding_batch_with_settings(
+                        storage_clone,
+                        atoms,
+                        false,
+                        on_event,
+                        s,
+                    ).await,
+                    None => embedding::process_embedding_batch(
+                        storage_clone,
+                        atoms,
+                        false,
+                        on_event,
+                    ).await,
+                };
+            });
+        }
+
+        Ok(count)
+    }
+
     /// Retry tagging for a specific atom
     pub fn retry_tagging<F>(&self, atom_id: &str, on_event: F) -> Result<(), AtomicCoreError>
     where

--- a/crates/atomic-core/src/storage/mod.rs
+++ b/crates/atomic-core/src/storage/mod.rs
@@ -281,6 +281,8 @@ dispatch! {
         => sqlite: recreate_vector_index_sync, pg_trait: ChunkStore, pg_method: recreate_vector_index;
     fn claim_pending_reembedding_sync(&self) -> Result<Vec<(String, String)>, AtomicCoreError>
         => sqlite: claim_pending_reembedding_sync, pg_trait: ChunkStore, pg_method: claim_pending_reembedding;
+    fn claim_all_for_reembedding_sync(&self) -> Result<Vec<(String, String)>, AtomicCoreError>
+        => sqlite: claim_all_for_reembedding_sync, pg_trait: ChunkStore, pg_method: claim_all_for_reembedding;
 
     // ---- SearchStore ----
     fn vector_search_sync(&self, query_embedding: &[f32], limit: i32, threshold: f32, tag_id: Option<&str>) -> Result<Vec<SemanticSearchResult>, AtomicCoreError>

--- a/crates/atomic-core/src/storage/postgres/chunks.rs
+++ b/crates/atomic-core/src/storage/postgres/chunks.rs
@@ -877,6 +877,19 @@ impl ChunkStore for PostgresStorage {
         .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
         Ok(rows)
     }
+
+    async fn claim_all_for_reembedding(&self) -> StorageResult<Vec<(String, String)>> {
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "UPDATE atoms SET embedding_status = 'processing'
+             WHERE db_id = $1
+             RETURNING id, content",
+        )
+        .bind(&self.db_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+        Ok(rows)
+    }
 }
 
 // ==================== Private Helpers ====================

--- a/crates/atomic-core/src/storage/sqlite/chunks.rs
+++ b/crates/atomic-core/src/storage/sqlite/chunks.rs
@@ -458,6 +458,22 @@ impl SqliteStorage {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(results)
     }
+
+    pub(crate) fn claim_all_for_reembedding_sync(&self) -> StorageResult<Vec<(String, String)>> {
+        let conn = self
+            .db
+            .conn
+            .lock()
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
+        let mut stmt = conn.prepare(
+            "UPDATE atoms SET embedding_status = 'processing'
+             RETURNING id, content",
+        )?;
+        let results = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(results)
+    }
 }
 
 #[async_trait]
@@ -576,5 +592,9 @@ impl ChunkStore for SqliteStorage {
 
     async fn claim_pending_reembedding(&self) -> StorageResult<Vec<(String, String)>> {
         self.claim_pending_reembedding_sync()
+    }
+
+    async fn claim_all_for_reembedding(&self) -> StorageResult<Vec<(String, String)>> {
+        self.claim_all_for_reembedding_sync()
     }
 }

--- a/crates/atomic-core/src/storage/traits.rs
+++ b/crates/atomic-core/src/storage/traits.rs
@@ -298,6 +298,10 @@ pub trait ChunkStore: Send + Sync {
     /// Claim pending/processing atoms for re-embedding after dimension change.
     /// Sets status to 'processing' and returns (atom_id, content) pairs.
     async fn claim_pending_reembedding(&self) -> StorageResult<Vec<(String, String)>>;
+
+    /// Claim ALL atoms for re-embedding regardless of current status.
+    /// Sets status to 'processing' and returns (atom_id, content) pairs.
+    async fn claim_all_for_reembedding(&self) -> StorageResult<Vec<(String, String)>>;
 }
 
 // ==================== Search Storage ====================

--- a/crates/atomic-server/src/lib.rs
+++ b/crates/atomic-server/src/lib.rs
@@ -66,6 +66,7 @@ pub use utoipa_scalar::{Scalar, Servable};
         routes::embedding::process_pending_tagging,
         routes::embedding::retry_embedding,
         routes::embedding::retry_tagging,
+        routes::embedding::reembed_all_atoms,
         routes::embedding::reset_stuck_processing,
         routes::embedding::get_embedding_status,
         // Canvas

--- a/crates/atomic-server/src/routes/embedding.rs
+++ b/crates/atomic-server/src/routes/embedding.rs
@@ -52,6 +52,15 @@ pub async fn retry_tagging(
     }
 }
 
+#[utoipa::path(post, path = "/api/embeddings/reembed-all", responses((status = 200, description = "Number of atoms queued for re-embedding")), tag = "embeddings")]
+pub async fn reembed_all_atoms(state: web::Data<AppState>, db: Db) -> HttpResponse {
+    let on_event = embedding_event_callback(state.event_tx.clone());
+    match db.0.reembed_all_atoms(on_event) {
+        Ok(count) => HttpResponse::Ok().json(serde_json::json!({"count": count})),
+        Err(e) => crate::error::error_response(e),
+    }
+}
+
 #[utoipa::path(post, path = "/api/embeddings/reset-stuck", responses((status = 200, description = "Number of stuck atoms reset")), tag = "embeddings")]
 pub async fn reset_stuck_processing(db: Db) -> HttpResponse {
     match db.0.reset_stuck_processing() {

--- a/crates/atomic-server/src/routes/mod.rs
+++ b/crates/atomic-server/src/routes/mod.rs
@@ -109,6 +109,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         web::post().to(embedding::retry_tagging),
     );
     cfg.route(
+        "/embeddings/reembed-all",
+        web::post().to(embedding::reembed_all_atoms),
+    );
+    cfg.route(
         "/embeddings/reset-stuck",
         web::post().to(embedding::reset_stuck_processing),
     );

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -31,6 +31,7 @@ import {
   type ApiTokenInfo,
   type CreateTokenResponse,
   type Feed,
+  reembedAllAtoms,
   type IngestionResult,
   type FeedPollResult,
 } from '../../lib/api';
@@ -336,6 +337,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const [ingesting, setIngesting] = useState(false);
   const [ingestResult, setIngestResult] = useState<IngestionResult | null>(null);
   const [ingestError, setIngestError] = useState<string | null>(null);
+
+  // Re-embed state
+  const [showReembedConfirm, setShowReembedConfirm] = useState(false);
+  const [reembedding, setReembedding] = useState(false);
+  const [reembedResult, setReembedResult] = useState<number | null>(null);
+  const [reembedError, setReembedError] = useState<string | null>(null);
 
   // Feed action state
   const [pollingFeedId, setPollingFeedId] = useState<string | null>(null);
@@ -1489,6 +1496,82 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                       </div>
                     </>
                   )}
+                  {/* Re-embed All Section */}
+                  <div className="space-y-3 pt-4 border-t border-[var(--color-border)]">
+                    <div className="space-y-1">
+                      <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                        Re-embed All Atoms
+                      </label>
+                      <p className="text-xs text-[var(--color-text-secondary)]">
+                        Regenerate embeddings for every atom in the current database. Useful after changing providers or if embeddings were interrupted.
+                      </p>
+                    </div>
+
+                    {!showReembedConfirm ? (
+                      <Button
+                        variant="secondary"
+                        onClick={() => { setShowReembedConfirm(true); setReembedResult(null); setReembedError(null); }}
+                        disabled={reembedding}
+                      >
+                        Re-embed All Atoms
+                      </Button>
+                    ) : (
+                      <div className="p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-md space-y-3">
+                        <p className="text-sm text-yellow-200">
+                          This will re-embed <strong>all</strong> atoms in the current database. This is a bulk operation that may take a while depending on how many atoms you have and your provider's rate limits.
+                        </p>
+                        <div className="flex gap-2">
+                          <Button
+                            onClick={async () => {
+                              setReembedding(true);
+                              setShowReembedConfirm(false);
+                              setReembedResult(null);
+                              setReembedError(null);
+                              try {
+                                const count = await reembedAllAtoms();
+                                setReembedResult(count);
+                              } catch (e) {
+                                setReembedError(String(e));
+                              } finally {
+                                setReembedding(false);
+                              }
+                            }}
+                            disabled={reembedding}
+                          >
+                            {reembedding ? (
+                              <>
+                                <svg className="w-4 h-4 animate-spin mr-1" fill="none" viewBox="0 0 24 24">
+                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                                </svg>
+                                Starting...
+                              </>
+                            ) : 'Confirm Re-embed'}
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            onClick={() => setShowReembedConfirm(false)}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+
+                    {reembedResult !== null && (
+                      <div className="p-3 bg-green-500/10 border border-green-500/30 rounded-md text-sm">
+                        <div className="text-green-400 font-medium">Queued {reembedResult} atoms for re-embedding</div>
+                        <div className="text-[var(--color-text-secondary)]">Embeddings are being generated in the background.</div>
+                      </div>
+                    )}
+
+                    {reembedError && (
+                      <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-md text-sm">
+                        <div className="text-red-400 font-medium">Re-embedding failed</div>
+                        <div className="text-[var(--color-text-secondary)]">{reembedError}</div>
+                      </div>
+                    )}
+                  </div>
                 </>
               )}
 
@@ -1766,6 +1849,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                       )}
                     </div>
                   )}
+
                 </>
               )}
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,11 @@ export async function retryTagging(atomId: string): Promise<void> {
   return getTransport().invoke('retry_tagging', { atomId });
 }
 
+// Re-embed all atoms
+export async function reembedAllAtoms(): Promise<number> {
+  return getTransport().invoke('reembed_all_atoms');
+}
+
 // Reset atoms stuck in 'processing' state (call on app startup)
 export async function resetStuckProcessing(): Promise<number> {
   return getTransport().invoke('reset_stuck_processing');

--- a/src/lib/transport/command-map.ts
+++ b/src/lib/transport/command-map.ts
@@ -152,6 +152,11 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
     method: 'POST',
     path: (a) => `/api/tagging/retry/${encodeURIComponent(a.atomId as string)}`,
   },
+  reembed_all_atoms: {
+    method: 'POST',
+    path: '/api/embeddings/reembed-all',
+    transformResponse: (d: any) => d.count as number,
+  },
   reset_stuck_processing: {
     method: 'POST',
     path: '/api/embeddings/reset-stuck',


### PR DESCRIPTION
Adds a bulk re-embedding action under the AI Models settings tab. Includes a confirmation step warning users this is a bulk operation that may take time depending on atom count and provider rate limits.