### PR TITLE
Add Louvain and Leiden clustering algorithms with canvas selector

### DIFF
--- a/crates/atomic-core/src/canvas_level.rs
+++ b/crates/atomic-core/src/canvas_level.rs
@@ -173,7 +173,7 @@ pub fn get_canvas_level(
 /// Root level: show semantic clusters of all atoms
 fn build_root_level(conn: &Connection) -> Result<CanvasLevel, AtomicCoreError> {
     // Compute semantic clusters on-demand from all semantic edges
-    let clusters = clustering::compute_atom_clusters(conn, CLUSTER_MIN_SIMILARITY, 3)
+    let clusters = clustering::compute_atom_clusters(conn, CLUSTER_MIN_SIMILARITY, 3, crate::models::ClusterAlgorithm::default())
         .map_err(|e| AtomicCoreError::Configuration(e))?;
 
     let mut nodes: Vec<CanvasNode> = Vec::new();

--- a/crates/atomic-core/src/clustering.rs
+++ b/crates/atomic-core/src/clustering.rs
@@ -152,19 +152,11 @@ pub fn louvain(edges: &[(String, String, f32)]) -> HashMap<String, u32> {
     for _ in 0..max_passes {
         let mut improved = false;
 
-        // Compute community aggregates: sum_tot (total incident weight) and sum_in (internal weight)
+        // Compute sum_tot: total incident weight per community
         let mut sum_tot: HashMap<u32, f64> = HashMap::new();
-        let mut sum_in: HashMap<u32, f64> = HashMap::new();
         for node in &sorted_nodes {
             let c = community[node];
             *sum_tot.entry(c).or_default() += k[node];
-        }
-        for (source, target, weight) in edges {
-            let cs = community[source];
-            let ct = community[target];
-            if cs == ct {
-                *sum_in.entry(cs).or_default() += 2.0 * (*weight as f64);
-            }
         }
 
         for node in &sorted_nodes {
@@ -181,9 +173,10 @@ pub fn louvain(edges: &[(String, String, f32)]) -> HashMap<String, u32> {
             }
 
             // Delta Q for removing node from its current community
+            // Standard formula uses (sum_tot[C] - k_i) to exclude node i's own contribution
             let ki_in_current = neighbor_comm_weights.get(&current_comm).copied().unwrap_or(0.0);
             let st_current = sum_tot.get(&current_comm).copied().unwrap_or(0.0);
-            let remove_cost = ki_in_current / two_m - (st_current * ki) / (two_m * two_m);
+            let remove_cost = ki_in_current / two_m - ((st_current - ki) * ki) / (two_m * two_m);
 
             // Find best community to move to
             let mut best_comm = current_comm;
@@ -202,13 +195,9 @@ pub fn louvain(edges: &[(String, String, f32)]) -> HashMap<String, u32> {
             }
 
             if best_comm != current_comm {
-                // Update aggregates
-                let ki = k[node];
+                // Update sum_tot aggregates
                 *sum_tot.entry(current_comm).or_default() -= ki;
                 *sum_tot.entry(best_comm).or_default() += ki;
-                *sum_in.entry(current_comm).or_default() -= 2.0 * ki_in_current;
-                let ki_in_best = neighbor_comm_weights.get(&best_comm).copied().unwrap_or(0.0);
-                *sum_in.entry(best_comm).or_default() += 2.0 * ki_in_best;
 
                 community.insert(node.clone(), best_comm);
                 improved = true;
@@ -237,9 +226,15 @@ pub fn louvain(edges: &[(String, String, f32)]) -> HashMap<String, u32> {
     result
 }
 
-/// Run Leiden community detection on a weighted adjacency list.
-/// Improves on Louvain by adding a refinement phase that ensures
-/// communities are well-connected internally.
+/// Louvain-based community detection with intra-community refinement.
+///
+/// Extends the Louvain algorithm with a refinement phase: after the initial
+/// local-move pass, each community is re-partitioned from singletons using
+/// modularity-guided local moves restricted to that community. This encourages
+/// internally well-connected communities, inspired by (but not identical to)
+/// the Leiden algorithm of Traag et al. 2019 — the published Leiden uses
+/// randomised CPM-gated merging whereas this variant uses deterministic
+/// modularity-based local moves for the refinement step.
 pub fn leiden(edges: &[(String, String, f32)]) -> HashMap<String, u32> {
     if edges.is_empty() {
         return HashMap::new();
@@ -320,7 +315,7 @@ pub fn leiden(edges: &[(String, String, f32)]) -> HashMap<String, u32> {
                     neighbor_comm_weights.get(&current_comm).copied().unwrap_or(0.0);
                 let st_current = sum_tot.get(&current_comm).copied().unwrap_or(0.0);
                 let remove_cost =
-                    ki_in_current / two_m - (st_current * ki) / (two_m * two_m);
+                    ki_in_current / two_m - ((st_current - ki) * ki) / (two_m * two_m);
 
                 let mut best_comm = current_comm;
                 let mut best_gain = 0.0;
@@ -421,7 +416,7 @@ pub fn leiden(edges: &[(String, String, f32)]) -> HashMap<String, u32> {
                         neighbor_sub_weights.get(&current_sub).copied().unwrap_or(0.0);
                     let st_current = sub_sum_tot.get(&current_sub).copied().unwrap_or(0.0);
                     let remove_cost =
-                        ki_in_current / two_m - (st_current * ki) / (two_m * two_m);
+                        ki_in_current / two_m - ((st_current - ki) * ki) / (two_m * two_m);
 
                     let mut best_sub = current_sub;
                     let mut best_gain = 0.0;

--- a/crates/atomic-core/src/clustering.rs
+++ b/crates/atomic-core/src/clustering.rs
@@ -5,7 +5,20 @@
 use rusqlite::Connection;
 use std::collections::{HashMap, HashSet};
 
-use crate::models::AtomCluster;
+use crate::models::{AtomCluster, ClusterAlgorithm};
+
+/// Dispatch to the selected clustering algorithm.
+/// All algorithms take the same weighted edge list and return node → cluster label.
+pub fn run_algorithm(
+    algorithm: ClusterAlgorithm,
+    edges: &[(String, String, f32)],
+) -> HashMap<String, u32> {
+    match algorithm {
+        ClusterAlgorithm::LabelPropagation => label_propagation(edges),
+        ClusterAlgorithm::Louvain => louvain(edges),
+        ClusterAlgorithm::Leiden => leiden(edges),
+    }
+}
 
 /// Run label propagation on an arbitrary weighted adjacency list.
 /// Returns a map from node ID to cluster label (u32).
@@ -80,6 +93,392 @@ pub fn label_propagation(
     labels
 }
 
+/// Run Louvain modularity optimization on a weighted adjacency list.
+/// Phase 1: Greedily move nodes to neighbor communities to maximize modularity.
+/// Phase 2: Collapse communities into super-nodes; repeat until no improvement.
+pub fn louvain(edges: &[(String, String, f32)]) -> HashMap<String, u32> {
+    if edges.is_empty() {
+        return HashMap::new();
+    }
+
+    // Build adjacency and compute total weight
+    let mut adjacency: HashMap<String, Vec<(String, f32)>> = HashMap::new();
+    let mut all_nodes: HashSet<String> = HashSet::new();
+    let mut total_weight: f64 = 0.0;
+
+    for (source, target, weight) in edges {
+        let w = *weight;
+        adjacency
+            .entry(source.clone())
+            .or_default()
+            .push((target.clone(), w));
+        adjacency
+            .entry(target.clone())
+            .or_default()
+            .push((source.clone(), w));
+        all_nodes.insert(source.clone());
+        all_nodes.insert(target.clone());
+        total_weight += w as f64;
+    }
+
+    // total_weight = sum of all edge weights (each edge counted once above)
+    // In modularity formula, m = total_weight, and we use 2m for normalization
+    let two_m = 2.0 * total_weight;
+    if two_m == 0.0 {
+        return HashMap::new();
+    }
+
+    let mut sorted_nodes: Vec<String> = all_nodes.into_iter().collect();
+    sorted_nodes.sort();
+
+    // Initialize: each node in its own community
+    let mut community: HashMap<String, u32> = HashMap::new();
+    for (i, node) in sorted_nodes.iter().enumerate() {
+        community.insert(node.clone(), i as u32);
+    }
+
+    // k_i = sum of weights of all edges incident to node i
+    let mut k: HashMap<String, f64> = HashMap::new();
+    for node in &sorted_nodes {
+        let ki: f64 = adjacency
+            .get(node)
+            .map(|neighbors| neighbors.iter().map(|(_, w)| *w as f64).sum())
+            .unwrap_or(0.0);
+        k.insert(node.clone(), ki);
+    }
+
+    // Phase 1: Local moves
+    let max_passes = 20;
+    for _ in 0..max_passes {
+        let mut improved = false;
+
+        // Compute community aggregates: sum_tot (total incident weight) and sum_in (internal weight)
+        let mut sum_tot: HashMap<u32, f64> = HashMap::new();
+        let mut sum_in: HashMap<u32, f64> = HashMap::new();
+        for node in &sorted_nodes {
+            let c = community[node];
+            *sum_tot.entry(c).or_default() += k[node];
+        }
+        for (source, target, weight) in edges {
+            let cs = community[source];
+            let ct = community[target];
+            if cs == ct {
+                *sum_in.entry(cs).or_default() += 2.0 * (*weight as f64);
+            }
+        }
+
+        for node in &sorted_nodes {
+            let ki = k[node];
+            let current_comm = community[node];
+
+            // Compute k_i_in for each neighboring community
+            let mut neighbor_comm_weights: HashMap<u32, f64> = HashMap::new();
+            if let Some(neighbors) = adjacency.get(node) {
+                for (neighbor, w) in neighbors {
+                    let nc = community[neighbor];
+                    *neighbor_comm_weights.entry(nc).or_default() += *w as f64;
+                }
+            }
+
+            // Delta Q for removing node from its current community
+            let ki_in_current = neighbor_comm_weights.get(&current_comm).copied().unwrap_or(0.0);
+            let st_current = sum_tot.get(&current_comm).copied().unwrap_or(0.0);
+            let remove_cost = ki_in_current / two_m - (st_current * ki) / (two_m * two_m);
+
+            // Find best community to move to
+            let mut best_comm = current_comm;
+            let mut best_gain = 0.0;
+
+            for (&target_comm, &ki_in_target) in &neighbor_comm_weights {
+                if target_comm == current_comm {
+                    continue;
+                }
+                let st_target = sum_tot.get(&target_comm).copied().unwrap_or(0.0);
+                let gain = ki_in_target / two_m - (st_target * ki) / (two_m * two_m) - remove_cost;
+                if gain > best_gain {
+                    best_gain = gain;
+                    best_comm = target_comm;
+                }
+            }
+
+            if best_comm != current_comm {
+                // Update aggregates
+                let ki = k[node];
+                *sum_tot.entry(current_comm).or_default() -= ki;
+                *sum_tot.entry(best_comm).or_default() += ki;
+                *sum_in.entry(current_comm).or_default() -= 2.0 * ki_in_current;
+                let ki_in_best = neighbor_comm_weights.get(&best_comm).copied().unwrap_or(0.0);
+                *sum_in.entry(best_comm).or_default() += 2.0 * ki_in_best;
+
+                community.insert(node.clone(), best_comm);
+                improved = true;
+            }
+        }
+
+        if !improved {
+            break;
+        }
+    }
+
+    // Normalize labels to 0..N
+    let mut label_map: HashMap<u32, u32> = HashMap::new();
+    let mut next_label = 0u32;
+    let mut result: HashMap<String, u32> = HashMap::new();
+    for node in &sorted_nodes {
+        let c = community[node];
+        let label = *label_map.entry(c).or_insert_with(|| {
+            let l = next_label;
+            next_label += 1;
+            l
+        });
+        result.insert(node.clone(), label);
+    }
+
+    result
+}
+
+/// Run Leiden community detection on a weighted adjacency list.
+/// Improves on Louvain by adding a refinement phase that ensures
+/// communities are well-connected internally.
+pub fn leiden(edges: &[(String, String, f32)]) -> HashMap<String, u32> {
+    if edges.is_empty() {
+        return HashMap::new();
+    }
+
+    // Build adjacency
+    let mut adjacency: HashMap<String, Vec<(String, f32)>> = HashMap::new();
+    let mut all_nodes: HashSet<String> = HashSet::new();
+    let mut total_weight: f64 = 0.0;
+
+    for (source, target, weight) in edges {
+        let w = *weight;
+        adjacency
+            .entry(source.clone())
+            .or_default()
+            .push((target.clone(), w));
+        adjacency
+            .entry(target.clone())
+            .or_default()
+            .push((source.clone(), w));
+        all_nodes.insert(source.clone());
+        all_nodes.insert(target.clone());
+        total_weight += w as f64;
+    }
+
+    let two_m = 2.0 * total_weight;
+    if two_m == 0.0 {
+        return HashMap::new();
+    }
+
+    let mut sorted_nodes: Vec<String> = all_nodes.into_iter().collect();
+    sorted_nodes.sort();
+
+    // k_i = sum of weights of all edges incident to node i
+    let mut k: HashMap<String, f64> = HashMap::new();
+    for node in &sorted_nodes {
+        let ki: f64 = adjacency
+            .get(node)
+            .map(|neighbors| neighbors.iter().map(|(_, w)| *w as f64).sum())
+            .unwrap_or(0.0);
+        k.insert(node.clone(), ki);
+    }
+
+    // Initialize: each node in its own community
+    let mut community: HashMap<String, u32> = HashMap::new();
+    for (i, node) in sorted_nodes.iter().enumerate() {
+        community.insert(node.clone(), i as u32);
+    }
+
+    let max_iterations = 10;
+    for _ in 0..max_iterations {
+        // --- Phase 1: Local moving (same as Louvain) ---
+        let mut phase1_community = community.clone();
+        let mut moved = false;
+
+        for _ in 0..20 {
+            let mut pass_moved = false;
+
+            let mut sum_tot: HashMap<u32, f64> = HashMap::new();
+            for node in &sorted_nodes {
+                let c = phase1_community[node];
+                *sum_tot.entry(c).or_default() += k[node];
+            }
+
+            for node in &sorted_nodes {
+                let ki = k[node];
+                let current_comm = phase1_community[node];
+
+                let mut neighbor_comm_weights: HashMap<u32, f64> = HashMap::new();
+                if let Some(neighbors) = adjacency.get(node) {
+                    for (neighbor, w) in neighbors {
+                        let nc = phase1_community[neighbor];
+                        *neighbor_comm_weights.entry(nc).or_default() += *w as f64;
+                    }
+                }
+
+                let ki_in_current =
+                    neighbor_comm_weights.get(&current_comm).copied().unwrap_or(0.0);
+                let st_current = sum_tot.get(&current_comm).copied().unwrap_or(0.0);
+                let remove_cost =
+                    ki_in_current / two_m - (st_current * ki) / (two_m * two_m);
+
+                let mut best_comm = current_comm;
+                let mut best_gain = 0.0;
+
+                for (&target_comm, &ki_in_target) in &neighbor_comm_weights {
+                    if target_comm == current_comm {
+                        continue;
+                    }
+                    let st_target = sum_tot.get(&target_comm).copied().unwrap_or(0.0);
+                    let gain =
+                        ki_in_target / two_m - (st_target * ki) / (two_m * two_m) - remove_cost;
+                    if gain > best_gain {
+                        best_gain = gain;
+                        best_comm = target_comm;
+                    }
+                }
+
+                if best_comm != current_comm {
+                    *sum_tot.entry(current_comm).or_default() -= ki;
+                    *sum_tot.entry(best_comm).or_default() += ki;
+                    phase1_community.insert(node.clone(), best_comm);
+                    pass_moved = true;
+                    moved = true;
+                }
+            }
+
+            if !pass_moved {
+                break;
+            }
+        }
+
+        if !moved {
+            break;
+        }
+
+        // --- Phase 2: Refinement ---
+        // Within each phase-1 community, re-partition nodes using local moves
+        // restricted to subcommunities of that community. This ensures communities
+        // are internally well-connected.
+        let mut refined_community: HashMap<String, u32> = HashMap::new();
+        let mut next_refined_label = 0u32;
+
+        // Group nodes by phase-1 community
+        let mut comm_members: HashMap<u32, Vec<String>> = HashMap::new();
+        for node in &sorted_nodes {
+            comm_members
+                .entry(phase1_community[node])
+                .or_default()
+                .push(node.clone());
+        }
+
+        for (_comm_id, members) in &comm_members {
+            if members.len() <= 1 {
+                // Singleton — keep as-is
+                for node in members {
+                    refined_community.insert(node.clone(), next_refined_label);
+                }
+                next_refined_label += 1;
+                continue;
+            }
+
+            // Start each node in its own sub-community within this phase-1 community
+            let member_set: HashSet<&String> = members.iter().collect();
+            let mut sub_comm: HashMap<String, u32> = HashMap::new();
+            let mut sub_label = next_refined_label;
+            for node in members {
+                sub_comm.insert(node.clone(), sub_label);
+                sub_label += 1;
+            }
+
+            // Local moves within this community only
+            for _ in 0..10 {
+                let mut sub_moved = false;
+
+                let mut sub_sum_tot: HashMap<u32, f64> = HashMap::new();
+                for node in members {
+                    let c = sub_comm[node];
+                    *sub_sum_tot.entry(c).or_default() += k[node];
+                }
+
+                for node in members {
+                    let ki = k[node];
+                    let current_sub = sub_comm[node];
+
+                    // Only consider neighbors within this community
+                    let mut neighbor_sub_weights: HashMap<u32, f64> = HashMap::new();
+                    if let Some(neighbors) = adjacency.get(node) {
+                        for (neighbor, w) in neighbors {
+                            if !member_set.contains(neighbor) {
+                                continue;
+                            }
+                            let nc = sub_comm[neighbor];
+                            *neighbor_sub_weights.entry(nc).or_default() += *w as f64;
+                        }
+                    }
+
+                    let ki_in_current =
+                        neighbor_sub_weights.get(&current_sub).copied().unwrap_or(0.0);
+                    let st_current = sub_sum_tot.get(&current_sub).copied().unwrap_or(0.0);
+                    let remove_cost =
+                        ki_in_current / two_m - (st_current * ki) / (two_m * two_m);
+
+                    let mut best_sub = current_sub;
+                    let mut best_gain = 0.0;
+
+                    for (&target_sub, &ki_in_target) in &neighbor_sub_weights {
+                        if target_sub == current_sub {
+                            continue;
+                        }
+                        let st_target = sub_sum_tot.get(&target_sub).copied().unwrap_or(0.0);
+                        let gain = ki_in_target / two_m
+                            - (st_target * ki) / (two_m * two_m)
+                            - remove_cost;
+                        if gain > best_gain {
+                            best_gain = gain;
+                            best_sub = target_sub;
+                        }
+                    }
+
+                    if best_sub != current_sub {
+                        *sub_sum_tot.entry(current_sub).or_default() -= ki;
+                        *sub_sum_tot.entry(best_sub).or_default() += ki;
+                        sub_comm.insert(node.clone(), best_sub);
+                        sub_moved = true;
+                    }
+                }
+
+                if !sub_moved {
+                    break;
+                }
+            }
+
+            for node in members {
+                refined_community.insert(node.clone(), sub_comm[node]);
+            }
+            next_refined_label = sub_label;
+        }
+
+        community = refined_community;
+    }
+
+    // Normalize labels to 0..N
+    let mut label_map: HashMap<u32, u32> = HashMap::new();
+    let mut next_label = 0u32;
+    let mut result: HashMap<String, u32> = HashMap::new();
+    for node in &sorted_nodes {
+        let c = community[node];
+        let label = *label_map.entry(c).or_insert_with(|| {
+            let l = next_label;
+            next_label += 1;
+            l
+        });
+        result.insert(node.clone(), label);
+    }
+
+    result
+}
+
 /// Group label propagation results into clusters, filtering by minimum size.
 /// Returns Vec of (cluster members, dominant tags).
 pub fn group_labels_into_clusters(
@@ -107,6 +506,7 @@ pub fn compute_atom_clusters(
     conn: &Connection,
     min_similarity: f32,
     min_cluster_size: i32,
+    algorithm: ClusterAlgorithm,
 ) -> Result<Vec<AtomCluster>, String> {
     // Load all semantic edges above threshold
     let mut stmt = conn
@@ -129,7 +529,7 @@ pub fn compute_atom_clusters(
         return Ok(vec![]);
     }
 
-    let labels = label_propagation(&edges);
+    let labels = run_algorithm(algorithm, &edges);
     let groups = group_labels_into_clusters(&labels, min_cluster_size as usize);
 
     let mut clusters: Vec<AtomCluster> = Vec::new();
@@ -311,7 +711,7 @@ mod tests {
         let conn = db.conn.lock().unwrap();
 
         // No edges = no clusters
-        let clusters = compute_atom_clusters(&conn, 0.5, 2).unwrap();
+        let clusters = compute_atom_clusters(&conn, 0.5, 2, ClusterAlgorithm::LabelPropagation).unwrap();
         assert!(clusters.is_empty(), "No edges should result in empty clusters");
     }
 
@@ -331,7 +731,7 @@ mod tests {
         insert_semantic_edge(&conn, "atom1", "atom3", 0.8);
 
         // All 3 should end up in one cluster (min_cluster_size = 2)
-        let clusters = compute_atom_clusters(&conn, 0.5, 2).unwrap();
+        let clusters = compute_atom_clusters(&conn, 0.5, 2, ClusterAlgorithm::LabelPropagation).unwrap();
         assert_eq!(clusters.len(), 1, "All connected atoms should form one cluster");
         assert_eq!(
             clusters[0].atom_ids.len(),

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -1288,8 +1288,9 @@ impl AtomicCore {
         &self,
         min_similarity: f32,
         min_cluster_size: i32,
+        algorithm: ClusterAlgorithm,
     ) -> Result<Vec<AtomCluster>, AtomicCoreError> {
-        self.storage.compute_clusters_sync(min_similarity, min_cluster_size)
+        self.storage.compute_clusters_sync(min_similarity, min_cluster_size, algorithm)
     }
 
     /// Save cluster assignments to the database
@@ -1436,7 +1437,7 @@ impl AtomicCore {
     /// top-K edges per atom, and cluster centroid labels.
     /// Pure read operation — does not persist positions to the database.
     /// Works with both SQLite and Postgres backends via storage dispatch.
-    pub fn compute_and_get_canvas_data(&self) -> Result<GlobalCanvasData, AtomicCoreError> {
+    pub fn compute_and_get_canvas_data(&self, algorithm: ClusterAlgorithm) -> Result<GlobalCanvasData, AtomicCoreError> {
         // Load all average embeddings via storage abstraction
         let embeddings = self.storage.get_all_embedding_pairs_sync()?;
         if embeddings.is_empty() {
@@ -1477,7 +1478,7 @@ impl AtomicCore {
         let edges = self.storage.get_top_k_canvas_edges_sync(2)?;
 
         // Compute cluster centroids
-        let cluster_data = self.storage.compute_clusters_sync(0.5, 3)?;
+        let cluster_data = self.storage.compute_clusters_sync(0.5, 3, algorithm)?;
         let clusters = Self::build_cluster_centroids(&cluster_data, &position_map);
 
         Ok(GlobalCanvasData { atoms, edges, clusters })

--- a/crates/atomic-core/src/models.rs
+++ b/crates/atomic-core/src/models.rs
@@ -420,6 +420,17 @@ pub struct NeighborhoodEdge {
     pub similarity_score: Option<f32>,
 }
 
+/// Algorithm used to compute clusters
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ClusterAlgorithm {
+    #[default]
+    LabelPropagation,
+    Louvain,
+    Leiden,
+}
+
 /// Atom cluster assignment
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/crates/atomic-core/src/storage/mod.rs
+++ b/crates/atomic-core/src/storage/mod.rs
@@ -406,7 +406,7 @@ dispatch! {
         => sqlite: backfill_feed_metadata_sync, pg_trait: FeedStore, pg_method: backfill_feed_metadata;
 
     // ---- ClusterStore ----
-    fn compute_clusters_sync(&self, min_similarity: f32, min_cluster_size: i32) -> Result<Vec<AtomCluster>, AtomicCoreError>
+    fn compute_clusters_sync(&self, min_similarity: f32, min_cluster_size: i32, algorithm: ClusterAlgorithm) -> Result<Vec<AtomCluster>, AtomicCoreError>
         => sqlite: compute_clusters_sync, pg_trait: ClusterStore, pg_method: compute_clusters;
     fn save_clusters_sync(&self, clusters: &[AtomCluster]) -> Result<(), AtomicCoreError>
         => sqlite: save_clusters_sync, pg_trait: ClusterStore, pg_method: save_clusters;

--- a/crates/atomic-core/src/storage/postgres/clusters.rs
+++ b/crates/atomic-core/src/storage/postgres/clusters.rs
@@ -1149,6 +1149,7 @@ impl ClusterStore for PostgresStorage {
         &self,
         min_similarity: f32,
         min_cluster_size: i32,
+        algorithm: ClusterAlgorithm,
     ) -> StorageResult<Vec<AtomCluster>> {
         // Load semantic edges above threshold
         let edges: Vec<(String, String, f32)> = sqlx::query_as(
@@ -1166,7 +1167,7 @@ impl ClusterStore for PostgresStorage {
             return Ok(vec![]);
         }
 
-        let labels = clustering::label_propagation(&edges);
+        let labels = clustering::run_algorithm(algorithm, &edges);
         let groups = clustering::group_labels_into_clusters(&labels, min_cluster_size as usize);
 
         let mut clusters: Vec<AtomCluster> = Vec::new();
@@ -1220,7 +1221,7 @@ impl ClusterStore for PostgresStorage {
         let count = count.unwrap_or(0);
 
         if count == 0 {
-            let clusters = self.compute_clusters(0.5, 2).await?;
+            let clusters = self.compute_clusters(0.5, 2, ClusterAlgorithm::default()).await?;
             self.save_clusters(&clusters).await?;
             return Ok(clusters);
         }

--- a/crates/atomic-core/src/storage/sqlite/clusters.rs
+++ b/crates/atomic-core/src/storage/sqlite/clusters.rs
@@ -11,13 +11,14 @@ impl SqliteStorage {
         &self,
         min_similarity: f32,
         min_cluster_size: i32,
+        algorithm: ClusterAlgorithm,
     ) -> StorageResult<Vec<AtomCluster>> {
         let conn = self
             .db
             .conn
             .lock()
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
-        clustering::compute_atom_clusters(&conn, min_similarity, min_cluster_size)
+        clustering::compute_atom_clusters(&conn, min_similarity, min_cluster_size, algorithm)
             .map_err(|e| AtomicCoreError::Clustering(e))
     }
 
@@ -46,7 +47,7 @@ impl SqliteStorage {
             .unwrap_or(0);
 
         if count == 0 {
-            let clusters = clustering::compute_atom_clusters(&conn, 0.5, 2)
+            let clusters = clustering::compute_atom_clusters(&conn, 0.5, 2, ClusterAlgorithm::default())
                 .map_err(|e| AtomicCoreError::Clustering(e))?;
             clustering::save_cluster_assignments(&conn, &clusters)
                 .map_err(|e| AtomicCoreError::Clustering(e))?;
@@ -102,8 +103,9 @@ impl ClusterStore for SqliteStorage {
         &self,
         min_similarity: f32,
         min_cluster_size: i32,
+        algorithm: ClusterAlgorithm,
     ) -> StorageResult<Vec<AtomCluster>> {
-        self.compute_clusters_sync(min_similarity, min_cluster_size)
+        self.compute_clusters_sync(min_similarity, min_cluster_size, algorithm)
     }
 
     async fn save_clusters(&self, clusters: &[AtomCluster]) -> StorageResult<()> {

--- a/crates/atomic-core/src/storage/traits.rs
+++ b/crates/atomic-core/src/storage/traits.rs
@@ -658,6 +658,7 @@ pub trait ClusterStore: Send + Sync {
         &self,
         min_similarity: f32,
         min_cluster_size: i32,
+        algorithm: ClusterAlgorithm,
     ) -> StorageResult<Vec<AtomCluster>>;
 
     /// Save computed clusters (replaces existing).

--- a/crates/atomic-server/src/routes/canvas.rs
+++ b/crates/atomic-server/src/routes/canvas.rs
@@ -58,9 +58,21 @@ pub async fn get_canvas_level(
     blocking_ok(move || core.get_canvas_level(parent_id.as_deref(), children_hint)).await
 }
 
+/// Query parameters for the global canvas endpoint
+#[derive(Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct GlobalCanvasQuery {
+    /// Clustering algorithm (default: label_propagation)
+    pub algorithm: Option<atomic_core::ClusterAlgorithm>,
+}
+
 /// Compute PCA 2D projection and return all atoms with positions, edges, and cluster labels
-#[utoipa::path(get, path = "/api/canvas/global", responses((status = 200, description = "Global canvas data", body = atomic_core::GlobalCanvasData)), tag = "canvas")]
-pub async fn get_global_canvas(db: Db) -> HttpResponse {
+#[utoipa::path(get, path = "/api/canvas/global", params(GlobalCanvasQuery), responses((status = 200, description = "Global canvas data", body = atomic_core::GlobalCanvasData)), tag = "canvas")]
+pub async fn get_global_canvas(
+    db: Db,
+    query: web::Query<GlobalCanvasQuery>,
+) -> HttpResponse {
+    let algorithm = query.algorithm.unwrap_or_default();
     let core = db.0;
-    blocking_ok(move || core.compute_and_get_canvas_data()).await
+    blocking_ok(move || core.compute_and_get_canvas_data(algorithm)).await
 }

--- a/crates/atomic-server/src/routes/clustering.rs
+++ b/crates/atomic-server/src/routes/clustering.rs
@@ -12,6 +12,8 @@ pub struct ComputeClustersBody {
     pub min_similarity: Option<f32>,
     /// Minimum cluster size (default: 2)
     pub min_cluster_size: Option<i32>,
+    /// Clustering algorithm (default: label_propagation)
+    pub algorithm: Option<atomic_core::ClusterAlgorithm>,
 }
 
 #[utoipa::path(post, path = "/api/clustering/compute", request_body = ComputeClustersBody, responses((status = 200, description = "Computed clusters", body = Vec<atomic_core::AtomCluster>)), tag = "clustering")]
@@ -21,9 +23,10 @@ pub async fn compute_clusters(
 ) -> HttpResponse {
     let min_similarity = body.min_similarity.unwrap_or(0.6);
     let min_cluster_size = body.min_cluster_size.unwrap_or(2);
+    let algorithm = body.algorithm.unwrap_or_default();
     let core = db.0;
     match web::block(move || {
-        let clusters = core.compute_clusters(min_similarity, min_cluster_size)?;
+        let clusters = core.compute_clusters(min_similarity, min_cluster_size, algorithm)?;
         core.save_clusters(&clusters)?;
         Ok::<_, atomic_core::AtomicCoreError>(clusters)
     }).await {

--- a/src/components/canvas/SigmaCanvas.tsx
+++ b/src/components/canvas/SigmaCanvas.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useUIStore } from '../../stores/ui';
 import { useDatabasesStore } from '../../stores/databases';
-import { getGlobalCanvas, type GlobalCanvasData } from '../../lib/api';
+import { getGlobalCanvas, type GlobalCanvasData, type ClusterAlgorithm } from '../../lib/api';
 import Graph from 'graphology';
 import Sigma from 'sigma';
 import EdgeCurveProgram from '@sigma/edge-curve';
@@ -12,6 +12,20 @@ import {
   edgeColor,
   type CanvasTheme,
 } from './sigma/themes';
+
+const ALGORITHM_OPTIONS: { value: ClusterAlgorithm; label: string }[] = [
+  { value: 'label_propagation', label: 'Label Propagation' },
+  { value: 'louvain', label: 'Louvain' },
+  { value: 'leiden', label: 'Leiden' },
+];
+
+function getStoredAlgorithm(): ClusterAlgorithm {
+  const stored = localStorage.getItem('canvas-cluster-algorithm');
+  if (stored === 'label_propagation' || stored === 'louvain' || stored === 'leiden') {
+    return stored;
+  }
+  return 'label_propagation';
+}
 
 function truncLabel(str: string, max: number): string {
   return str.length > max ? str.substring(0, max - 1) + '\u2026' : str;
@@ -29,6 +43,8 @@ export function SigmaCanvas() {
   const [error, setError] = useState<string | null>(null);
   const [theme, setTheme] = useState<CanvasTheme>(DEFAULT_THEME);
   const [themePickerOpen, setThemePickerOpen] = useState(false);
+  const [algorithm, setAlgorithm] = useState<ClusterAlgorithm>(getStoredAlgorithm);
+  const [algPickerOpen, setAlgPickerOpen] = useState(false);
   const [edgeThreshold, setEdgeThreshold] = useState(0);
   const edgeThresholdRef = useRef(0);
   const edgeAnimProgress = useRef(1); // 0 = invisible, 1 = fully visible
@@ -45,7 +61,7 @@ export function SigmaCanvas() {
     setIsLoading(true);
     setError(null);
 
-    getGlobalCanvas()
+    getGlobalCanvas(algorithm)
       .then((result) => {
         if (!cancelled) {
           setData(result);
@@ -60,7 +76,7 @@ export function SigmaCanvas() {
       });
 
     return () => { cancelled = true; };
-  }, [activeDbId]);
+  }, [activeDbId, algorithm]);
 
   // Precomputed data for the graph
   const graphDataRef = useRef<{
@@ -491,6 +507,34 @@ export function SigmaCanvas() {
               <span className="text-[9px] text-white/30">
                 {Math.round((1 - edgeThreshold) * 100)}%
               </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => setAlgPickerOpen(!algPickerOpen)}
+                title="Clustering algorithm"
+                className="px-2 py-0.5 rounded-full text-[9px] font-medium border border-white/20 hover:border-white/40 transition-all text-white/50 hover:text-white/70"
+              >
+                {ALGORITHM_OPTIONS.find(a => a.value === algorithm)?.label}
+              </button>
+              <div
+                className={`flex gap-1 overflow-hidden transition-all duration-200 ${
+                  algPickerOpen ? 'max-w-[300px] opacity-100' : 'max-w-0 opacity-0'
+                }`}
+              >
+                {ALGORITHM_OPTIONS.filter(a => a.value !== algorithm).map((alg) => (
+                  <button
+                    key={alg.value}
+                    onClick={() => {
+                      localStorage.setItem('canvas-cluster-algorithm', alg.value);
+                      setAlgorithm(alg.value);
+                      setAlgPickerOpen(false);
+                    }}
+                    className="px-2 py-0.5 rounded-full text-[9px] border border-white/15 hover:border-white/40 transition-all text-white/40 hover:text-white/60 whitespace-nowrap"
+                  >
+                    {alg.label}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
         )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -188,8 +188,10 @@ export interface GlobalCanvasData {
   clusters: CanvasClusterLabel[];
 }
 
-export async function getGlobalCanvas(): Promise<GlobalCanvasData> {
-  return getTransport().invoke('get_global_canvas', {});
+export type ClusterAlgorithm = 'label_propagation' | 'louvain' | 'leiden';
+
+export async function getGlobalCanvas(algorithm?: ClusterAlgorithm): Promise<GlobalCanvasData> {
+  return getTransport().invoke('get_global_canvas', { algorithm });
 }
 
 // Semantic graph types and commands
@@ -259,9 +261,10 @@ export interface AtomCluster {
 
 export async function computeClusters(
   minSimilarity: number = 0.5,
-  minClusterSize: number = 2
+  minClusterSize: number = 2,
+  algorithm?: ClusterAlgorithm
 ): Promise<AtomCluster[]> {
-  return getTransport().invoke('compute_clusters', { minSimilarity, minClusterSize });
+  return getTransport().invoke('compute_clusters', { minSimilarity, minClusterSize, algorithm });
 }
 
 export async function getClusters(): Promise<AtomCluster[]> {

--- a/src/lib/transport/command-map.ts
+++ b/src/lib/transport/command-map.ts
@@ -317,7 +317,12 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
 
   get_global_canvas: {
     method: 'GET',
-    path: '/api/canvas/global',
+    path: (a) => {
+      const params = new URLSearchParams();
+      if (a.algorithm) params.set('algorithm', a.algorithm as string);
+      const qs = params.toString();
+      return `/api/canvas/global${qs ? `?${qs}` : ''}`;
+    },
   },
 
   // ==================== Graph ====================
@@ -343,6 +348,7 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
     transformArgs: (a) => ({
       min_similarity: a.minSimilarity,
       min_cluster_size: a.minClusterSize,
+      algorithm: a.algorithm ?? undefined,
     }),
   },
   get_clusters: {


### PR DESCRIPTION
Implement Louvain (modularity optimization) and Leiden (with refinement phase) as alternatives to the existing Label Propagation algorithm. Thread a ClusterAlgorithm enum through the full stack — models, storage traits, core facade, server routes, and frontend — with a picker UI on the Sigma canvas view that persists the choice to localStorage.