### PR TITLE
Obsidian plugin: onboarding wizard, database support, sync improvements

### DIFF
--- a/crates/atomic-core/src/chat.rs
+++ b/crates/atomic-core/src/chat.rs
@@ -18,7 +18,7 @@ pub fn get_conversation_tags(
     conversation_id: &str,
 ) -> Result<Vec<Tag>, AtomicCoreError> {
     let mut stmt = conn.prepare(
-        "SELECT t.id, t.name, t.parent_id, t.created_at
+        "SELECT t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
          FROM tags t
          JOIN conversation_tags ct ON ct.tag_id = t.id
          WHERE ct.conversation_id = ?1
@@ -32,6 +32,7 @@ pub fn get_conversation_tags(
                 name: row.get(1)?,
                 parent_id: row.get(2)?,
                 created_at: row.get(3)?,
+                is_autotag_target: row.get::<_, i32>(4)? != 0,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -270,7 +271,7 @@ fn batch_fetch_conversation_tags(
     }
     let placeholders = conv_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let query = format!(
-        "SELECT ct.conversation_id, t.id, t.name, t.parent_id, t.created_at
+        "SELECT ct.conversation_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
          FROM conversation_tags ct
          JOIN tags t ON ct.tag_id = t.id
          WHERE ct.conversation_id IN ({})
@@ -287,6 +288,7 @@ fn batch_fetch_conversation_tags(
                 name: row.get(2)?,
                 parent_id: row.get(3)?,
                 created_at: row.get(4)?,
+                is_autotag_target: row.get::<_, i32>(5)? != 0,
             },
         ))
     })?;

--- a/crates/atomic-core/src/db.rs
+++ b/crates/atomic-core/src/db.rs
@@ -199,7 +199,7 @@ impl Database {
     ///   1. Add a new `if version < N` block at the end (before the virtual-table section)
     ///   2. End the block with `PRAGMA user_version = N;`
     ///   3. Bump LATEST_VERSION
-    const LATEST_VERSION: i32 = 10;
+    const LATEST_VERSION: i32 = 11;
 
     pub fn run_migrations(conn: &Connection) -> Result<(), AtomicCoreError> {
         let version: i32 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
@@ -618,6 +618,31 @@ impl Database {
                 [],
             )?;
             conn.execute_batch("PRAGMA user_version = 10;")?;
+        }
+
+        // --- V10 → V11: Mark which top-level tags the auto-tagger may extend ---
+        if version < 11 {
+            let has_col: bool = conn
+                .query_row(
+                    "SELECT 1 FROM pragma_table_info('tags') WHERE name='is_autotag_target'",
+                    [],
+                    |_| Ok(true),
+                )
+                .unwrap_or(false);
+
+            if !has_col {
+                conn.execute_batch(
+                    "ALTER TABLE tags ADD COLUMN is_autotag_target INTEGER NOT NULL DEFAULT 0;",
+                )?;
+            }
+
+            // Backfill: the five seeded categories are auto-tag targets by default.
+            conn.execute_batch(
+                "UPDATE tags SET is_autotag_target = 1
+                   WHERE parent_id IS NULL
+                     AND name IN ('Topics', 'People', 'Locations', 'Organizations', 'Events');
+                 PRAGMA user_version = 11;",
+            )?;
         }
 
         // --- Triggers (recreated every startup to stay current) ---

--- a/crates/atomic-core/src/embedding.rs
+++ b/crates/atomic-core/src/embedding.rs
@@ -530,9 +530,18 @@ async fn process_tagging_only_inner(
             None
         };
 
-    // Get tag tree for LLM context
+    // Get tag tree for LLM context (only top-level tags flagged as auto-tag targets)
     let tag_tree_json = storage.get_tag_tree_for_llm_impl()
         .map_err(|e| e.to_string())?;
+
+    // No auto-tag targets configured — skip tagging entirely.
+    // The user has either unflagged all defaults during onboarding or hasn't created any.
+    if tag_tree_json == "(no existing tags)" {
+        tracing::debug!(atom_id = %atom_id, "No auto-tag targets configured; skipping tagging");
+        storage.set_tagging_status_sync(atom_id, "skipped", None)
+            .map_err(|e| e.to_string())?;
+        return Ok((Vec::new(), Vec::new()));
+    }
 
     // Single LLM call on full content — no per-chunk loop, no consolidation
     let tags = extract_tags_from_content(

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -109,29 +109,25 @@ Tags help users navigate and filter their content. Users can browse by tag and g
 
 IMPORTANT:
 - Each tag MUST have a parent_name set to one of the existing top-level categories shown below
-- DO NOT create new top-level categories - only use the ones provided
+- DO NOT create new top-level categories - only use the ones the user has provided below
 - Tag names are case-insensitive and globally unique
 
-The tags listed below are a sample of commonly-used tags included as a point of reference for the kinds of tags in this system.
+The user has chosen which top-level categories the auto-tagger may extend. They are listed below along with a sample of existing sub-tags under each, as a point of reference for the kinds of tags in this system.
 
 HIERARCHY STRUCTURE:
 - Level 1: Categories (shown below) - use ONLY these existing categories as parent_name
-- Level 2: Specific tags (e.g., "AI", "John Smith", "San Francisco")
+- Level 2: Specific tags you create under those categories
 - Maximum 2 levels - no deeper nesting
 
-EXAMPLES:
-- {"name": "AI", "parent_name": "Topics"}
-- {"name": "Machine Learning", "parent_name": "Topics"}
-- {"name": "San Francisco", "parent_name": "Locations"}
-
 RESPONSE FORMAT:
-Return a JSON object with a "tags" array. Each tag is an object with "name" and "parent_name":
-{"tags": [{"name": "AI", "parent_name": "Topics"}, {"name": "San Francisco", "parent_name": "Locations"}]}
+Return a JSON object with a "tags" array. Each tag is an object with "name" and "parent_name", where parent_name is one of the categories shown below:
+{"tags": [{"name": "<specific tag>", "parent_name": "<category from the list below>"}]}
 
 Guidelines:
-- Create new Level 2 tags under existing categories when needed
-- Prefer broad tags like "John Smith" rather than overly specific tags such as "Early Life of John Smith"
-- Every tag must have a valid parent_name from the top-level categories"#;
+- Create new Level 2 tags under the user's existing categories when needed
+- Prefer broad tags rather than overly specific ones (e.g., "John Smith" instead of "Early Life of John Smith")
+- Every tag must have a valid parent_name from the top-level categories listed below
+- If none of the categories below feel like a natural fit for the content, return an empty tag list rather than forcing a poor match"#;
 
 /// Parse tag extractions from LLM output, handling both:
 /// - `{"tags": [...]}` (schema-enforced, OpenRouter/OpenAI)
@@ -406,9 +402,11 @@ pub async fn extract_tags_from_chunk(
 /// 2. For each category, shows only the top 10 most-used child tags (by atom count)
 /// 3. Excludes any tags at Level 3 or deeper
 pub fn get_tag_tree_for_llm(conn: &Connection) -> Result<String, String> {
-    // Step 1: Get top-level category tags
+    // Step 1: Get top-level category tags flagged as auto-tag targets.
+    // Tags without is_autotag_target = 1 are intentionally excluded so the
+    // auto-tagger only extends categories the user has opted into.
     let mut top_level_stmt = conn
-        .prepare("SELECT id, name FROM tags WHERE parent_id IS NULL ORDER BY name")
+        .prepare("SELECT id, name FROM tags WHERE parent_id IS NULL AND is_autotag_target = 1 ORDER BY name")
         .map_err(|e| format!("Failed to prepare top-level tag query: {}", e))?;
 
     let top_level_tags: Vec<(String, String)> = top_level_stmt
@@ -795,16 +793,16 @@ mod tests {
         let (db, _temp) = create_test_db();
         let conn = db.conn.lock().unwrap();
 
-        // Create a top-level tag
+        // Create a top-level tag flagged as an auto-tag target
         let tag_id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now().to_rfc3339();
         conn.execute(
-            "INSERT INTO tags (id, name, parent_id, created_at) VALUES (?1, ?2, NULL, ?3)",
+            "INSERT INTO tags (id, name, parent_id, created_at, is_autotag_target) VALUES (?1, ?2, NULL, ?3, 1)",
             rusqlite::params![&tag_id, "Topics", &now],
         )
         .unwrap();
 
-        // Create a child tag
+        // Create a child tag (children inherit visibility via the parent filter)
         let child_id = uuid::Uuid::new_v4().to_string();
         conn.execute(
             "INSERT INTO tags (id, name, parent_id, created_at) VALUES (?1, ?2, ?3, ?4)",
@@ -817,6 +815,26 @@ mod tests {
         // Should have tree format
         assert!(result.contains("Topics"), "Should contain parent tag");
         assert!(result.contains("AI"), "Should contain child tag");
+    }
+
+    #[test]
+    fn test_get_tag_tree_for_llm_excludes_unflagged_top_level() {
+        let (db, _temp) = create_test_db();
+        let conn = db.conn.lock().unwrap();
+
+        // Create a top-level tag NOT flagged as an auto-tag target
+        let tag_id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO tags (id, name, parent_id, created_at, is_autotag_target) VALUES (?1, ?2, NULL, ?3, 0)",
+            rusqlite::params![&tag_id, "Imported Folder", &now],
+        )
+        .unwrap();
+
+        let result = get_tag_tree_for_llm(&conn).unwrap();
+
+        // Unflagged tags must not appear; with no flagged tags the sentinel is returned
+        assert_eq!(result, "(no existing tags)");
     }
 
     // ==================== Tag Name Lookup Tests ====================

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -206,25 +206,13 @@ impl AtomicCore {
         Self::seed_and_backfill(db, None)
     }
 
-    /// Shared initialization: seed default tags, reconcile vec dimension, backfill centroids.
+    /// Shared initialization: reconcile vec dimension, backfill centroids.
+    ///
+    /// Note: default category tags are NOT auto-seeded. The onboarding wizard
+    /// (or the user via the settings tab / API) decides which top-level categories
+    /// the auto-tagger may extend. Existing databases that were seeded before this
+    /// change keep their tags via the V11 migration's backfill.
     fn seed_and_backfill(db: Database, registry: Option<Arc<registry::Registry>>) -> Result<Self, AtomicCoreError> {
-        // Seed default category tags if tags table is empty
-        {
-            let conn = db.conn.lock().map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
-            let tag_count: i64 = conn
-                .query_row("SELECT COUNT(*) FROM tags", [], |row| row.get(0))
-                .unwrap_or(0);
-            if tag_count == 0 {
-                let now = Utc::now().to_rfc3339();
-                for category in &["Topics", "People", "Locations", "Organizations", "Events"] {
-                    let id = Uuid::new_v4().to_string();
-                    conn.execute(
-                        "INSERT OR IGNORE INTO tags (id, name, parent_id, created_at) VALUES (?1, ?2, NULL, ?3)",
-                        rusqlite::params![&id, category, &now],
-                    )?;
-                }
-            }
-        }
 
         // Reconcile vec_chunks dimension with the configured embedding model.
         // Only for empty databases (no atoms yet) — e.g. newly created databases
@@ -727,6 +715,104 @@ impl AtomicCore {
     /// Delete a tag
     pub fn delete_tag(&self, id: &str, recursive: bool) -> Result<(), AtomicCoreError> {
         self.storage.delete_tag_impl(id, recursive)
+    }
+
+    /// Mark or unmark a top-level tag as a candidate for AI auto-tagging to extend.
+    /// When false, the auto-tagger will not create new sub-tags under this tag.
+    pub fn set_tag_autotag_target(&self, id: &str, value: bool) -> Result<(), AtomicCoreError> {
+        self.storage.set_tag_autotag_target_impl(id, value)
+    }
+
+    /// Configure auto-tag targets in one shot — used by the onboarding wizard
+    /// and the settings tab.
+    ///
+    /// `keep_default_names`: which of the well-known default category names
+    /// (case-insensitive) the user wants. Each one is created if it doesn't exist
+    /// and flagged as an auto-tag target.
+    ///
+    /// `add_custom_names`: new top-level tag names to create with the flag set.
+    /// Names that already exist as top-level tags are flagged in place rather than duplicated.
+    ///
+    /// Defaults that exist but are NOT in `keep_default_names` are deleted if they
+    /// have no atoms or sub-tags (the safe case during onboarding). If they have
+    /// content, they're unflagged instead so their data isn't lost — re-runs from
+    /// settings after the user has tagged things stay non-destructive.
+    pub fn configure_autotag_targets(
+        &self,
+        keep_default_names: &[String],
+        add_custom_names: &[String],
+    ) -> Result<Vec<Tag>, AtomicCoreError> {
+        const DEFAULT_NAMES: &[&str] = &["Topics", "People", "Locations", "Organizations", "Events"];
+
+        let keep_lower: std::collections::HashSet<String> = keep_default_names
+            .iter()
+            .map(|n| n.trim().to_lowercase())
+            .filter(|n| !n.is_empty())
+            .collect();
+
+        // Snapshot current top-level tags so we can decide create vs. flag vs. delete.
+        let all_tags = self.storage.get_all_tags_impl()?;
+        let top_level: Vec<&TagWithCount> = all_tags
+            .iter()
+            .filter(|t| t.tag.parent_id.is_none())
+            .collect();
+
+        // Step 1: For each requested default, create it if missing and ensure it's flagged.
+        for default_name in DEFAULT_NAMES {
+            if !keep_lower.contains(&default_name.to_lowercase()) {
+                continue;
+            }
+            let existing = top_level
+                .iter()
+                .find(|t| t.tag.name.eq_ignore_ascii_case(default_name));
+            let tag_id = match existing {
+                Some(t) => t.tag.id.clone(),
+                None => self.storage.create_tag_impl(default_name, None)?.id,
+            };
+            self.storage.set_tag_autotag_target_impl(&tag_id, true)?;
+        }
+
+        // Step 2: For each existing default the user did NOT keep, delete if empty,
+        // otherwise unflag to keep their data intact.
+        for tag_with_count in &top_level {
+            let name = &tag_with_count.tag.name;
+            let is_default = DEFAULT_NAMES.iter().any(|d| d.eq_ignore_ascii_case(name));
+            let is_kept = keep_lower.contains(&name.to_lowercase());
+            if !is_default || is_kept {
+                continue;
+            }
+            if tag_with_count.atom_count == 0 && tag_with_count.children_total == 0 {
+                self.storage.delete_tag_impl(&tag_with_count.tag.id, false)?;
+            } else if tag_with_count.tag.is_autotag_target {
+                self.storage.set_tag_autotag_target_impl(&tag_with_count.tag.id, false)?;
+            }
+        }
+
+        // Step 3: Custom additions — create new top-level tags or flag existing ones.
+        let mut custom_tags: Vec<Tag> = Vec::new();
+        for name in add_custom_names {
+            let trimmed = name.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            // Refresh the top-level snapshot since we may have just created/deleted defaults.
+            let current = self.storage.get_all_tags_impl()?;
+            let existing = current.iter().find(|t| {
+                t.tag.parent_id.is_none() && t.tag.name.eq_ignore_ascii_case(trimmed)
+            });
+            let tag_id = match existing {
+                Some(t) => t.tag.id.clone(),
+                None => self.storage.create_tag_impl(trimmed, None)?.id,
+            };
+            self.storage.set_tag_autotag_target_impl(&tag_id, true)?;
+            if let Some(updated) = self.storage.get_all_tags_impl()?.into_iter()
+                .find(|t| t.tag.id == tag_id)
+            {
+                custom_tags.push(updated.tag);
+            }
+        }
+
+        Ok(custom_tags)
     }
 
     // ==================== Search Operations ====================
@@ -2941,7 +3027,7 @@ pub(crate) fn atom_from_row(row: &rusqlite::Row) -> rusqlite::Result<Atom> {
 pub(crate) fn get_tags_for_atom(conn: &Connection, atom_id: &str) -> Result<Vec<Tag>, AtomicCoreError> {
     let mut stmt = conn
         .prepare(
-            "SELECT t.id, t.name, t.parent_id, t.created_at
+            "SELECT t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
              FROM tags t
              INNER JOIN atom_tags at ON t.id = at.tag_id
              WHERE at.atom_id = ?1",
@@ -2955,6 +3041,7 @@ pub(crate) fn get_tags_for_atom(conn: &Connection, atom_id: &str) -> Result<Vec<
                 name: row.get(1)?,
                 parent_id: row.get(2)?,
                 created_at: row.get(3)?,
+                is_autotag_target: row.get::<_, i32>(4)? != 0,
             })
         })
         ?
@@ -2969,7 +3056,7 @@ pub(crate) fn get_tags_for_atom(conn: &Connection, atom_id: &str) -> Result<Vec<
 pub(crate) fn get_all_atom_tags_map(conn: &Connection) -> Result<std::collections::HashMap<String, Vec<Tag>>, AtomicCoreError> {
     let mut stmt = conn
         .prepare(
-            "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at
+            "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
              FROM atom_tags at
              INNER JOIN tags t ON at.tag_id = t.id",
         )?;
@@ -2985,6 +3072,7 @@ pub(crate) fn get_all_atom_tags_map(conn: &Connection) -> Result<std::collection
                     name: row.get(2)?,
                     parent_id: row.get(3)?,
                     created_at: row.get(4)?,
+                    is_autotag_target: row.get::<_, i32>(5)? != 0,
                 },
             ))
         })?;
@@ -3005,7 +3093,7 @@ pub(crate) fn get_atom_tags_map_for_ids(conn: &Connection, atom_ids: &[String]) 
 
     let placeholders = atom_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let query = format!(
-        "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at
+        "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
          FROM atom_tags at
          INNER JOIN tags t ON at.tag_id = t.id
          WHERE at.atom_id IN ({})",
@@ -3025,6 +3113,7 @@ pub(crate) fn get_atom_tags_map_for_ids(conn: &Connection, atom_ids: &[String]) 
                     name: row.get(2)?,
                     parent_id: row.get(3)?,
                     created_at: row.get(4)?,
+                    is_autotag_target: row.get::<_, i32>(5)? != 0,
                 },
             ))
         })?;
@@ -3114,8 +3203,22 @@ mod tests {
     use super::*;
     use tempfile::NamedTempFile;
 
-    /// Test utility: Create a test database
+    /// Test utility: Create a test database with the five default category tags seeded.
+    /// (Production code no longer auto-seeds; tests opt in via this helper.)
     fn create_test_db() -> (AtomicCore, NamedTempFile) {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db = AtomicCore::open_or_create(temp_file.path()).unwrap();
+        let defaults: Vec<String> = ["Topics", "People", "Locations", "Organizations", "Events"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        db.configure_autotag_targets(&defaults, &[]).unwrap();
+        (db, temp_file)
+    }
+
+    /// Test utility: Create an empty test database with no seeded tags.
+    #[allow(dead_code)]
+    fn create_empty_test_db() -> (AtomicCore, NamedTempFile) {
         let temp_file = NamedTempFile::new().unwrap();
         let db = AtomicCore::open_or_create(temp_file.path()).unwrap();
         (db, temp_file)
@@ -3125,14 +3228,14 @@ mod tests {
     fn get_seeded_tag(db: &AtomicCore, name: &str) -> Tag {
         let sqlite = db.storage.as_sqlite().unwrap();
         let conn = sqlite.db.conn.lock().unwrap();
-        let (id, tag_name, parent_id, created_at): (String, String, Option<String>, String) = conn
+        let (id, tag_name, parent_id, created_at, is_autotag_target): (String, String, Option<String>, String, i32) = conn
             .query_row(
-                "SELECT id, name, parent_id, created_at FROM tags WHERE LOWER(name) = LOWER(?1)",
+                "SELECT id, name, parent_id, created_at, is_autotag_target FROM tags WHERE LOWER(name) = LOWER(?1)",
                 [name],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
             )
             .unwrap();
-        Tag { id, name: tag_name, parent_id, created_at }
+        Tag { id, name: tag_name, parent_id, created_at, is_autotag_target: is_autotag_target != 0 }
     }
 
     /// Test utility: Create a test atom

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -737,82 +737,15 @@ impl AtomicCore {
     /// have no atoms or sub-tags (the safe case during onboarding). If they have
     /// content, they're unflagged instead so their data isn't lost — re-runs from
     /// settings after the user has tagged things stay non-destructive.
+    ///
+    /// All steps run in a single storage-layer transaction, so a failure mid-flight
+    /// rolls back cleanly rather than leaving the tags table partially modified.
     pub fn configure_autotag_targets(
         &self,
         keep_default_names: &[String],
         add_custom_names: &[String],
     ) -> Result<Vec<Tag>, AtomicCoreError> {
-        const DEFAULT_NAMES: &[&str] = &["Topics", "People", "Locations", "Organizations", "Events"];
-
-        let keep_lower: std::collections::HashSet<String> = keep_default_names
-            .iter()
-            .map(|n| n.trim().to_lowercase())
-            .filter(|n| !n.is_empty())
-            .collect();
-
-        // Snapshot current top-level tags so we can decide create vs. flag vs. delete.
-        let all_tags = self.storage.get_all_tags_impl()?;
-        let top_level: Vec<&TagWithCount> = all_tags
-            .iter()
-            .filter(|t| t.tag.parent_id.is_none())
-            .collect();
-
-        // Step 1: For each requested default, create it if missing and ensure it's flagged.
-        for default_name in DEFAULT_NAMES {
-            if !keep_lower.contains(&default_name.to_lowercase()) {
-                continue;
-            }
-            let existing = top_level
-                .iter()
-                .find(|t| t.tag.name.eq_ignore_ascii_case(default_name));
-            let tag_id = match existing {
-                Some(t) => t.tag.id.clone(),
-                None => self.storage.create_tag_impl(default_name, None)?.id,
-            };
-            self.storage.set_tag_autotag_target_impl(&tag_id, true)?;
-        }
-
-        // Step 2: For each existing default the user did NOT keep, delete if empty,
-        // otherwise unflag to keep their data intact.
-        for tag_with_count in &top_level {
-            let name = &tag_with_count.tag.name;
-            let is_default = DEFAULT_NAMES.iter().any(|d| d.eq_ignore_ascii_case(name));
-            let is_kept = keep_lower.contains(&name.to_lowercase());
-            if !is_default || is_kept {
-                continue;
-            }
-            if tag_with_count.atom_count == 0 && tag_with_count.children_total == 0 {
-                self.storage.delete_tag_impl(&tag_with_count.tag.id, false)?;
-            } else if tag_with_count.tag.is_autotag_target {
-                self.storage.set_tag_autotag_target_impl(&tag_with_count.tag.id, false)?;
-            }
-        }
-
-        // Step 3: Custom additions — create new top-level tags or flag existing ones.
-        let mut custom_tags: Vec<Tag> = Vec::new();
-        for name in add_custom_names {
-            let trimmed = name.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            // Refresh the top-level snapshot since we may have just created/deleted defaults.
-            let current = self.storage.get_all_tags_impl()?;
-            let existing = current.iter().find(|t| {
-                t.tag.parent_id.is_none() && t.tag.name.eq_ignore_ascii_case(trimmed)
-            });
-            let tag_id = match existing {
-                Some(t) => t.tag.id.clone(),
-                None => self.storage.create_tag_impl(trimmed, None)?.id,
-            };
-            self.storage.set_tag_autotag_target_impl(&tag_id, true)?;
-            if let Some(updated) = self.storage.get_all_tags_impl()?.into_iter()
-                .find(|t| t.tag.id == tag_id)
-            {
-                custom_tags.push(updated.tag);
-            }
-        }
-
-        Ok(custom_tags)
+        self.storage.configure_autotag_targets_impl(keep_default_names, add_custom_names)
     }
 
     // ==================== Search Operations ====================

--- a/crates/atomic-core/src/models.rs
+++ b/crates/atomic-core/src/models.rs
@@ -31,6 +31,7 @@ pub struct Tag {
     pub name: String,
     pub parent_id: Option<String>,
     pub created_at: String,
+    pub is_autotag_target: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -175,6 +176,12 @@ pub struct WikiCitation {
     pub atom_id: String,
     pub chunk_index: Option<i32>,
     pub excerpt: String,
+    /// The cited atom's source URL (e.g. `obsidian://VaultName/path.md`,
+    /// `https://...`, or null for atoms without a source). Joined from `atoms` at read time;
+    /// not stored on the `wiki_citations` row. `#[serde(default)]` keeps backward compatibility
+    /// with proposals serialized before this field existed.
+    #[serde(default)]
+    pub source_url: Option<String>,
 }
 
 /// Wiki article with all its citations

--- a/crates/atomic-core/src/search.rs
+++ b/crates/atomic-core/src/search.rs
@@ -268,7 +268,7 @@ fn batch_fetch_tags(conn: &rusqlite::Connection, atom_ids: &[String]) -> Result<
     }
     let placeholders = atom_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let query = format!(
-        "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at
+        "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
          FROM atom_tags at
          INNER JOIN tags t ON at.tag_id = t.id
          WHERE at.atom_id IN ({})",
@@ -285,6 +285,7 @@ fn batch_fetch_tags(conn: &rusqlite::Connection, atom_ids: &[String]) -> Result<
                     name: row.get(2)?,
                     parent_id: row.get(3)?,
                     created_at: row.get(4)?,
+                    is_autotag_target: row.get::<_, i32>(5)? != 0,
                 },
             ))
         })

--- a/crates/atomic-core/src/storage/mod.rs
+++ b/crates/atomic-core/src/storage/mod.rs
@@ -254,6 +254,8 @@ dispatch! {
         => sqlite: update_tag_impl, pg_trait: TagStore, pg_method: update_tag;
     fn delete_tag_impl(&self, id: &str, recursive: bool) -> Result<(), AtomicCoreError>
         => sqlite: delete_tag_impl, pg_trait: TagStore, pg_method: delete_tag;
+    fn set_tag_autotag_target_impl(&self, id: &str, value: bool) -> Result<(), AtomicCoreError>
+        => sqlite: set_tag_autotag_target_impl, pg_trait: TagStore, pg_method: set_tag_autotag_target;
     fn get_related_tags_impl(&self, tag_id: &str, limit: usize) -> Result<Vec<RelatedTag>, AtomicCoreError>
         => sqlite: get_related_tags_impl, pg_trait: TagStore, pg_method: get_related_tags;
     fn get_tags_for_compaction_impl(&self) -> Result<String, AtomicCoreError>

--- a/crates/atomic-core/src/storage/mod.rs
+++ b/crates/atomic-core/src/storage/mod.rs
@@ -256,6 +256,8 @@ dispatch! {
         => sqlite: delete_tag_impl, pg_trait: TagStore, pg_method: delete_tag;
     fn set_tag_autotag_target_impl(&self, id: &str, value: bool) -> Result<(), AtomicCoreError>
         => sqlite: set_tag_autotag_target_impl, pg_trait: TagStore, pg_method: set_tag_autotag_target;
+    fn configure_autotag_targets_impl(&self, keep_default_names: &[String], add_custom_names: &[String]) -> Result<Vec<Tag>, AtomicCoreError>
+        => sqlite: configure_autotag_targets_impl, pg_trait: TagStore, pg_method: configure_autotag_targets;
     fn get_related_tags_impl(&self, tag_id: &str, limit: usize) -> Result<Vec<RelatedTag>, AtomicCoreError>
         => sqlite: get_related_tags_impl, pg_trait: TagStore, pg_method: get_related_tags;
     fn get_tags_for_compaction_impl(&self) -> Result<String, AtomicCoreError>

--- a/crates/atomic-core/src/storage/postgres/atoms.rs
+++ b/crates/atomic-core/src/storage/postgres/atoms.rs
@@ -15,8 +15,8 @@ macro_rules! db_err {
 impl PostgresStorage {
     /// Fetch tags for a single atom.
     async fn tags_for_atom(&self, atom_id: &str) -> StorageResult<Vec<Tag>> {
-        let rows: Vec<(String, String, Option<String>, String)> = sqlx::query_as(
-            "SELECT t.id, t.name, t.parent_id, t.created_at
+        let rows: Vec<(String, String, Option<String>, String, bool)> = sqlx::query_as(
+            "SELECT t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
              FROM tags t
              JOIN atom_tags at ON t.id = at.tag_id
              WHERE at.atom_id = $1 AND at.db_id = $2
@@ -30,11 +30,12 @@ impl PostgresStorage {
 
         Ok(rows
             .into_iter()
-            .map(|(id, name, parent_id, created_at)| Tag {
+            .map(|(id, name, parent_id, created_at, is_autotag_target)| Tag {
                 id,
                 name,
                 parent_id,
                 created_at,
+                is_autotag_target,
             })
             .collect())
     }
@@ -53,7 +54,7 @@ impl PostgresStorage {
         // Build dynamic placeholders $1, $2, ... (reserve $1 for db_id)
         let placeholders: Vec<String> = (2..=atom_ids.len() + 1).map(|i| format!("${}", i)).collect();
         let sql = format!(
-            "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at
+            "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
              FROM atom_tags at
              JOIN tags t ON t.id = at.tag_id
              WHERE at.db_id = $1 AND at.atom_id IN ({})
@@ -61,7 +62,7 @@ impl PostgresStorage {
             placeholders.join(", ")
         );
 
-        let mut query = sqlx::query_as::<_, (String, String, String, Option<String>, String)>(&sql);
+        let mut query = sqlx::query_as::<_, (String, String, String, Option<String>, String, bool)>(&sql);
         query = query.bind(&self.db_id);
         for id in atom_ids {
             query = query.bind(id);
@@ -73,12 +74,13 @@ impl PostgresStorage {
             .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
         let mut map: HashMap<String, Vec<Tag>> = HashMap::new();
-        for (atom_id, tag_id, name, parent_id, created_at) in rows {
+        for (atom_id, tag_id, name, parent_id, created_at, is_autotag_target) in rows {
             map.entry(atom_id).or_default().push(Tag {
                 id: tag_id,
                 name,
                 parent_id,
                 created_at,
+                is_autotag_target,
             });
         }
 

--- a/crates/atomic-core/src/storage/postgres/chat.rs
+++ b/crates/atomic-core/src/storage/postgres/chat.rs
@@ -11,8 +11,8 @@ async fn fetch_conversation_tags(
     conversation_id: &str,
     db_id: &str,
 ) -> StorageResult<Vec<Tag>> {
-    let rows = sqlx::query_as::<_, (String, String, Option<String>, String)>(
-        "SELECT t.id, t.name, t.parent_id, t.created_at
+    let rows = sqlx::query_as::<_, (String, String, Option<String>, String, bool)>(
+        "SELECT t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
          FROM tags t
          JOIN conversation_tags ct ON ct.tag_id = t.id
          WHERE ct.conversation_id = $1 AND ct.db_id = $2 AND t.db_id = $2
@@ -26,11 +26,12 @@ async fn fetch_conversation_tags(
 
     Ok(rows
         .into_iter()
-        .map(|(id, name, parent_id, created_at)| Tag {
+        .map(|(id, name, parent_id, created_at, is_autotag_target)| Tag {
             id,
             name,
             parent_id,
             created_at,
+            is_autotag_target,
         })
         .collect())
 }
@@ -124,8 +125,8 @@ async fn batch_fetch_conversation_tags(
         return Ok(HashMap::new());
     }
 
-    let rows = sqlx::query_as::<_, (String, String, String, Option<String>, String)>(
-        "SELECT ct.conversation_id, t.id, t.name, t.parent_id, t.created_at
+    let rows = sqlx::query_as::<_, (String, String, String, Option<String>, String, bool)>(
+        "SELECT ct.conversation_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
          FROM conversation_tags ct
          JOIN tags t ON ct.tag_id = t.id
          WHERE ct.conversation_id = ANY($1) AND ct.db_id = $2 AND t.db_id = $2
@@ -138,12 +139,13 @@ async fn batch_fetch_conversation_tags(
     .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
     let mut map: HashMap<String, Vec<Tag>> = HashMap::new();
-    for (conv_id, id, name, parent_id, created_at) in rows {
+    for (conv_id, id, name, parent_id, created_at, is_autotag_target) in rows {
         map.entry(conv_id).or_default().push(Tag {
             id,
             name,
             parent_id,
             created_at,
+            is_autotag_target,
         });
     }
 

--- a/crates/atomic-core/src/storage/postgres/chunks.rs
+++ b/crates/atomic-core/src/storage/postgres/chunks.rs
@@ -487,8 +487,8 @@ impl ChunkStore for PostgresStorage {
             .collect();
 
         // Batch fetch tags
-        let tag_rows: Vec<(String, String, String, Option<String>, String)> = sqlx::query_as(
-            "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at
+        let tag_rows: Vec<(String, String, String, Option<String>, String, bool)> = sqlx::query_as(
+            "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
              FROM atom_tags at
              INNER JOIN tags t ON at.tag_id = t.id
              WHERE at.atom_id = ANY($1) AND at.db_id = $2",
@@ -505,12 +505,13 @@ impl ChunkStore for PostgresStorage {
         })?;
 
         let mut tag_map: HashMap<String, Vec<Tag>> = HashMap::new();
-        for (atom_id_val, tag_id, name, parent_id, created_at) in tag_rows {
+        for (atom_id_val, tag_id, name, parent_id, created_at, is_autotag_target) in tag_rows {
             tag_map.entry(atom_id_val).or_default().push(Tag {
                 id: tag_id,
                 name,
                 parent_id,
                 created_at,
+                is_autotag_target,
             });
         }
 

--- a/crates/atomic-core/src/storage/postgres/migrations/005_autotag_target.sql
+++ b/crates/atomic-core/src/storage/postgres/migrations/005_autotag_target.sql
@@ -1,0 +1,7 @@
+-- Mark which top-level tags the auto-tagger may extend with sub-tags.
+ALTER TABLE tags ADD COLUMN IF NOT EXISTS is_autotag_target BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Backfill: the five seeded categories are auto-tag targets by default.
+UPDATE tags SET is_autotag_target = TRUE
+  WHERE parent_id IS NULL
+    AND name IN ('Topics', 'People', 'Locations', 'Organizations', 'Events');

--- a/crates/atomic-core/src/storage/postgres/mod.rs
+++ b/crates/atomic-core/src/storage/postgres/mod.rs
@@ -102,6 +102,7 @@ impl PostgresStorage {
             (2, include_str!("migrations/002_add_db_id.sql")),
             (3, include_str!("migrations/003_add_error_columns.sql")),
             (4, include_str!("migrations/004_wiki_proposals.sql")),
+            (5, include_str!("migrations/005_autotag_target.sql")),
         ];
 
         // Advisory lock key — arbitrary fixed i64 to serialize migrations

--- a/crates/atomic-core/src/storage/postgres/search.rs
+++ b/crates/atomic-core/src/storage/postgres/search.rs
@@ -488,8 +488,8 @@ async fn pg_batch_fetch_tags(
         return Ok(HashMap::new());
     }
 
-    let rows: Vec<(String, String, String, Option<String>, String)> = sqlx::query_as(
-        "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at
+    let rows: Vec<(String, String, String, Option<String>, String, bool)> = sqlx::query_as(
+        "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
          FROM atom_tags at
          INNER JOIN tags t ON at.tag_id = t.id
          WHERE at.atom_id = ANY($1) AND at.db_id = $2",
@@ -501,12 +501,13 @@ async fn pg_batch_fetch_tags(
     .map_err(|e| AtomicCoreError::Search(format!("Failed to batch fetch tags: {}", e)))?;
 
     let mut map: HashMap<String, Vec<Tag>> = HashMap::new();
-    for (atom_id, tag_id, name, parent_id, created_at) in rows {
+    for (atom_id, tag_id, name, parent_id, created_at, is_autotag_target) in rows {
         map.entry(atom_id).or_default().push(Tag {
             id: tag_id,
             name,
             parent_id,
             created_at,
+            is_autotag_target,
         });
     }
     Ok(map)

--- a/crates/atomic-core/src/storage/postgres/tags.rs
+++ b/crates/atomic-core/src/storage/postgres/tags.rs
@@ -11,8 +11,8 @@ use chrono::Utc;
 impl PostgresStorage {
     /// Load all tags and their direct (denormalized) atom counts.
     async fn load_tags_and_counts(&self) -> StorageResult<(Vec<Tag>, HashMap<String, i32>)> {
-        let rows: Vec<(String, String, Option<String>, String, i32)> = sqlx::query_as(
-            "SELECT id, name, parent_id, created_at, atom_count FROM tags WHERE db_id = $1 ORDER BY name",
+        let rows: Vec<(String, String, Option<String>, String, i32, bool)> = sqlx::query_as(
+            "SELECT id, name, parent_id, created_at, atom_count, is_autotag_target FROM tags WHERE db_id = $1 ORDER BY name",
         )
         .bind(&self.db_id)
         .fetch_all(&self.pool)
@@ -22,13 +22,14 @@ impl PostgresStorage {
         let mut direct_counts: HashMap<String, i32> = HashMap::new();
         let all_tags: Vec<Tag> = rows
             .into_iter()
-            .map(|(id, name, parent_id, created_at, count)| {
+            .map(|(id, name, parent_id, created_at, count, is_autotag_target)| {
                 direct_counts.insert(id.clone(), count);
                 Tag {
                     id,
                     name,
                     parent_id,
                     created_at,
+                    is_autotag_target,
                 }
             })
             .collect();
@@ -246,9 +247,10 @@ impl TagStore for PostgresStorage {
             });
         }
 
-        let rows: Vec<(String, String, Option<String>, String, i32, i64)> = sqlx::query_as(
+        let rows: Vec<(String, String, Option<String>, String, i32, i64, bool)> = sqlx::query_as(
             "SELECT t.id, t.name, t.parent_id, t.created_at, t.atom_count,
-                (SELECT COUNT(*) FROM tags c WHERE c.parent_id = t.id AND c.db_id = $2) AS children_total
+                (SELECT COUNT(*) FROM tags c WHERE c.parent_id = t.id AND c.db_id = $2) AS children_total,
+                t.is_autotag_target
             FROM tags t
             WHERE t.parent_id = $1 AND t.db_id = $2
             ORDER BY t.atom_count DESC
@@ -264,12 +266,13 @@ impl TagStore for PostgresStorage {
 
         let mut children: Vec<TagWithCount> = rows
             .into_iter()
-            .map(|(id, name, parent_id, created_at, atom_count, children_total)| TagWithCount {
+            .map(|(id, name, parent_id, created_at, atom_count, children_total, is_autotag_target)| TagWithCount {
                 tag: Tag {
                     id,
                     name,
                     parent_id,
                     created_at,
+                    is_autotag_target,
                 },
                 atom_count,
                 children_total: children_total as i32,
@@ -309,6 +312,7 @@ impl TagStore for PostgresStorage {
             name: name.to_string(),
             parent_id: parent_id.map(String::from),
             created_at: now,
+            is_autotag_target: false,
         })
     }
 
@@ -327,8 +331,8 @@ impl TagStore for PostgresStorage {
             .await
             .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
-        let row: (String, String, Option<String>, String) = sqlx::query_as(
-            "SELECT id, name, parent_id, created_at FROM tags WHERE id = $1 AND db_id = $2",
+        let row: (String, String, Option<String>, String, bool) = sqlx::query_as(
+            "SELECT id, name, parent_id, created_at, is_autotag_target FROM tags WHERE id = $1 AND db_id = $2",
         )
         .bind(id)
         .bind(&self.db_id)
@@ -341,7 +345,19 @@ impl TagStore for PostgresStorage {
             name: row.1,
             parent_id: row.2,
             created_at: row.3,
+            is_autotag_target: row.4,
         })
+    }
+
+    async fn set_tag_autotag_target(&self, id: &str, value: bool) -> StorageResult<()> {
+        sqlx::query("UPDATE tags SET is_autotag_target = $1 WHERE id = $2 AND db_id = $3")
+            .bind(value)
+            .bind(id)
+            .bind(&self.db_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+        Ok(())
     }
 
     async fn delete_tag(&self, id: &str, recursive: bool) -> StorageResult<()> {

--- a/crates/atomic-core/src/storage/postgres/tags.rs
+++ b/crates/atomic-core/src/storage/postgres/tags.rs
@@ -350,14 +350,169 @@ impl TagStore for PostgresStorage {
     }
 
     async fn set_tag_autotag_target(&self, id: &str, value: bool) -> StorageResult<()> {
-        sqlx::query("UPDATE tags SET is_autotag_target = $1 WHERE id = $2 AND db_id = $3")
+        let result = sqlx::query("UPDATE tags SET is_autotag_target = $1 WHERE id = $2 AND db_id = $3")
             .bind(value)
             .bind(id)
             .bind(&self.db_id)
             .execute(&self.pool)
             .await
             .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+        if result.rows_affected() == 0 {
+            return Err(AtomicCoreError::NotFound(format!("tag {}", id)));
+        }
         Ok(())
+    }
+
+    async fn configure_autotag_targets(
+        &self,
+        keep_default_names: &[String],
+        add_custom_names: &[String],
+    ) -> StorageResult<Vec<Tag>> {
+        const DEFAULT_NAMES: &[&str] = &["Topics", "People", "Locations", "Organizations", "Events"];
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+
+        let keep_lower: std::collections::HashSet<String> = keep_default_names
+            .iter()
+            .map(|n| n.trim().to_lowercase())
+            .filter(|n| !n.is_empty())
+            .collect();
+
+        // Snapshot current top-level tags + counts.
+        let top_level: Vec<(String, String, bool, i32, i64)> = sqlx::query_as(
+            "SELECT t.id, t.name, t.is_autotag_target, t.atom_count,
+                    (SELECT COUNT(*) FROM tags c WHERE c.parent_id = t.id AND c.db_id = $1) AS children_count
+             FROM tags t
+             WHERE t.parent_id IS NULL AND t.db_id = $1",
+        )
+        .bind(&self.db_id)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Step 1: ensure each requested default exists and is flagged.
+        for default_name in DEFAULT_NAMES {
+            if !keep_lower.contains(&default_name.to_lowercase()) {
+                continue;
+            }
+            let existing = top_level.iter().find(|(_, n, _, _, _)| n.eq_ignore_ascii_case(default_name));
+            let id = match existing {
+                Some((id, _, _, _, _)) => id.clone(),
+                None => {
+                    let new_id = Uuid::new_v4().to_string();
+                    sqlx::query(
+                        "INSERT INTO tags (id, name, parent_id, created_at, is_autotag_target, db_id)
+                         VALUES ($1, $2, NULL, $3, TRUE, $4)",
+                    )
+                    .bind(&new_id)
+                    .bind(default_name)
+                    .bind(&now)
+                    .bind(&self.db_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+                    new_id
+                }
+            };
+            sqlx::query("UPDATE tags SET is_autotag_target = TRUE WHERE id = $1 AND db_id = $2")
+                .bind(&id)
+                .bind(&self.db_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+        }
+
+        // Step 2: handle unrequested defaults — delete if empty, otherwise unflag.
+        for (id, name, is_target, atom_count, children_count) in &top_level {
+            let is_default = DEFAULT_NAMES.iter().any(|d| d.eq_ignore_ascii_case(name));
+            let is_kept = keep_lower.contains(&name.to_lowercase());
+            if !is_default || is_kept {
+                continue;
+            }
+            if *atom_count == 0 && *children_count == 0 {
+                sqlx::query("DELETE FROM tags WHERE id = $1 AND db_id = $2")
+                    .bind(id)
+                    .bind(&self.db_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+            } else if *is_target {
+                sqlx::query("UPDATE tags SET is_autotag_target = FALSE WHERE id = $1 AND db_id = $2")
+                    .bind(id)
+                    .bind(&self.db_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+            }
+        }
+
+        // Step 3: custom additions — re-query each name since Step 2 may have deleted rows.
+        let mut custom_tags: Vec<Tag> = Vec::new();
+        for name in add_custom_names {
+            let trimmed = name.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let existing_id: Option<(String,)> = sqlx::query_as(
+                "SELECT id FROM tags WHERE parent_id IS NULL AND LOWER(name) = LOWER($1) AND db_id = $2 LIMIT 1",
+            )
+            .bind(trimmed)
+            .bind(&self.db_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+            let id = match existing_id {
+                Some((id,)) => id,
+                None => {
+                    let new_id = Uuid::new_v4().to_string();
+                    sqlx::query(
+                        "INSERT INTO tags (id, name, parent_id, created_at, is_autotag_target, db_id)
+                         VALUES ($1, $2, NULL, $3, TRUE, $4)",
+                    )
+                    .bind(&new_id)
+                    .bind(trimmed)
+                    .bind(&now)
+                    .bind(&self.db_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+                    new_id
+                }
+            };
+            sqlx::query("UPDATE tags SET is_autotag_target = TRUE WHERE id = $1 AND db_id = $2")
+                .bind(&id)
+                .bind(&self.db_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+            let row: (String, String, Option<String>, String, bool) = sqlx::query_as(
+                "SELECT id, name, parent_id, created_at, is_autotag_target FROM tags WHERE id = $1 AND db_id = $2",
+            )
+            .bind(&id)
+            .bind(&self.db_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+            custom_tags.push(Tag {
+                id: row.0,
+                name: row.1,
+                parent_id: row.2,
+                created_at: row.3,
+                is_autotag_target: row.4,
+            });
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+
+        Ok(custom_tags)
     }
 
     async fn delete_tag(&self, id: &str, recursive: bool) -> StorageResult<()> {

--- a/crates/atomic-core/src/storage/postgres/wiki.rs
+++ b/crates/atomic-core/src/storage/postgres/wiki.rs
@@ -34,12 +34,15 @@ impl WikiStore for PostgresStorage {
             None => return Ok(None),
         };
 
-        // Get citations
-        let citation_rows = sqlx::query_as::<_, (String, i32, String, Option<i32>, String)>(
-            "SELECT id, citation_index, atom_id, chunk_index, excerpt
-             FROM wiki_citations
-             WHERE wiki_article_id = $1 AND db_id = $2
-             ORDER BY citation_index",
+        // Get citations, joining atoms for source_url so clients can render
+        // citations differently based on the cited atom's origin (e.g. Obsidian
+        // plugin rewriting them as wikilinks).
+        let citation_rows = sqlx::query_as::<_, (String, i32, String, Option<i32>, String, Option<String>)>(
+            "SELECT c.id, c.citation_index, c.atom_id, c.chunk_index, c.excerpt, a.source_url
+             FROM wiki_citations c
+             LEFT JOIN atoms a ON a.id = c.atom_id AND a.db_id = c.db_id
+             WHERE c.wiki_article_id = $1 AND c.db_id = $2
+             ORDER BY c.citation_index",
         )
         .bind(&article.id)
         .bind(&self.db_id)
@@ -49,12 +52,13 @@ impl WikiStore for PostgresStorage {
 
         let citations: Vec<WikiCitation> = citation_rows
             .into_iter()
-            .map(|(id, citation_index, atom_id, chunk_index, excerpt)| WikiCitation {
+            .map(|(id, citation_index, atom_id, chunk_index, excerpt, source_url)| WikiCitation {
                 id,
                 citation_index,
                 atom_id,
                 chunk_index,
                 excerpt,
+                source_url,
             })
             .collect();
 

--- a/crates/atomic-core/src/storage/sqlite/search.rs
+++ b/crates/atomic-core/src/storage/sqlite/search.rs
@@ -520,7 +520,7 @@ fn batch_fetch_tags(
     }
     let placeholders = atom_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let query = format!(
-        "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at
+        "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
          FROM atom_tags at
          INNER JOIN tags t ON at.tag_id = t.id
          WHERE at.atom_id IN ({})",
@@ -539,6 +539,7 @@ fn batch_fetch_tags(
                     name: row.get(2)?,
                     parent_id: row.get(3)?,
                     created_at: row.get(4)?,
+                    is_autotag_target: row.get::<_, i32>(5)? != 0,
                 },
             ))
         })

--- a/crates/atomic-core/src/storage/sqlite/tags.rs
+++ b/crates/atomic-core/src/storage/sqlite/tags.rs
@@ -12,7 +12,7 @@ use chrono::Utc;
 /// Load all tags and their direct (denormalized) atom counts from the database.
 fn load_tags_and_counts(conn: &Connection) -> Result<(Vec<Tag>, HashMap<String, i32>), AtomicCoreError> {
     let mut stmt = conn
-        .prepare("SELECT id, name, parent_id, created_at, atom_count FROM tags ORDER BY name")?;
+        .prepare("SELECT id, name, parent_id, created_at, atom_count, is_autotag_target FROM tags ORDER BY name")?;
 
     let mut direct_counts: HashMap<String, i32> = HashMap::new();
     let all_tags: Vec<Tag> = stmt
@@ -25,6 +25,7 @@ fn load_tags_and_counts(conn: &Connection) -> Result<(Vec<Tag>, HashMap<String, 
                 name: row.get(1)?,
                 parent_id: row.get(2)?,
                 created_at: row.get(3)?,
+                is_autotag_target: row.get::<_, i32>(5)? != 0,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -67,7 +68,8 @@ impl SqliteStorage {
         // so no JOIN or GROUP BY needed — just read the column directly.
         let mut stmt = conn.prepare(
             "SELECT t.id, t.name, t.parent_id, t.created_at, t.atom_count,
-                (SELECT COUNT(*) FROM tags c WHERE c.parent_id = t.id) AS children_total
+                (SELECT COUNT(*) FROM tags c WHERE c.parent_id = t.id) AS children_total,
+                t.is_autotag_target
             FROM tags t
             WHERE t.parent_id = ?1
             ORDER BY t.atom_count DESC
@@ -82,6 +84,7 @@ impl SqliteStorage {
                         name: row.get(1)?,
                         parent_id: row.get(2)?,
                         created_at: row.get(3)?,
+                        is_autotag_target: row.get::<_, i32>(6)? != 0,
                     },
                     atom_count: row.get(4)?,
                     children_total: row.get(5)?,
@@ -117,6 +120,7 @@ impl SqliteStorage {
             name: name.to_string(),
             parent_id: parent_id.map(String::from),
             created_at: now,
+            is_autotag_target: false,
         })
     }
 
@@ -135,7 +139,7 @@ impl SqliteStorage {
 
         let tag = conn
             .query_row(
-                "SELECT id, name, parent_id, created_at FROM tags WHERE id = ?1",
+                "SELECT id, name, parent_id, created_at, is_autotag_target FROM tags WHERE id = ?1",
                 [id],
                 |row| {
                     Ok(Tag {
@@ -143,11 +147,26 @@ impl SqliteStorage {
                         name: row.get(1)?,
                         parent_id: row.get(2)?,
                         created_at: row.get(3)?,
+                        is_autotag_target: row.get::<_, i32>(4)? != 0,
                     })
                 },
             )?;
 
         Ok(tag)
+    }
+
+    pub(crate) fn set_tag_autotag_target_impl(
+        &self,
+        id: &str,
+        value: bool,
+    ) -> StorageResult<()> {
+        let conn = self.db.conn.lock().map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
+        let val = if value { 1 } else { 0 };
+        conn.execute(
+            "UPDATE tags SET is_autotag_target = ?1 WHERE id = ?2",
+            rusqlite::params![val, id],
+        )?;
+        Ok(())
     }
 
     pub(crate) fn delete_tag_impl(&self, id: &str, recursive: bool) -> StorageResult<()> {
@@ -307,6 +326,10 @@ impl TagStore for SqliteStorage {
 
     async fn delete_tag(&self, id: &str, recursive: bool) -> StorageResult<()> {
         self.delete_tag_impl(id, recursive)
+    }
+
+    async fn set_tag_autotag_target(&self, id: &str, value: bool) -> StorageResult<()> {
+        self.set_tag_autotag_target_impl(id, value)
     }
 
     async fn get_related_tags(

--- a/crates/atomic-core/src/storage/sqlite/tags.rs
+++ b/crates/atomic-core/src/storage/sqlite/tags.rs
@@ -4,8 +4,8 @@ use crate::error::AtomicCoreError;
 use crate::models::*;
 use crate::storage::traits::*;
 use async_trait::async_trait;
-use rusqlite::Connection;
-use std::collections::HashMap;
+use rusqlite::{Connection, OptionalExtension};
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 use chrono::Utc;
 
@@ -162,11 +162,156 @@ impl SqliteStorage {
     ) -> StorageResult<()> {
         let conn = self.db.conn.lock().map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
         let val = if value { 1 } else { 0 };
-        conn.execute(
+        let affected = conn.execute(
             "UPDATE tags SET is_autotag_target = ?1 WHERE id = ?2",
             rusqlite::params![val, id],
         )?;
+        if affected == 0 {
+            return Err(AtomicCoreError::NotFound(format!("tag {}", id)));
+        }
         Ok(())
+    }
+
+    /// Apply a full auto-tag-target configuration in a single transaction.
+    ///
+    /// Steps run atomically: any error rolls back the savepoint, leaving the
+    /// tags table in its prior state. The orchestration mirrors the previous
+    /// `AtomicCore::configure_autotag_targets` flow but acquires the connection
+    /// lock once and uses an `unchecked_transaction` so a panic or early return
+    /// can't leave the DB partially modified.
+    pub(crate) fn configure_autotag_targets_impl(
+        &self,
+        keep_default_names: &[String],
+        add_custom_names: &[String],
+    ) -> StorageResult<Vec<Tag>> {
+        const DEFAULT_NAMES: &[&str] = &["Topics", "People", "Locations", "Organizations", "Events"];
+
+        let conn = self.db.conn.lock().map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
+        let tx = conn.unchecked_transaction()?;
+
+        let keep_lower: HashSet<String> = keep_default_names
+            .iter()
+            .map(|n| n.trim().to_lowercase())
+            .filter(|n| !n.is_empty())
+            .collect();
+
+        // Snapshot current top-level tags with the counts we need to decide
+        // delete-vs-unflag for unrequested defaults.
+        #[derive(Clone)]
+        struct TopLevel {
+            id: String,
+            name: String,
+            is_target: bool,
+            atom_count: i32,
+            children_count: i32,
+        }
+        let mut stmt = tx.prepare(
+            "SELECT t.id, t.name, t.is_autotag_target, t.atom_count,
+                    (SELECT COUNT(*) FROM tags c WHERE c.parent_id = t.id) AS children_count
+             FROM tags t
+             WHERE t.parent_id IS NULL"
+        )?;
+        let top_level: Vec<TopLevel> = stmt
+            .query_map([], |row| Ok(TopLevel {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                is_target: row.get::<_, i32>(2)? != 0,
+                atom_count: row.get(3)?,
+                children_count: row.get(4)?,
+            }))?
+            .collect::<Result<Vec<_>, _>>()?;
+        drop(stmt);
+
+        let now = Utc::now().to_rfc3339();
+
+        // Step 1: ensure each requested default exists and is flagged.
+        for default_name in DEFAULT_NAMES {
+            if !keep_lower.contains(&default_name.to_lowercase()) {
+                continue;
+            }
+            let existing = top_level.iter().find(|t| t.name.eq_ignore_ascii_case(default_name));
+            let id = match existing {
+                Some(t) => t.id.clone(),
+                None => {
+                    let new_id = Uuid::new_v4().to_string();
+                    tx.execute(
+                        "INSERT INTO tags (id, name, parent_id, created_at, is_autotag_target)
+                         VALUES (?1, ?2, NULL, ?3, 1)",
+                        rusqlite::params![&new_id, default_name, &now],
+                    )?;
+                    new_id
+                }
+            };
+            tx.execute(
+                "UPDATE tags SET is_autotag_target = 1 WHERE id = ?1",
+                rusqlite::params![&id],
+            )?;
+        }
+
+        // Step 2: handle unrequested defaults — delete if empty, otherwise unflag.
+        for t in &top_level {
+            let is_default = DEFAULT_NAMES.iter().any(|d| d.eq_ignore_ascii_case(&t.name));
+            let is_kept = keep_lower.contains(&t.name.to_lowercase());
+            if !is_default || is_kept {
+                continue;
+            }
+            if t.atom_count == 0 && t.children_count == 0 {
+                tx.execute("DELETE FROM tags WHERE id = ?1", rusqlite::params![&t.id])?;
+            } else if t.is_target {
+                tx.execute(
+                    "UPDATE tags SET is_autotag_target = 0 WHERE id = ?1",
+                    rusqlite::params![&t.id],
+                )?;
+            }
+        }
+
+        // Step 3: custom additions — create or flag in place. Re-query each
+        // name since Step 2 may have deleted rows that were in our snapshot.
+        let mut custom_tags: Vec<Tag> = Vec::new();
+        for name in add_custom_names {
+            let trimmed = name.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let existing_id: Option<String> = tx
+                .query_row(
+                    "SELECT id FROM tags WHERE parent_id IS NULL AND LOWER(name) = LOWER(?1) LIMIT 1",
+                    [trimmed],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            let id = match existing_id {
+                Some(id) => id,
+                None => {
+                    let new_id = Uuid::new_v4().to_string();
+                    tx.execute(
+                        "INSERT INTO tags (id, name, parent_id, created_at, is_autotag_target)
+                         VALUES (?1, ?2, NULL, ?3, 1)",
+                        rusqlite::params![&new_id, trimmed, &now],
+                    )?;
+                    new_id
+                }
+            };
+            tx.execute(
+                "UPDATE tags SET is_autotag_target = 1 WHERE id = ?1",
+                rusqlite::params![&id],
+            )?;
+            let tag = tx.query_row(
+                "SELECT id, name, parent_id, created_at, is_autotag_target FROM tags WHERE id = ?1",
+                [&id],
+                |row| Ok(Tag {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    parent_id: row.get(2)?,
+                    created_at: row.get(3)?,
+                    is_autotag_target: row.get::<_, i32>(4)? != 0,
+                }),
+            )?;
+            custom_tags.push(tag);
+        }
+
+        tx.commit()?;
+        Ok(custom_tags)
     }
 
     pub(crate) fn delete_tag_impl(&self, id: &str, recursive: bool) -> StorageResult<()> {
@@ -330,6 +475,14 @@ impl TagStore for SqliteStorage {
 
     async fn set_tag_autotag_target(&self, id: &str, value: bool) -> StorageResult<()> {
         self.set_tag_autotag_target_impl(id, value)
+    }
+
+    async fn configure_autotag_targets(
+        &self,
+        keep_default_names: &[String],
+        add_custom_names: &[String],
+    ) -> StorageResult<Vec<Tag>> {
+        self.configure_autotag_targets_impl(keep_default_names, add_custom_names)
     }
 
     async fn get_related_tags(

--- a/crates/atomic-core/src/storage/traits.rs
+++ b/crates/atomic-core/src/storage/traits.rs
@@ -183,6 +183,9 @@ pub trait TagStore: Send + Sync {
     /// Delete a tag. If recursive, also deletes child tags.
     async fn delete_tag(&self, id: &str, recursive: bool) -> StorageResult<()>;
 
+    /// Mark or unmark a tag as a candidate for AI auto-tagging to extend with sub-tags.
+    async fn set_tag_autotag_target(&self, id: &str, value: bool) -> StorageResult<()>;
+
     /// Get tags semantically related to a given tag (via centroid similarity).
     async fn get_related_tags(
         &self,

--- a/crates/atomic-core/src/storage/traits.rs
+++ b/crates/atomic-core/src/storage/traits.rs
@@ -186,6 +186,14 @@ pub trait TagStore: Send + Sync {
     /// Mark or unmark a tag as a candidate for AI auto-tagging to extend with sub-tags.
     async fn set_tag_autotag_target(&self, id: &str, value: bool) -> StorageResult<()>;
 
+    /// Apply a full auto-tag-target configuration in a single transaction.
+    /// See `AtomicCore::configure_autotag_targets` for semantics.
+    async fn configure_autotag_targets(
+        &self,
+        keep_default_names: &[String],
+        add_custom_names: &[String],
+    ) -> StorageResult<Vec<Tag>>;
+
     /// Get tags semantically related to a given tag (via centroid similarity).
     async fn get_related_tags(
         &self,

--- a/crates/atomic-core/src/wiki/mod.rs
+++ b/crates/atomic-core/src/wiki/mod.rs
@@ -440,6 +440,7 @@ async fn generate_section_ops_proposal(
                 atom_id: existing_citation.atom_id.clone(),
                 chunk_index: existing_citation.chunk_index,
                 excerpt: existing_citation.excerpt.clone(),
+                source_url: existing_citation.source_url.clone(),
             });
         } else if let Some(chunk) = new_by_index.get(&index) {
             let excerpt = if chunk.content.len() > 300 {
@@ -460,6 +461,8 @@ async fn generate_section_ops_proposal(
                 atom_id: chunk.atom_id.clone(),
                 chunk_index: Some(chunk.chunk_index),
                 excerpt,
+                // Populated by the read path's JOIN; not stored on the row.
+                source_url: None,
             });
         } else {
             tracing::warn!(
@@ -734,6 +737,8 @@ pub(crate) fn extract_citations(
                         atom_id: chunk.atom_id.clone(),
                         chunk_index: Some(chunk.chunk_index),
                         excerpt,
+                        // Populated by the read path's JOIN; not stored on the row.
+                        source_url: None,
                     });
                 }
             }
@@ -982,6 +987,8 @@ fn archive_existing_article(conn: &Connection, tag_id: &str) -> Result<(), Strin
                 atom_id: row.get(2)?,
                 chunk_index: row.get(3)?,
                 excerpt: row.get(4)?,
+                // Version archive read path; source_url not needed here.
+                source_url: None,
             })
         })
         .map_err(|e| format!("Failed to query citations: {}", e))?
@@ -1106,10 +1113,16 @@ pub fn load_wiki_article(
         None => return Ok(None),
     };
 
-    // Get citations
+    // Get citations, joining atoms for source_url so clients can render
+    // citations differently based on the cited atom's origin (e.g. Obsidian
+    // plugin rewriting them as wikilinks).
     let mut stmt = conn
         .prepare(
-            "SELECT id, citation_index, atom_id, chunk_index, excerpt FROM wiki_citations WHERE wiki_article_id = ?1 ORDER BY citation_index"
+            "SELECT c.id, c.citation_index, c.atom_id, c.chunk_index, c.excerpt, a.source_url
+             FROM wiki_citations c
+             LEFT JOIN atoms a ON a.id = c.atom_id
+             WHERE c.wiki_article_id = ?1
+             ORDER BY c.citation_index"
         )
         .map_err(|e| format!("Failed to prepare citations query: {}", e))?;
 
@@ -1121,6 +1134,7 @@ pub fn load_wiki_article(
                 atom_id: row.get(2)?,
                 chunk_index: row.get(3)?,
                 excerpt: row.get(4)?,
+                source_url: row.get(5)?,
             })
         })
         .map_err(|e| format!("Failed to query citations: {}", e))?
@@ -1701,6 +1715,7 @@ mod tests {
             atom_id: "atom1".to_string(),
             chunk_index: Some(0),
             excerpt: "Source text here".to_string(),
+            source_url: None,
         }];
 
         // Save

--- a/crates/atomic-server/src/lib.rs
+++ b/crates/atomic-server/src/lib.rs
@@ -41,6 +41,8 @@ pub use utoipa_scalar::{Scalar, Servable};
         routes::atoms::create_tag,
         routes::atoms::update_tag,
         routes::atoms::delete_tag,
+        routes::atoms::set_tag_autotag_target,
+        routes::atoms::configure_autotag_targets,
         // Search
         routes::search::search,
         routes::search::find_similar,
@@ -184,6 +186,8 @@ pub use utoipa_scalar::{Scalar, Servable};
         routes::atoms::UpdateAtomRequest,
         routes::atoms::CreateTagRequest,
         routes::atoms::UpdateTagRequest,
+        routes::atoms::SetAutotagTargetRequest,
+        routes::atoms::ConfigureAutotagTargetsRequest,
         routes::search::SearchRequest,
         routes::wiki::GenerateWikiBody,
         routes::settings::SetSettingBody,

--- a/crates/atomic-server/src/routes/atoms.rs
+++ b/crates/atomic-server/src/routes/atoms.rs
@@ -501,3 +501,65 @@ pub async fn delete_tag(
     let core = db.0;
     blocking_ok(move || core.delete_tag(&id, recursive)).await
 }
+
+#[derive(Deserialize, Serialize, ToSchema)]
+pub struct SetAutotagTargetRequest {
+    /// Whether the tag should be a candidate for AI auto-tagging.
+    pub value: bool,
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/tags/{id}/autotag-target",
+    params(
+        ("id" = String, Path, description = "Tag ID"),
+    ),
+    request_body = SetAutotagTargetRequest,
+    responses(
+        (status = 204, description = "Flag updated"),
+        (status = 404, description = "Tag not found", body = ApiErrorResponse),
+    ),
+    tag = "tags",
+)]
+pub async fn set_tag_autotag_target(
+    db: Db,
+    path: web::Path<String>,
+    body: web::Json<SetAutotagTargetRequest>,
+) -> HttpResponse {
+    let id = path.into_inner();
+    let value = body.into_inner().value;
+    let core = db.0;
+    match web::block(move || core.set_tag_autotag_target(&id, value)).await {
+        Ok(Ok(())) => HttpResponse::NoContent().finish(),
+        Ok(Err(e)) => crate::error::error_response(e),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()})),
+    }
+}
+
+#[derive(Deserialize, Serialize, ToSchema)]
+pub struct ConfigureAutotagTargetsRequest {
+    /// Names of seeded default categories to keep flagged.
+    /// Any seeded default not in this list is unflagged.
+    pub keep_defaults: Vec<String>,
+    /// Names of new top-level tags to create with the flag set.
+    /// Existing top-level tags with matching names are flagged in place.
+    pub add_custom: Vec<String>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/tags/configure-autotag-targets",
+    request_body = ConfigureAutotagTargetsRequest,
+    responses(
+        (status = 200, description = "Newly created/flagged custom tags", body = Vec<Tag>),
+    ),
+    tag = "tags",
+)]
+pub async fn configure_autotag_targets(
+    db: Db,
+    body: web::Json<ConfigureAutotagTargetsRequest>,
+) -> HttpResponse {
+    let req = body.into_inner();
+    let core = db.0;
+    blocking_ok(move || core.configure_autotag_targets(&req.keep_defaults, &req.add_custom)).await
+}

--- a/crates/atomic-server/src/routes/mod.rs
+++ b/crates/atomic-server/src/routes/mod.rs
@@ -42,7 +42,9 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     // Tags
     cfg.route("/tags", web::get().to(atoms::get_tags));
     cfg.route("/tags", web::post().to(atoms::create_tag));
+    cfg.route("/tags/configure-autotag-targets", web::post().to(atoms::configure_autotag_targets));
     cfg.route("/tags/{id}/children", web::get().to(atoms::get_tag_children));
+    cfg.route("/tags/{id}/autotag-target", web::put().to(atoms::set_tag_autotag_target));
     cfg.route("/tags/{id}", web::put().to(atoms::update_tag));
     cfg.route("/tags/{id}", web::delete().to(atoms::delete_tag));
 

--- a/docs/auto-tag-targets.md
+++ b/docs/auto-tag-targets.md
@@ -1,0 +1,209 @@
+# Auto-Tag Targets
+
+A user-controllable mechanism for which top-level tags the AI is allowed to extend during auto-tagging. This is the foundation for the broader Obsidian tag round-trip work (see `obsidian-tag-roundtrip.md`), but it stands alone as an Atomic feature.
+
+## Motivation
+
+Today, the auto-tagger creates sub-tags under five hardcoded categories: Topics, People, Locations, Organizations, Events. These are seeded once on first DB init (`crates/atomic-core/src/lib.rs:213-226`) and the LLM prompt in `crates/atomic-core/src/extraction.rs` instructs the model to use only these as `parent_name`.
+
+Two limitations:
+
+1. Users can't opt out of categories they don't care about (e.g., a vault that's purely technical research has no use for People/Locations/Events).
+2. Users can't add their own (e.g., "Methodologies", "Projects", "Books") and have the AI extend them.
+
+The fix is a single boolean column on `tags` plus UI in onboarding and settings to manage it.
+
+## Schema change
+
+Add `is_autotag_target` to the `tags` table in `crates/atomic-core/src/db.rs`. The existing schema (line 221):
+
+```sql
+CREATE TABLE IF NOT EXISTS tags (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL COLLATE NOCASE,
+    parent_id TEXT REFERENCES tags(id) ON DELETE SET NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(name COLLATE NOCASE)
+);
+```
+
+Becomes:
+
+```sql
+CREATE TABLE IF NOT EXISTS tags (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL COLLATE NOCASE,
+    parent_id TEXT REFERENCES tags(id) ON DELETE SET NULL,
+    created_at TEXT NOT NULL,
+    is_autotag_target INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(name COLLATE NOCASE)
+);
+```
+
+For existing databases, add a new migration block (next free version is **V11** — V10 is the highest currently in `db.rs`):
+
+```rust
+if version < 11 {
+    conn.execute_batch(
+        "ALTER TABLE tags ADD COLUMN is_autotag_target INTEGER NOT NULL DEFAULT 0;
+         UPDATE tags SET is_autotag_target = 1
+           WHERE parent_id IS NULL
+             AND name IN ('Topics', 'People', 'Locations', 'Organizations', 'Events');
+         PRAGMA user_version = 11;",
+    )?;
+}
+```
+
+The seed loop in `lib.rs:213-226` should also be updated to insert with `is_autotag_target = 1` for new databases, so the seed and the migration agree.
+
+## Auto-tagger filter
+
+`crates/atomic-core/src/extraction.rs` builds a tag tree to feed the LLM via `get_tag_tree_for_llm()` (around line 355–380 per the explore). The change is one filter:
+
+```rust
+// Before: SELECT id, name FROM tags WHERE parent_id IS NULL
+// After:  SELECT id, name FROM tags WHERE parent_id IS NULL AND is_autotag_target = 1
+```
+
+The system prompt at lines 105–134 already lists categories generically — it should keep working unchanged as long as the filtered list is non-empty. Two things to add:
+
+1. **Empty-list guard.** If no tags are flagged, skip auto-tagging entirely and log a debug message. Don't send a degenerate prompt.
+2. **Prompt wording.** The current prompt may mention the five defaults by name as examples. Re-read it and remove any hardcoded category names so it adapts to whatever the user has flagged.
+
+**Scope decision: top-level only for the first pass.** A flag on a mid-tree tag (e.g., `Topics/Programming` as a target so the AI creates `Topics/Programming/Rust`) is a natural extension but expands the prompt-construction logic non-trivially. Defer to a follow-up. Document the limitation in the settings UI.
+
+## Tag CRUD changes
+
+`Tag` struct in `crates/atomic-core/src/models.rs` gains `is_autotag_target: bool`. All read paths (`list_tags`, `get_tag`, etc.) populate it. The tag CRUD module accepts it on create (defaulting to `false`) and exposes either:
+
+- A focused method `set_tag_autotag_target(id: &str, value: bool)`, or
+- An expanded `update_tag` that accepts an optional flag
+
+I'd lean toward the focused method — it makes the audit trail clearer and doesn't entangle the flag with name/parent updates.
+
+REST surface in `crates/atomic-server/src/routes/tags.rs`:
+
+- `PATCH /api/tags/:id/autotag-target` with `{ "value": true|false }`, or
+- Fold into existing `PATCH /api/tags/:id`
+
+The frontend transport command map gains a corresponding `set_tag_autotag_target` command.
+
+## Onboarding step
+
+The Atomic onboarding wizard is at `src/components/onboarding/OnboardingWizard.tsx`, with steps defined in `src/components/onboarding/useOnboardingState.ts:261-266`:
+
+```typescript
+export const STEPS: { id: StepId; label: string; required: boolean }[] = [
+  { id: 'welcome', label: 'Welcome', required: true },
+  { id: 'ai-provider', label: 'AI Provider', required: true },
+  { id: 'integrations', label: 'Integrations', required: false },
+  { id: 'tutorial', label: 'Tutorial', required: false },
+];
+```
+
+Insert a new step `tag-categories` after `ai-provider`:
+
+```typescript
+{ id: 'ai-provider', label: 'AI Provider', required: true },
+{ id: 'tag-categories', label: 'Tag Categories', required: false },
+{ id: 'integrations', label: 'Integrations', required: false },
+```
+
+**Conditional skip.** The AI Provider step saves `auto_tagging_enabled`. If the user disabled auto-tagging there, skip the tag categories step entirely (no point picking targets if the AI won't run).
+
+**New file:** `src/components/onboarding/steps/TagCategoriesStep.tsx`. UI:
+
+- Heading: "Choose your tag categories"
+- Description: "Atomic auto-tags your notes by creating sub-tags under top-level categories you choose. Pick the ones that fit your knowledge base — you can change these later in Settings."
+- Five default checkboxes (Topics, People, Locations, Organizations, Events), all checked by default
+- "Add custom category" text input + "Add" button
+- Custom categories appear as removable chips below the input
+- Footer: "Back" / "Continue" buttons
+
+**State shape:**
+
+```typescript
+interface TagCategoriesState {
+  selectedDefaults: Set<string>;  // starts with all 5
+  customCategories: string[];
+}
+```
+
+**On step complete**, call a new backend command `configure_autotag_targets({ keep_defaults: string[], add_custom: string[] })` that:
+
+1. For each name in `keep_defaults`: create the tag if it doesn't exist, then ensure `is_autotag_target = 1`.
+2. For each well-known default NOT in `keep_defaults`: if the tag exists with no atoms and no children, **delete it** (the safe case during first-run onboarding). Otherwise unflag it (so re-running the wizard from settings after the user has tagged things stays non-destructive).
+3. For each name in `add_custom`: create a new top-level tag (or flag an existing one) with `is_autotag_target = 1`.
+
+This is idempotent and safe to re-run.
+
+**Important: defaults are no longer auto-seeded on DB creation.** A brand-new database starts with zero tags. The onboarding wizard (or the user via the settings tab / API) is solely responsible for deciding which categories exist. Headless/no-onboarding paths get a clean slate; the auto-tagger gracefully no-ops when no tags are flagged.
+
+## Settings panel section
+
+Atomic's settings live in `src/components/settings/SettingsModal.tsx`. Tabs are defined at lines 48–57:
+
+```typescript
+const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
+  { id: 'general', label: 'General' },
+  { id: 'ai', label: 'AI Models' },
+  { id: 'connection', label: 'Connection' },
+  { id: 'feeds', label: 'Feeds' },
+  { id: 'integrations', label: 'Integrations' },
+  { id: 'databases', label: 'Databases' },
+];
+```
+
+Add a new tab `'tag-categories'` (or `'tags'` if we want a broader Tags tab eventually):
+
+```typescript
+{ id: 'tag-categories', label: 'Tag Categories' },
+```
+
+**Component:** `TagCategoriesTab` — either inline in `SettingsModal.tsx` (matches the existing pattern per the explore) or as a separate file if it grows. UI sections:
+
+1. **Header / explanation.** "Tags marked as auto-tag targets are the only ones the AI will create new sub-tags under. Top-level tags only — sub-tag targets aren't supported yet."
+2. **Active targets.** List of all top-level tags where `is_autotag_target = true`. Each row: name, atom count, toggle to remove the flag.
+3. **Available top-level tags.** List of all top-level tags where `is_autotag_target = false` (e.g., folder-imported ones, or defaults the user previously unflagged). Each row: toggle to mark as a target.
+4. **Create new target.** Text input + "Add" button. Creates a new top-level tag with the flag set.
+5. **Empty-state warning.** If the active list is empty, show a yellow notice: "No auto-tag targets configured. Auto-tagging will be skipped for new atoms."
+
+This tab overlaps slightly with the broader tag management UI (if one exists). The doc deliberately scopes this to *target management* — full tag CRUD (rename, merge, delete) belongs elsewhere.
+
+## Edge cases & open questions
+
+- **Existing tag management UI.** I haven't mapped the full tag-management surface yet. Before building the settings tab, check whether there's already a tag editor that should host the toggle inline rather than living in a separate tab.
+- **Mid-tree targets.** Out of scope for the first pass. When added, the auto-tagger needs to walk the tag tree differently and the prompt construction needs to express "extend these specific sub-trees, but don't create new top-level tags."
+- **Multi-database.** The flag is per-database (lives in the data DB, not registry.db), so each knowledge base has its own auto-tag target set. Onboarding only runs once globally — additional databases inherit nothing. Consider whether a per-database "first sync" flow should re-prompt for targets.
+- **Custom category name validation.** Reject empty names, names matching existing tags (case-insensitive — the table already has `COLLATE NOCASE`), and names containing `/` (which we use as a hierarchy separator in display).
+- **Telemetry.** None for now, but worth noting which categories users actually select if/when telemetry exists — informs future defaults.
+
+## File-by-file change list
+
+Backend:
+- `crates/atomic-core/src/db.rs` — add column to `CREATE TABLE`, add V11 migration block
+- `crates/atomic-core/src/lib.rs:213-226` — set `is_autotag_target = 1` in seed insert
+- `crates/atomic-core/src/models.rs` — add field to `Tag` struct
+- `crates/atomic-core/src/tags.rs` (or wherever tag CRUD lives) — read/write the field, add `set_tag_autotag_target` and `configure_autotag_targets`
+- `crates/atomic-core/src/extraction.rs` — filter `get_tag_tree_for_llm()` by the flag, add empty-list guard, scrub hardcoded names from prompt
+- `crates/atomic-core/src/lib.rs` (the `AtomicCore` facade) — expose new methods
+- `crates/atomic-server/src/routes/tags.rs` — REST endpoints for the new methods
+- `src-tauri/src/lib.rs` (if applicable) — Tauri command wrappers
+
+Frontend:
+- `src/components/onboarding/useOnboardingState.ts` — add `tag-categories` step + state
+- `src/components/onboarding/OnboardingWizard.tsx` — render switch case for new step
+- `src/components/onboarding/steps/TagCategoriesStep.tsx` — **new file**
+- `src/components/settings/SettingsModal.tsx` — add tab + `TagCategoriesTab` component
+- `src/transport/commandMap.ts` (or wherever commands are mapped) — add `configure_autotag_targets`, `set_tag_autotag_target`
+- `src/types/` (if tag types live there) — add `is_autotag_target` field
+
+## Implementation order
+
+1. Schema + migration + `Tag` struct field. Verify with `cargo test` and a manual sqlite3 check on a fresh DB.
+2. Auto-tagger filter + empty-list guard. Test by unflagging all defaults and confirming new atoms get no AI tags.
+3. Backend tag CRUD methods + REST routes.
+4. Frontend transport wiring.
+5. Settings tab (lets us iterate on the UI before touching onboarding).
+6. Onboarding step.
+7. Manual end-to-end test: fresh DB → onboarding → uncheck Locations and Events, add "Methodologies" → create an atom about a research paper → confirm it gets a `Methodologies/...` sub-tag and no Locations sub-tag.

--- a/docs/obsidian-tag-roundtrip.md
+++ b/docs/obsidian-tag-roundtrip.md
@@ -1,0 +1,101 @@
+# Obsidian Tag Round-Trip
+
+How to reconcile Obsidian's freeform tag system with Atomic's hierarchical, AI-curated one — and eventually flow auto-extracted tags back into Obsidian vaults.
+
+## The tension
+
+Atomic constrains AI-extracted tags to live under a small set of seeded top-level categories (Topics, People, Locations, Organizations, Events). The auto-tagger only ever creates sub-tags under these parents, which keeps the tag tree coherent.
+
+Obsidian vaults, by contrast, are a free-for-all: tags come from folder structure, freeform `#hashtags`, and YAML frontmatter, with no enforced hierarchy. Two problems follow:
+
+1. If we import an Obsidian vault wholesale (treating folder names as top-level tags), those imported tags become candidates for the AI to create sub-tags under — even though they may not make sense as auto-tag targets.
+2. The AI-extracted tags Atomic generates never make it back to the user's Obsidian vault, where they could provide enormous value cleaning up unorganized "tag graveyards."
+
+This doc plans a path through both.
+
+## Part 1 — Constraining auto-tag targets
+
+> **Detailed plan:** see [`auto-tag-targets.md`](./auto-tag-targets.md) for the concrete schema, migration, onboarding step, and settings UI design. The summary below is the conceptual sketch.
+
+### The flag
+
+Add `is_autotag_target: bool` to the `tags` table. The five seeded categories get it set on creation; everything else (including imported tags from Obsidian folders) defaults to `false`.
+
+The auto-tagger in `atomic-core` filters its candidate-parent list by this flag before constructing the LLM prompt. Imported folder tags coexist with the seeded categories in the tag tree, but the AI only ever extends the flagged ones.
+
+### Granularity
+
+The flag should apply to *any* tag, not just top-level ones. Use cases:
+
+- Mark `Topics/Programming` as a target so the AI creates `Topics/Programming/Rust` rather than dumping language names directly under `Topics/`.
+- Unmark `Topics/` itself so the AI is forced to be more specific.
+
+This is a one-line cost in the filter logic and gives users far more leverage over the tag tree's shape.
+
+### Edge cases
+
+- **Zero flagged tags:** Auto-tagging becomes a no-op. Legitimate, but the settings UI should explain why nothing is happening.
+- **User unflags a category mid-stream:** Existing sub-tags stay; only new auto-tag runs are affected. No retroactive cleanup.
+
+### UI surface
+
+- Checkbox in the tag context menu / tag editor.
+- Filtered view in tag-management settings: "Tags the AI can extend."
+- When importing an Obsidian vault, show a one-time prompt: "Treat folder names as auto-tag targets?" Default no.
+
+## Part 2 — Surfacing Atomic tags inside Obsidian
+
+Auto-writing files in the user's vault is perilous. Instead, ship this in phases that build trust before any background mutation.
+
+### Phase 1: Read-only display
+
+Sidebar view in the Obsidian plugin: "Atomic suggests these tags" for the active note. Each suggested tag is a chip with a one-click "Apply to frontmatter" action. No background writes; nothing happens unless the user clicks.
+
+This is a sidebar view, not a sync subsystem. It reuses the existing `getAtomBySourceUrl` lookup the plugin already does, plus a new endpoint to fetch the atom's tags. Implementation cost is small.
+
+The value: users see AI-suggested tags in the UI they already trust, on the note they're already looking at. No fear of files being rewritten behind their back.
+
+### Phase 2: Opt-in batch apply
+
+Command: "Apply Atomic tags to all notes." Generates a preview diff (file-by-file: tags to add, tags already present) and waits for user confirmation before writing anything.
+
+Writing rules:
+- Touch only the `tags` field of YAML frontmatter. Preserve every other field, including ordering and comments where Obsidian's API permits.
+- Use Obsidian's nested tag convention: `Topics/AI/LLMs` → `topic/ai/llms`. Lowercase by default; configurable.
+- Never remove existing user tags. Only additive.
+- After write, the content hash (computed post-frontmatter strip) doesn't change, so the plugin won't trigger a re-sync of the same note. No loop.
+
+### Phase 3: Background auto-write
+
+**Off by default.** Setting toggle with a warning notice on enable: "Atomic will modify YAML frontmatter in your vault."
+
+Even with this enabled, writes should be additive only — never silently remove tags the user has stripped out, since removal is a meaningful signal we shouldn't fight.
+
+This phase requires solving the conflict-resolution problems below, which is why it comes last.
+
+## Conflict resolution (deferred to Phase 3)
+
+Hard questions that don't need answers until Phase 3 ships:
+
+- **User removes a tag in Obsidian.** Re-add on next pull, or treat removal as authoritative? Probably need a per-file shadow state tracking "tags Atomic wrote" separately from "tags that exist now," so removals can be detected and respected.
+- **User adds a tag in Obsidian that doesn't exist in Atomic.** Import back? As what type? Probably attach to the atom but don't auto-create a new top-level category.
+- **AI re-runs auto-tagging and changes its mind.** Silently rewrite? Probably not — once written, an applied tag should stick unless the user explicitly removes it.
+
+## The bigger unlock: tag unification
+
+The juiciest version of this work: detect when an existing Obsidian tag (`#productivity`) overlaps with an AI-extracted tag (`Topics/Productivity`) and unify them — both in Atomic's tag tree and on the Obsidian side. That turns Atomic into a tag-graveyard cleaner, which is a much sharper value prop than "we add more tags."
+
+This depends on Part 1 being solid first. The user needs control over which parents the AI uses before they'll trust it to merge their existing tags into Atomic's hierarchy.
+
+Mechanically, unification needs:
+- A similarity check (string + embedding) between Obsidian tag names and Atomic tag paths.
+- A user-facing review UI: "These look like the same thing. Merge?"
+- A merge operation in `atomic-core` that re-points all `atom_tags` rows from one tag to another and deletes the loser.
+
+## Implementation order
+
+1. Add `is_autotag_target` column + filter in auto-tagger. Seed the five default categories with it set. Add UI to toggle it.
+2. Phase 1 sidebar view in the Obsidian plugin.
+3. Phase 2 batch-apply command with preview diff.
+4. Tag unification UI (depends on 1).
+5. Phase 3 background auto-write — only if Phases 1–2 prove the trust model works.

--- a/plugins/obsidian-plugin/src/atomic-client.ts
+++ b/plugins/obsidian-plugin/src/atomic-client.ts
@@ -68,6 +68,21 @@ export interface WikiArticle {
   updated_at: string;
 }
 
+export interface WikiCitation {
+  id: string;
+  citation_index: number;
+  atom_id: string;
+  chunk_index: number | null;
+  excerpt: string;
+  /** Source URL of the cited atom (e.g. `obsidian://VaultName/path.md`), or null. */
+  source_url: string | null;
+}
+
+export interface WikiArticleWithCitations {
+  article: WikiArticle;
+  citations: WikiCitation[];
+}
+
 export interface CreateAtomRequest {
   content: string;
   source_url?: string | null;
@@ -208,21 +223,23 @@ export class AtomicClient {
 
   // Wiki
 
-  async getWikiArticle(tagId: string): Promise<WikiArticle | null> {
+  async getWikiArticle(tagId: string): Promise<WikiArticleWithCitations | null> {
     try {
-      return await this.request({
+      const result = await this.request<WikiArticleWithCitations | null>({
         url: `${this.baseUrl}/api/wiki/${tagId}`,
         method: "GET",
       });
+      return result ?? null;
     } catch {
       return null;
     }
   }
 
-  async generateWikiArticle(tagId: string): Promise<WikiArticle> {
+  async generateWikiArticle(tagId: string, tagName: string): Promise<WikiArticleWithCitations> {
     return this.request({
       url: `${this.baseUrl}/api/wiki/${tagId}/generate`,
       method: "POST",
+      body: JSON.stringify({ tag_name: tagName }),
     });
   }
 

--- a/plugins/obsidian-plugin/src/atomic-client.ts
+++ b/plugins/obsidian-plugin/src/atomic-client.ts
@@ -88,6 +88,8 @@ export interface CreateAtomRequest {
   source_url?: string | null;
   published_at?: string | null;
   tag_ids?: string[];
+  /** When true, the server skips creation if an atom with the same source_url already exists. */
+  skip_if_source_exists?: boolean;
 }
 
 export interface UpdateAtomRequest {

--- a/plugins/obsidian-plugin/src/atomic-client.ts
+++ b/plugins/obsidian-plugin/src/atomic-client.ts
@@ -24,8 +24,7 @@ export interface Tag {
   created_at: string;
 }
 
-export interface AtomWithTags {
-  atom: Atom;
+export interface AtomWithTags extends Atom {
   tags: Tag[];
 }
 
@@ -95,10 +94,14 @@ export class AtomicClient {
   }
 
   private get headers(): Record<string, string> {
-    return {
+    const headers: Record<string, string> = {
       Authorization: `Bearer ${this.settings.authToken}`,
       "Content-Type": "application/json",
     };
+    if (this.settings.databaseName) {
+      headers["X-Atomic-Database"] = this.settings.databaseName;
+    }
+    return headers;
   }
 
   private async request<T>(params: RequestUrlParam): Promise<T> {

--- a/plugins/obsidian-plugin/src/main.ts
+++ b/plugins/obsidian-plugin/src/main.ts
@@ -82,7 +82,11 @@ export default class AtomicPlugin extends Plugin {
       return new SimilarView(leaf, this.client, () => syncState);
     });
 
-    this.registerView(WIKI_VIEW_TYPE, (leaf) => new WikiView(leaf, this.client));
+    this.registerView(WIKI_VIEW_TYPE, (leaf) => new WikiView(
+      leaf,
+      this.client,
+      () => this.settings.vaultName || this.app.vault.getName(),
+    ));
 
     // Auto-sync if enabled (skip if not yet configured)
     if (this.settings.authToken && this.settings.autoSync) {

--- a/plugins/obsidian-plugin/src/main.ts
+++ b/plugins/obsidian-plugin/src/main.ts
@@ -6,6 +6,7 @@ import { SyncState, type SyncStateData } from "./sync-state";
 import { SearchModal } from "./search-modal";
 import { SimilarView, SIMILAR_VIEW_TYPE } from "./similar-view";
 import { WikiView, WIKI_VIEW_TYPE } from "./wiki-view";
+import { OnboardingModal } from "./onboarding-modal";
 
 interface PluginData {
   settings: AtomicSettings;
@@ -69,6 +70,12 @@ export default class AtomicPlugin extends Plugin {
       callback: () => this.activateView(WIKI_VIEW_TYPE),
     });
 
+    this.addCommand({
+      id: "setup-wizard",
+      name: "Setup Wizard",
+      callback: () => new OnboardingModal(this.app, this).open(),
+    });
+
     // Register sidebar views
     this.registerView(SIMILAR_VIEW_TYPE, (leaf) => {
       const syncState = SyncState.fromJSON(this.syncEngine.getSyncStateData());
@@ -77,9 +84,16 @@ export default class AtomicPlugin extends Plugin {
 
     this.registerView(WIKI_VIEW_TYPE, (leaf) => new WikiView(leaf, this.client));
 
-    // Auto-sync if enabled
-    if (this.settings.autoSync) {
+    // Auto-sync if enabled (skip if not yet configured)
+    if (this.settings.authToken && this.settings.autoSync) {
       this.syncEngine.startWatching();
+    }
+
+    // First-run: open onboarding wizard if no auth token configured
+    if (!this.settings.authToken) {
+      setTimeout(() => {
+        new OnboardingModal(this.app, this).open();
+      }, 500);
     }
 
     // Status bar

--- a/plugins/obsidian-plugin/src/onboarding-modal.ts
+++ b/plugins/obsidian-plugin/src/onboarding-modal.ts
@@ -1,0 +1,346 @@
+import { App, Modal, Setting } from "obsidian";
+import type AtomicPlugin from "./main";
+import type { SyncProgress } from "./sync-engine";
+
+const STEPS = ["Welcome", "Connect", "Index", "Done"] as const;
+
+export class OnboardingModal extends Modal {
+  private plugin: AtomicPlugin;
+  private currentStep = 0;
+  private connectionVerified = false;
+  private syncResult: SyncProgress | null = null;
+
+  constructor(app: App, plugin: AtomicPlugin) {
+    super(app);
+    this.plugin = plugin;
+  }
+
+  onOpen(): void {
+    this.modalEl.addClass("atomic-onboarding-modal");
+    this.render();
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+
+  private render(): void {
+    this.contentEl.empty();
+
+    const wrapper = this.contentEl.createDiv({ cls: "atomic-onboarding" });
+
+    // Step indicator
+    this.renderStepIndicator(wrapper);
+
+    // Step content
+    const body = wrapper.createDiv({ cls: "atomic-onboarding-body" });
+    switch (this.currentStep) {
+      case 0: this.renderWelcome(body); break;
+      case 1: this.renderConnect(body); break;
+      case 2: this.renderSync(body); break;
+      case 3: this.renderDone(body); break;
+    }
+  }
+
+  private renderStepIndicator(container: HTMLElement): void {
+    const indicator = container.createDiv({ cls: "atomic-step-indicator" });
+
+    for (let i = 0; i < STEPS.length; i++) {
+      if (i > 0) {
+        const connector = indicator.createDiv({ cls: "atomic-step-connector" });
+        if (i <= this.currentStep) connector.addClass("completed");
+      }
+
+      const step = indicator.createDiv({ cls: "atomic-step" });
+      const dot = step.createDiv({ cls: "atomic-step-dot" });
+
+      if (i < this.currentStep) {
+        dot.addClass("completed");
+        dot.innerHTML = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>`;
+      } else if (i === this.currentStep) {
+        dot.addClass("active");
+      }
+
+      step.createDiv({ cls: "atomic-step-label", text: STEPS[i] });
+    }
+  }
+
+  // --- Step 1: Welcome ---
+
+  private renderWelcome(container: HTMLElement): void {
+    container.createEl("h2", { text: "Welcome to Atomic" });
+    container.createEl("p", {
+      cls: "atomic-onboarding-desc",
+      text: "Atomic turns your notes into a semantically-connected knowledge graph. This plugin syncs your vault to Atomic so you can:",
+    });
+
+    const features = container.createEl("ul", { cls: "atomic-onboarding-features" });
+    const items = [
+      ["Search semantically", "Find notes by meaning, not just keywords"],
+      ["Discover connections", "See which notes are related based on content"],
+      ["Generate wiki articles", "AI-synthesized summaries of topics across your notes"],
+    ];
+    for (const [title, desc] of items) {
+      const li = features.createEl("li");
+      li.createEl("strong", { text: title });
+      li.createSpan({ text: ` \u2014 ${desc}` });
+    }
+
+    const footer = container.createDiv({ cls: "atomic-onboarding-footer" });
+    const btn = footer.createEl("button", { text: "Get Started", cls: "mod-cta" });
+    btn.addEventListener("click", () => { this.currentStep = 1; this.render(); });
+  }
+
+  // --- Step 2: Connect ---
+
+  private renderConnect(container: HTMLElement): void {
+    container.createEl("h2", { text: "Connect to your server" });
+    container.createEl("p", {
+      cls: "atomic-onboarding-desc",
+      text: "Enter the URL and API token for your Atomic server.",
+    });
+
+    const form = container.createDiv({ cls: "atomic-onboarding-form" });
+
+    new Setting(form)
+      .setName("Server URL")
+      .addText((text) =>
+        text
+          .setPlaceholder("http://localhost:8080")
+          .setValue(this.plugin.settings.serverUrl)
+          .onChange((value) => {
+            this.plugin.settings.serverUrl = value;
+            this.connectionVerified = false;
+            this.updateConnectButtons();
+          })
+      );
+
+    new Setting(form)
+      .setName("API Token")
+      .addText((text) => {
+        text
+          .setPlaceholder("Enter your API token")
+          .setValue(this.plugin.settings.authToken)
+          .onChange((value) => {
+            this.plugin.settings.authToken = value;
+            this.connectionVerified = false;
+            this.updateConnectButtons();
+          });
+        text.inputEl.type = "password";
+      });
+
+    new Setting(form)
+      .setName("Database")
+      .setDesc("Leave empty for default")
+      .addText((text) =>
+        text
+          .setPlaceholder("default")
+          .setValue(this.plugin.settings.databaseName)
+          .onChange((value) => {
+            this.plugin.settings.databaseName = value;
+            this.connectionVerified = false;
+            this.updateConnectButtons();
+          })
+      );
+
+    // Test connection area
+    const testArea = container.createDiv({ cls: "atomic-onboarding-test" });
+    const testBtn = testArea.createEl("button", { text: "Test Connection" });
+    const testStatus = testArea.createDiv({ cls: "atomic-onboarding-test-status" });
+
+    testBtn.addEventListener("click", async () => {
+      testBtn.disabled = true;
+      testBtn.textContent = "Testing...";
+      testStatus.empty();
+      testStatus.removeClass("success", "error");
+
+      // Update the client with current settings
+      this.plugin.client = new (await import("./atomic-client")).AtomicClient(this.plugin.settings);
+
+      try {
+        await this.plugin.client.testConnection();
+        this.connectionVerified = true;
+        testStatus.addClass("success");
+        testStatus.textContent = "Connected successfully";
+        await this.plugin.saveSettings();
+      } catch (e) {
+        this.connectionVerified = false;
+        testStatus.addClass("error");
+        testStatus.textContent = e instanceof Error ? e.message : "Connection failed";
+      }
+
+      testBtn.disabled = false;
+      testBtn.textContent = "Test Connection";
+      this.updateConnectButtons();
+    });
+
+    // Footer
+    const footer = container.createDiv({ cls: "atomic-onboarding-footer" });
+
+    const backBtn = footer.createEl("button", { text: "Back" });
+    backBtn.addEventListener("click", () => { this.currentStep = 0; this.render(); });
+
+    const nextBtn = footer.createEl("button", { text: "Next", cls: "mod-cta" });
+    nextBtn.disabled = !this.connectionVerified;
+    nextBtn.addEventListener("click", () => { this.currentStep = 2; this.render(); });
+
+    // Store refs for updating button state
+    this._connectNextBtn = nextBtn;
+  }
+
+  private _connectNextBtn: HTMLButtonElement | null = null;
+
+  private updateConnectButtons(): void {
+    if (this._connectNextBtn) {
+      this._connectNextBtn.disabled = !this.connectionVerified;
+    }
+  }
+
+  // --- Step 3: Index Vault ---
+
+  private renderSync(container: HTMLElement): void {
+    container.createEl("h2", { text: "Index your vault" });
+
+    const files = this.app.vault.getMarkdownFiles().filter(
+      (f) => !this.plugin.syncEngine["shouldExclude"](f.path)
+    );
+
+    container.createEl("p", {
+      cls: "atomic-onboarding-desc",
+      text: `Found ${files.length} markdown files. Indexing sends them to Atomic for embedding and semantic analysis.`,
+    });
+
+    // Progress area (hidden initially)
+    const progressArea = container.createDiv({ cls: "atomic-sync-progress hidden" });
+    const barOuter = progressArea.createDiv({ cls: "atomic-progress-bar" });
+    const barFill = barOuter.createDiv({ cls: "atomic-progress-fill" });
+    const progressLabel = progressArea.createDiv({ cls: "atomic-progress-label" });
+
+    const stats = progressArea.createDiv({ cls: "atomic-sync-stats" });
+    const statCreated = stats.createDiv({ cls: "atomic-sync-stat" });
+    statCreated.createSpan({ cls: "atomic-sync-stat-value", text: "0" });
+    statCreated.createSpan({ cls: "atomic-sync-stat-label", text: "created" });
+
+    const statSkipped = stats.createDiv({ cls: "atomic-sync-stat" });
+    statSkipped.createSpan({ cls: "atomic-sync-stat-value", text: "0" });
+    statSkipped.createSpan({ cls: "atomic-sync-stat-label", text: "unchanged" });
+
+    const statErrors = stats.createDiv({ cls: "atomic-sync-stat" });
+    statErrors.createSpan({ cls: "atomic-sync-stat-value", text: "0" });
+    statErrors.createSpan({ cls: "atomic-sync-stat-label", text: "errors" });
+
+    // Buttons
+    const footer = container.createDiv({ cls: "atomic-onboarding-footer" });
+
+    const skipLink = footer.createEl("button", { cls: "atomic-skip-link", text: "Skip for now" });
+    skipLink.addEventListener("click", () => { this.currentStep = 3; this.render(); });
+
+    const startBtn = footer.createEl("button", { text: "Start Indexing", cls: "mod-cta" });
+
+    startBtn.addEventListener("click", async () => {
+      startBtn.disabled = true;
+      startBtn.textContent = "Indexing...";
+      skipLink.addClass("hidden");
+      progressArea.removeClass("hidden");
+
+      const onProgress = (p: SyncProgress) => {
+        const pct = p.totalFiles > 0 ? Math.round((p.processed / p.totalFiles) * 100) : 0;
+        barFill.style.width = `${pct}%`;
+
+        if (p.phase === "reading") {
+          progressLabel.textContent = "Reading files...";
+        } else if (p.phase === "syncing") {
+          progressLabel.textContent = `${p.processed} of ${p.totalFiles} files`;
+        } else {
+          progressLabel.textContent = "Complete!";
+        }
+
+        statCreated.querySelector(".atomic-sync-stat-value")!.textContent = String(p.created);
+        statSkipped.querySelector(".atomic-sync-stat-value")!.textContent = String(p.skipped);
+        statErrors.querySelector(".atomic-sync-stat-value")!.textContent = String(p.errors);
+      };
+
+      try {
+        this.syncResult = await this.plugin.syncEngine.syncAll(onProgress);
+      } catch (e) {
+        console.error("Atomic: Sync failed during onboarding:", e);
+      }
+
+      // Brief pause to let the user see "Complete!" before advancing
+      setTimeout(() => {
+        this.currentStep = 3;
+        this.render();
+      }, 1000);
+    });
+  }
+
+  // --- Step 4: Done ---
+
+  private renderDone(container: HTMLElement): void {
+    container.createEl("h2", { text: "You're all set!" });
+
+    if (this.syncResult) {
+      const { created, updated, skipped, errors } = this.syncResult;
+      const parts: string[] = [];
+      if (created > 0) parts.push(`${created} notes indexed`);
+      if (updated > 0) parts.push(`${updated} updated`);
+      if (skipped > 0) parts.push(`${skipped} unchanged`);
+      if (errors > 0) parts.push(`${errors} errors`);
+      container.createEl("p", {
+        cls: "atomic-onboarding-desc",
+        text: parts.join(", ") + ".",
+      });
+    } else {
+      container.createEl("p", {
+        cls: "atomic-onboarding-desc",
+        text: "Your vault is connected. Notes will sync automatically as you edit them.",
+      });
+    }
+
+    const cards = container.createDiv({ cls: "atomic-feature-cards" });
+
+    this.renderFeatureCard(cards, {
+      icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path stroke-linecap="round" d="m21 21-4.35-4.35"/></svg>`,
+      title: "Semantic Search",
+      desc: "Search by meaning across your entire vault.",
+      shortcut: "Cmd+P \u2192 Atomic: Semantic Search",
+    });
+
+    this.renderFeatureCard(cards, {
+      icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/></svg>`,
+      title: "Similar Notes",
+      desc: "See related notes in the sidebar as you work.",
+      shortcut: "Cmd+P \u2192 Atomic: Open Similar Notes",
+    });
+
+    this.renderFeatureCard(cards, {
+      icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/></svg>`,
+      title: "Wiki Articles",
+      desc: "AI-generated summaries of topics in your notes.",
+      shortcut: "Cmd+P \u2192 Atomic: Open Wiki",
+    });
+
+    const footer = container.createDiv({ cls: "atomic-onboarding-footer" });
+    const finishBtn = footer.createEl("button", { text: "Finish", cls: "mod-cta" });
+    finishBtn.addEventListener("click", async () => {
+      await this.plugin.saveSettings();
+      if (this.plugin.settings.autoSync) {
+        this.plugin.syncEngine.startWatching();
+      }
+      this.close();
+    });
+  }
+
+  private renderFeatureCard(
+    container: HTMLElement,
+    opts: { icon: string; title: string; desc: string; shortcut: string }
+  ): void {
+    const card = container.createDiv({ cls: "atomic-feature-card" });
+    const iconEl = card.createDiv({ cls: "atomic-feature-icon" });
+    iconEl.innerHTML = opts.icon;
+    const text = card.createDiv({ cls: "atomic-feature-text" });
+    text.createDiv({ cls: "atomic-feature-title", text: opts.title });
+    text.createDiv({ cls: "atomic-feature-desc", text: opts.desc });
+    text.createEl("code", { cls: "atomic-feature-shortcut", text: opts.shortcut });
+  }
+}

--- a/plugins/obsidian-plugin/src/settings.ts
+++ b/plugins/obsidian-plugin/src/settings.ts
@@ -82,7 +82,9 @@ export class AtomicSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
             if (dbDebounce) clearTimeout(dbDebounce);
             dbDebounce = setTimeout(() => {
-              this.plugin.syncEngine.resetAndResync();
+              this.plugin.syncEngine.resetAndResync().catch((e) =>
+                console.error("Atomic: resetAndResync failed:", e)
+              );
             }, 1500);
           })
       );

--- a/plugins/obsidian-plugin/src/settings.ts
+++ b/plugins/obsidian-plugin/src/settings.ts
@@ -4,6 +4,7 @@ import type AtomicPlugin from "./main";
 export interface AtomicSettings {
   serverUrl: string;
   authToken: string;
+  databaseName: string;
   vaultName: string;
   autoSync: boolean;
   syncDebounceMs: number;
@@ -15,8 +16,9 @@ export interface AtomicSettings {
 export const DEFAULT_SETTINGS: AtomicSettings = {
   serverUrl: "http://localhost:8080",
   authToken: "",
+  databaseName: "",
   vaultName: "",
-  autoSync: false,
+  autoSync: true,
   syncDebounceMs: 2000,
   excludePatterns: [".obsidian/**", ".trash/**", ".git/**", "node_modules/**"],
   syncFolderTags: true,
@@ -66,6 +68,24 @@ export class AtomicSettingTab extends PluginSettingTab {
           });
         text.inputEl.type = "password";
       });
+
+    let dbDebounce: ReturnType<typeof setTimeout> | null = null;
+    new Setting(containerEl)
+      .setName("Database")
+      .setDesc("Name of the Atomic database to sync with (leave empty for default)")
+      .addText((text) =>
+        text
+          .setPlaceholder("default")
+          .setValue(this.plugin.settings.databaseName)
+          .onChange(async (value) => {
+            this.plugin.settings.databaseName = value;
+            await this.plugin.saveSettings();
+            if (dbDebounce) clearTimeout(dbDebounce);
+            dbDebounce = setTimeout(() => {
+              this.plugin.syncEngine.resetAndResync();
+            }, 1500);
+          })
+      );
 
     new Setting(containerEl)
       .setName("Test Connection")

--- a/plugins/obsidian-plugin/src/sync-engine.ts
+++ b/plugins/obsidian-plugin/src/sync-engine.ts
@@ -308,8 +308,16 @@ export class SyncEngine {
 
     for (const batch of batches) {
       try {
+        // skip_if_source_exists prevents duplicates when re-syncing to a database
+        // that already has atoms (e.g., reverting a database name change). The
+        // server returns skipped entries' atom IDs nowhere in the response, so
+        // we fall back to getAtomBySourceUrl below for any unmatched entries.
         const result = await this.client.bulkCreateAtoms(
-          batch.map((f) => ({ content: f.content, source_url: f.sourceUrl }))
+          batch.map((f) => ({
+            content: f.content,
+            source_url: f.sourceUrl,
+            skip_if_source_exists: true,
+          }))
         );
 
         // Match returned atoms back to files via source_url
@@ -320,18 +328,55 @@ export class SyncEngine {
           }
         }
 
+        // Collect entries the bulk endpoint didn't return (skipped because the
+        // atom already existed, or otherwise dropped). Look each one up so we
+        // can register it in syncState — otherwise every subsequent sync would
+        // re-attempt and re-fail forever.
+        const unmatched = batch.filter((entry) => !atomByUrl.has(entry.sourceUrl));
+        const fallbackResults = await Promise.all(
+          unmatched.map(async (entry) => {
+            try {
+              const existing = await this.client.getAtomBySourceUrl(entry.sourceUrl);
+              return { entry, atomId: existing?.id ?? null, error: null as Error | null };
+            } catch (e) {
+              return { entry, atomId: null, error: e as Error };
+            }
+          })
+        );
+        const recovered = new Map<string, string>();
+        const lookupErrors = new Map<string, Error>();
+        for (const r of fallbackResults) {
+          if (r.atomId) recovered.set(r.entry.sourceUrl, r.atomId);
+          else if (r.error) lookupErrors.set(r.entry.sourceUrl, r.error);
+        }
+
         for (const entry of batch) {
-          const atomId = atomByUrl.get(entry.sourceUrl);
-          if (atomId) {
+          const newId = atomByUrl.get(entry.sourceUrl);
+          if (newId) {
             this.syncState.setFile(entry.file.path, {
-              atomId,
+              atomId: newId,
               contentHash: entry.hash,
               lastSynced: Date.now(),
             });
             progress.created++;
           } else {
-            progress.errors++;
-            console.error(`Atomic: No atom returned for ${entry.file.path}`);
+            const existingId = recovered.get(entry.sourceUrl);
+            if (existingId) {
+              // Atom already existed on the server — adopt it. Treat as updated
+              // for progress reporting since we didn't create anything new.
+              this.syncState.setFile(entry.file.path, {
+                atomId: existingId,
+                contentHash: entry.hash,
+                lastSynced: Date.now(),
+              });
+              progress.updated++;
+            } else {
+              progress.errors++;
+              const lookupErr = lookupErrors.get(entry.sourceUrl);
+              console.error(
+                `Atomic: No atom returned for ${entry.file.path}${lookupErr ? ` (lookup also failed: ${lookupErr.message})` : ""}`
+              );
+            }
           }
           progress.processed++;
         }

--- a/plugins/obsidian-plugin/src/sync-engine.ts
+++ b/plugins/obsidian-plugin/src/sync-engine.ts
@@ -3,6 +3,18 @@ import { AtomicClient } from "./atomic-client";
 import type { AtomicSettings } from "./settings";
 import { SyncState, hashContent, type SyncStateData } from "./sync-state";
 
+export interface SyncProgress {
+  phase: 'reading' | 'syncing' | 'complete';
+  totalFiles: number;
+  processed: number;
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+}
+
+export type SyncProgressCallback = (progress: SyncProgress) => void;
+
 export class SyncEngine {
   private app: App;
   private client: AtomicClient;
@@ -62,7 +74,16 @@ export class SyncEngine {
   // --- File event handlers ---
 
   private onFileChange(file: TAbstractFile): void {
-    if (!this.isMarkdownFile(file) || this.shouldExclude(file.path)) return;
+    if (!this.isMarkdownFile(file)) {
+      console.debug(`Atomic: ignoring non-markdown file: ${file.path}`);
+      return;
+    }
+    if (this.shouldExclude(file.path)) {
+      console.debug(`Atomic: excluded by pattern: ${file.path}`);
+      return;
+    }
+
+    console.debug(`Atomic: file changed, scheduling sync: ${file.path}`);
 
     const existing = this.pendingSync.get(file.path);
     if (existing) clearTimeout(existing);
@@ -70,6 +91,7 @@ export class SyncEngine {
     this.pendingSync.set(
       file.path,
       setTimeout(() => {
+        console.debug(`Atomic: debounce fired, syncing: ${file.path}`);
         this.syncFile(file).catch((e) =>
           console.error(`Atomic: Failed to sync ${file.path}:`, e)
         );
@@ -124,7 +146,8 @@ export class SyncEngine {
     // Update the atom's source_url to reflect new path
     const newSourceUrl = this.generateSourceUrl(file.path);
     try {
-      const content = await this.app.vault.read(file);
+      const raw = await this.app.vault.read(file);
+      const content = this.stripFrontmatter(file, raw);
       await this.client.updateAtom(info.atomId, {
         content,
         source_url: newSourceUrl,
@@ -135,15 +158,30 @@ export class SyncEngine {
     }
   }
 
+  /** Strip YAML frontmatter using Obsidian's parsed metadata cache */
+  private stripFrontmatter(file: TFile, content: string): string {
+    const cache = this.app.metadataCache.getFileCache(file);
+    if (cache?.frontmatterPosition) {
+      const end = cache.frontmatterPosition.end.offset;
+      return content.slice(end).trimStart();
+    }
+    return content;
+  }
+
   // --- Core sync logic ---
 
   async syncFile(file: TFile): Promise<void> {
-    const content = await this.app.vault.read(file);
+    const raw = await this.app.vault.read(file);
+    const content = this.stripFrontmatter(file, raw);
     const hash = await hashContent(content);
 
     // Skip if unchanged
     const existing = this.syncState.getFile(file.path);
-    if (existing && existing.contentHash === hash) return;
+    if (existing && existing.contentHash === hash) {
+      console.debug(`Atomic: skipping unchanged file: ${file.path}`);
+      return;
+    }
+    console.debug(`Atomic: syncing ${file.path} (existing atom: ${existing?.atomId ?? "none"})`);
 
     const sourceUrl = this.generateSourceUrl(file.path);
 
@@ -160,9 +198,9 @@ export class SyncEngine {
         // Check server for existing atom (e.g., imported via batch before plugin was installed)
         const serverAtom = await this.client.getAtomBySourceUrl(sourceUrl);
         if (serverAtom) {
-          await this.client.updateAtom(serverAtom.atom.id, { content, source_url: sourceUrl });
+          await this.client.updateAtom(serverAtom.id, { content, source_url: sourceUrl });
           this.syncState.setFile(file.path, {
-            atomId: serverAtom.atom.id,
+            atomId: serverAtom.id,
             contentHash: hash,
             lastSynced: Date.now(),
           });
@@ -170,7 +208,7 @@ export class SyncEngine {
           // Create new atom
           const created = await this.client.createAtom({ content, source_url: sourceUrl });
           this.syncState.setFile(file.path, {
-            atomId: created.atom.id,
+            atomId: created.id,
             contentHash: hash,
             lastSynced: Date.now(),
           });
@@ -201,34 +239,149 @@ export class SyncEngine {
     }
   }
 
-  async syncAll(): Promise<void> {
+  async syncAll(onProgress?: SyncProgressCallback): Promise<SyncProgress> {
     const files = this.app.vault.getMarkdownFiles().filter((f) => !this.shouldExclude(f.path));
-    let synced = 0;
-    let skipped = 0;
-    let errors = 0;
+    const progress: SyncProgress = {
+      phase: 'reading',
+      totalFiles: files.length,
+      processed: 0,
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      errors: 0,
+    };
 
-    new Notice(`Syncing ${files.length} files to Atomic...`);
+    if (!onProgress) {
+      new Notice(`Syncing ${files.length} files to Atomic...`);
+    }
+    onProgress?.(progress);
+
+    // Separate files into new (bulk-create) vs existing (individual update)
+    const newFiles: { file: TFile; content: string; hash: string; sourceUrl: string }[] = [];
+    const updatedFiles: { file: TFile; content: string; hash: string; sourceUrl: string; atomId: string }[] = [];
 
     for (const file of files) {
       try {
-        const content = await this.app.vault.read(file);
+        const raw = await this.app.vault.read(file);
+        const content = this.stripFrontmatter(file, raw);
         const hash = await hashContent(content);
         const existing = this.syncState.getFile(file.path);
 
         if (existing && existing.contentHash === hash) {
-          skipped++;
+          progress.skipped++;
+          progress.processed++;
           continue;
         }
 
-        await this.syncFile(file);
-        synced++;
+        const sourceUrl = this.generateSourceUrl(file.path);
+        if (existing) {
+          updatedFiles.push({ file, content, hash, sourceUrl, atomId: existing.atomId });
+        } else {
+          newFiles.push({ file, content, hash, sourceUrl });
+        }
       } catch (e) {
-        errors++;
-        console.error(`Atomic: Failed to sync ${file.path}:`, e);
+        progress.errors++;
+        progress.processed++;
+        console.error(`Atomic: Failed to read ${file.path}:`, e);
       }
     }
 
-    new Notice(`Sync complete: ${synced} synced, ${skipped} unchanged, ${errors} errors`);
+    progress.phase = 'syncing';
+    onProgress?.(progress);
+
+    // Bulk-create new files in batches (cap at ~1.5MB per batch to stay under actix-web's 2MB default)
+    const MAX_BATCH_BYTES = 1_500_000;
+    const batches: typeof newFiles[] = [];
+    let currentBatch: typeof newFiles = [];
+    let currentBytes = 0;
+    for (const entry of newFiles) {
+      const entryBytes = new TextEncoder().encode(entry.content).length;
+      if (currentBatch.length > 0 && currentBytes + entryBytes > MAX_BATCH_BYTES) {
+        batches.push(currentBatch);
+        currentBatch = [];
+        currentBytes = 0;
+      }
+      currentBatch.push(entry);
+      currentBytes += entryBytes;
+    }
+    if (currentBatch.length > 0) batches.push(currentBatch);
+
+    for (const batch of batches) {
+      try {
+        const result = await this.client.bulkCreateAtoms(
+          batch.map((f) => ({ content: f.content, source_url: f.sourceUrl }))
+        );
+
+        // Match returned atoms back to files via source_url
+        const atomByUrl = new Map<string, string>();
+        for (const atom of result.atoms) {
+          if (atom.source_url) {
+            atomByUrl.set(atom.source_url, atom.id);
+          }
+        }
+
+        for (const entry of batch) {
+          const atomId = atomByUrl.get(entry.sourceUrl);
+          if (atomId) {
+            this.syncState.setFile(entry.file.path, {
+              atomId,
+              contentHash: entry.hash,
+              lastSynced: Date.now(),
+            });
+            progress.created++;
+          } else {
+            progress.errors++;
+            console.error(`Atomic: No atom returned for ${entry.file.path}`);
+          }
+          progress.processed++;
+        }
+
+        await this.persistState();
+        onProgress?.(progress);
+      } catch (e) {
+        progress.errors += batch.length;
+        progress.processed += batch.length;
+        console.error(`Atomic: Bulk create failed (${batch.length} files):`, e);
+        onProgress?.(progress);
+      }
+    }
+
+    // Update existing files individually
+    for (const entry of updatedFiles) {
+      try {
+        await this.client.updateAtom(entry.atomId, {
+          content: entry.content,
+          source_url: entry.sourceUrl,
+        });
+        this.syncState.setFile(entry.file.path, {
+          atomId: entry.atomId,
+          contentHash: entry.hash,
+          lastSynced: Date.now(),
+        });
+        progress.updated++;
+      } catch (e) {
+        progress.errors++;
+        console.error(`Atomic: Failed to update ${entry.file.path}:`, e);
+      }
+      progress.processed++;
+      onProgress?.(progress);
+    }
+
+    await this.persistState();
+    progress.phase = 'complete';
+    onProgress?.(progress);
+
+    if (!onProgress) {
+      new Notice(`Sync complete: ${progress.created} created, ${progress.updated} updated, ${progress.skipped} unchanged, ${progress.errors} errors`);
+    }
+
+    return progress;
+  }
+
+  async resetAndResync(onProgress?: SyncProgressCallback): Promise<SyncProgress> {
+    this.syncState.clear();
+    await this.persistState();
+    return this.syncAll(onProgress);
   }
 
   // --- Watch management ---
@@ -236,6 +389,7 @@ export class SyncEngine {
   startWatching(): void {
     if (this.watching) return;
     this.watching = true;
+    console.log("Atomic: auto-sync started, watching vault events");
 
     this.eventRefs.push(
       this.app.vault.on("modify", (file) => this.onFileChange(file)),

--- a/plugins/obsidian-plugin/src/sync-state.ts
+++ b/plugins/obsidian-plugin/src/sync-state.ts
@@ -35,6 +35,10 @@ export class SyncState {
     }
   }
 
+  clear(): void {
+    this.data.files = {};
+  }
+
   getAllPaths(): string[] {
     return Object.keys(this.data.files);
   }

--- a/plugins/obsidian-plugin/src/wiki-view.ts
+++ b/plugins/obsidian-plugin/src/wiki-view.ts
@@ -1,18 +1,20 @@
 import { ItemView, WorkspaceLeaf, MarkdownRenderer } from "obsidian";
-import { AtomicClient, type TagWithCount, type WikiArticle } from "./atomic-client";
+import { AtomicClient, type TagWithCount, type WikiArticleWithCitations, type WikiCitation } from "./atomic-client";
 
 export const WIKI_VIEW_TYPE = "atomic-wiki";
 
 export class WikiView extends ItemView {
   private client: AtomicClient;
+  private getVaultName: () => string;
   private tags: TagWithCount[] = [];
   private selectedTagId: string | null = null;
-  private article: WikiArticle | null = null;
+  private article: WikiArticleWithCitations | null = null;
   private loading = false;
 
-  constructor(leaf: WorkspaceLeaf, client: AtomicClient) {
+  constructor(leaf: WorkspaceLeaf, client: AtomicClient, getVaultName: () => string) {
     super(leaf);
     this.client = client;
+    this.getVaultName = getVaultName;
   }
 
   getViewType(): string {
@@ -128,10 +130,15 @@ export class WikiView extends ItemView {
       const genBtn = actions.createEl("button", { text: "Generate Article" });
       genBtn.addEventListener("click", async () => {
         if (!this.selectedTagId) return;
+        const tagName = this.findTagName(this.selectedTagId);
+        if (!tagName) {
+          genBtn.setText("Tag not found");
+          return;
+        }
         genBtn.disabled = true;
         genBtn.setText("Generating...");
         try {
-          this.article = await this.client.generateWikiArticle(this.selectedTagId);
+          this.article = await this.client.generateWikiArticle(this.selectedTagId, tagName);
           this.renderContent(wrapper);
         } catch (e) {
           genBtn.setText("Failed - Retry");
@@ -143,12 +150,70 @@ export class WikiView extends ItemView {
     }
 
     const contentEl = wrapper.createDiv({ cls: "atomic-wiki-content" });
-    MarkdownRenderer.render(
-      this.app,
-      this.article.content,
-      contentEl,
-      "",
-      this
+    const rewritten = this.rewriteCitations(
+      this.article.article.content,
+      this.article.citations
     );
+    MarkdownRenderer.render(this.app, rewritten, contentEl, "", this);
+  }
+
+  /**
+   * Replace `[N]` citation markers in wiki content with Obsidian wikilinks
+   * for citations that point to atoms synced from this vault, and strip
+   * markers that point to non-Obsidian atoms.
+   *
+   * Caveat: this is a regex pass and does not respect markdown code fences.
+   * Wiki content from the LLM rarely contains code blocks with `[N]`-shaped
+   * strings, so the trade-off is acceptable for now.
+   */
+  private rewriteCitations(content: string, citations: WikiCitation[]): string {
+    const byIndex = new Map<number, WikiCitation>();
+    for (const c of citations) byIndex.set(c.citation_index, c);
+
+    const vaultPrefix = `obsidian://${this.getVaultName()}/`;
+
+    return content.replace(/\[(\d+)\]/g, (match, indexStr) => {
+      const index = parseInt(indexStr, 10);
+      const citation = byIndex.get(index);
+      // Unknown citation index — leave the marker untouched rather than silently dropping it.
+      if (!citation) return match;
+
+      const url = citation.source_url;
+      if (!url || !url.startsWith(vaultPrefix)) {
+        // Non-Obsidian (or different-vault) citation — strip the marker.
+        return "";
+      }
+
+      // Decode obsidian://VaultName/encoded/path.md → vault-relative path,
+      // then drop the .md extension for the wikilink target. Obsidian resolves
+      // both `[[Note]]` and `[[folder/Note]]`; using the path is unambiguous
+      // when basenames collide.
+      const encodedPath = url.slice(vaultPrefix.length);
+      let path: string;
+      try {
+        path = encodedPath
+          .split("/")
+          .map((seg) => decodeURIComponent(seg))
+          .join("/");
+      } catch {
+        return ""; // malformed encoding — strip rather than render garbage
+      }
+      const target = path.replace(/\.md$/i, "");
+      return `[[${target}]]`;
+    });
+  }
+
+  private findTagName(tagId: string): string | null {
+    const search = (nodes: TagWithCount[]): string | null => {
+      for (const node of nodes) {
+        if (node.id === tagId) return node.name;
+        if (node.children.length > 0) {
+          const found = search(node.children);
+          if (found) return found;
+        }
+      }
+      return null;
+    };
+    return search(this.tags);
   }
 }

--- a/plugins/obsidian-plugin/src/wiki-view.ts
+++ b/plugins/obsidian-plugin/src/wiki-view.ts
@@ -180,8 +180,11 @@ export class WikiView extends ItemView {
 
       const url = citation.source_url;
       if (!url || !url.startsWith(vaultPrefix)) {
-        // Non-Obsidian (or different-vault) citation — strip the marker.
-        return "";
+        // Non-Obsidian (or different-vault) citation — leave the marker as-is
+        // so prose like "…Smith [2] and Jones [3]…" doesn't end up with a
+        // dangling gap that looks like a typo. The reader can still see the
+        // citation existed even though we can't link it.
+        return match;
       }
 
       // Decode obsidian://VaultName/encoded/path.md → vault-relative path,

--- a/plugins/obsidian-plugin/styles.css
+++ b/plugins/obsidian-plugin/styles.css
@@ -82,6 +82,262 @@
   padding: 32px 16px;
 }
 
+/* Onboarding wizard */
+.atomic-onboarding-modal .modal-content {
+  padding: 0;
+}
+
+.atomic-onboarding {
+  padding: 24px;
+}
+
+.atomic-onboarding h2 {
+  margin: 0 0 8px;
+  font-size: 1.3em;
+}
+
+.atomic-onboarding-desc {
+  color: var(--text-muted);
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.atomic-onboarding-features {
+  color: var(--text-muted);
+  padding-left: 20px;
+  margin: 0 0 20px;
+  line-height: 1.7;
+}
+
+.atomic-onboarding-features strong {
+  color: var(--text-normal);
+}
+
+.atomic-onboarding-body {
+  min-height: 260px;
+}
+
+.atomic-onboarding-form .setting-item {
+  border-top: none;
+  padding: 6px 0;
+}
+
+.atomic-onboarding-test {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 8px 0 16px;
+}
+
+.atomic-onboarding-test-status {
+  font-size: 0.85em;
+}
+
+.atomic-onboarding-test-status.success {
+  color: var(--color-green);
+}
+
+.atomic-onboarding-test-status.error {
+  color: var(--color-red);
+}
+
+.atomic-onboarding-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+/* Step indicator */
+.atomic-step-indicator {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 0;
+  margin-bottom: 24px;
+}
+
+.atomic-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  z-index: 1;
+}
+
+.atomic-step-dot {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--background-modifier-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.atomic-step-dot svg {
+  width: 12px;
+  height: 12px;
+  color: var(--text-on-accent);
+}
+
+.atomic-step-dot.active {
+  background: var(--interactive-accent);
+  box-shadow: 0 0 0 3px var(--interactive-accent-hover);
+}
+
+.atomic-step-dot.completed {
+  background: var(--interactive-accent);
+}
+
+.atomic-step-label {
+  font-size: 0.7em;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.atomic-step-connector {
+  height: 2px;
+  flex: 1;
+  min-width: 32px;
+  max-width: 64px;
+  background: var(--background-modifier-border);
+  margin-top: 11px;
+  transition: background 0.2s ease;
+}
+
+.atomic-step-connector.completed {
+  background: var(--interactive-accent);
+}
+
+/* Progress bar */
+.atomic-sync-progress {
+  margin: 16px 0;
+}
+
+.atomic-sync-progress.hidden {
+  display: none;
+}
+
+.atomic-progress-bar {
+  height: 6px;
+  background: var(--background-modifier-border);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.atomic-progress-fill {
+  height: 100%;
+  width: 0;
+  background: var(--interactive-accent);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.atomic-progress-label {
+  font-size: 0.85em;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+/* Sync stats */
+.atomic-sync-stats {
+  display: flex;
+  gap: 20px;
+}
+
+.atomic-sync-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.atomic-sync-stat-value {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: var(--text-normal);
+}
+
+.atomic-sync-stat-label {
+  font-size: 0.75em;
+  color: var(--text-muted);
+}
+
+/* Feature cards */
+.atomic-feature-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.atomic-feature-card {
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 6px;
+  border: 1px solid var(--background-modifier-border);
+}
+
+.atomic-feature-icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  color: var(--interactive-accent);
+  margin-top: 2px;
+}
+
+.atomic-feature-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.atomic-feature-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.atomic-feature-title {
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
+.atomic-feature-desc {
+  font-size: 0.85em;
+  color: var(--text-muted);
+}
+
+.atomic-feature-shortcut {
+  font-size: 0.75em;
+  color: var(--text-faint);
+  margin-top: 2px;
+}
+
+/* Skip link */
+.atomic-skip-link {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.85em;
+  padding: 4px 8px;
+  margin-right: auto;
+}
+
+.atomic-skip-link:hover {
+  color: var(--text-normal);
+}
+
+.atomic-skip-link.hidden {
+  display: none;
+}
+
 /* Status bar */
 .atomic-status {
   display: flex;

--- a/scripts/scrape-gwern.sh
+++ b/scripts/scrape-gwern.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Scrape gwern.net essays as markdown files.
+# Usage: ./scripts/scrape-gwern.sh [output-dir] [max-pages]
+#
+# Fetches the index page (markdown source), extracts internal essay links,
+# then downloads each essay's markdown source into the output directory.
+
+set -euo pipefail
+
+OUT_DIR="${1:-/tmp/gwern-vault}"
+MAX_PAGES="${2:-200}"
+
+mkdir -p "$OUT_DIR"
+
+echo "Fetching gwern.net index..."
+
+# Grab the index page as markdown, extract internal links like (/some-path)
+# Filter to top-level essay paths (no /doc/, /static/, no anchors-only, no external)
+curl -sS -H "Accept: text/markdown" "https://gwern.net/index" \
+  | grep -oE '\(/[a-zA-Z][a-zA-Z0-9_/-]*\)' \
+  | sed 's/^(//; s/)$//' \
+  | sort -u \
+  | grep -v '^/doc/' \
+  | grep -v '^/static/' \
+  | grep -v '^/index' \
+  | head -n "$MAX_PAGES" \
+  > /tmp/gwern-paths.txt
+
+TOTAL=$(wc -l < /tmp/gwern-paths.txt | tr -d ' ')
+echo "Found $TOTAL essay paths (capped at $MAX_PAGES). Downloading..."
+
+COUNT=0
+ERRORS=0
+
+while IFS= read -r path; do
+  COUNT=$((COUNT + 1))
+  # Convert path to filename: /scaling-hypothesis -> scaling-hypothesis.md
+  filename=$(echo "$path" | sed 's|^/||; s|/|--|g').md
+
+  printf "\r[%d/%d] %s" "$COUNT" "$TOTAL" "$path"
+
+  if curl -sS -f -H "Accept: text/markdown" "https://gwern.net${path}" -o "$OUT_DIR/$filename" 2>/dev/null; then
+    # Skip files that are too small (likely error pages) or empty
+    size=$(wc -c < "$OUT_DIR/$filename" | tr -d ' ')
+    if [ "$size" -lt 100 ]; then
+      rm "$OUT_DIR/$filename"
+      ERRORS=$((ERRORS + 1))
+    fi
+  else
+    ERRORS=$((ERRORS + 1))
+  fi
+
+  # Be polite
+  sleep 0.3
+done < /tmp/gwern-paths.txt
+
+echo ""
+echo "Done! Downloaded $((COUNT - ERRORS)) essays to $OUT_DIR ($ERRORS skipped)"
+echo ""
+echo "To use as an Obsidian vault, open $OUT_DIR as a vault in Obsidian."

--- a/src/components/layout/LeftPanel.tsx
+++ b/src/components/layout/LeftPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { TagTree } from '../tags/TagTree';
-import { SettingsButton, SettingsModal } from '../settings';
+import { SettingsButton, SettingsModal, type SettingsTab } from '../settings';
 import { DatabaseSwitcher } from '../DatabaseSwitcher';
 import { useUIStore } from '../../stores/ui';
 import { isTauri } from '../../lib/platform';
@@ -9,6 +9,7 @@ const COLLAPSE_BREAKPOINT = 768;
 
 export function LeftPanel() {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTab | undefined>(undefined);
   const leftPanelOpen = useUIStore(s => s.leftPanelOpen);
   const setLeftPanelOpen = useUIStore(s => s.setLeftPanelOpen);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -63,16 +64,25 @@ export function LeftPanel() {
           {/* Titlebar row with settings button */}
           <div className={`h-[52px] flex items-center px-3 flex-shrink-0 gap-1 ${isTauri() ? 'pl-[78px]' : ''}`} data-tauri-drag-region>
             <DatabaseSwitcher />
-            <SettingsButton onClick={() => setIsSettingsOpen(true)} />
+            <SettingsButton onClick={() => { setSettingsInitialTab(undefined); setIsSettingsOpen(true); }} />
           </div>
 
           {/* Tag Tree with integrated search */}
           <div className="flex-1 overflow-hidden">
-            <TagTree />
+            <TagTree
+              onOpenTagSettings={() => {
+                setSettingsInitialTab('tag-categories');
+                setIsSettingsOpen(true);
+              }}
+            />
           </div>
         </div>
 
-        <SettingsModal isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
+        <SettingsModal
+          isOpen={isSettingsOpen}
+          onClose={() => setIsSettingsOpen(false)}
+          initialTab={settingsInitialTab}
+        />
       </aside>
     </>
   );

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -3,10 +3,12 @@ import { Button } from '../ui/Button';
 import { StepIndicator } from './StepIndicator';
 import { useOnboardingState, STEPS } from './useOnboardingState';
 import { useSettingsStore } from '../../stores/settings';
+import { useTagsStore } from '../../stores/tags';
 import { isDesktopApp, getTransport } from '../../lib/transport';
 
 import { WelcomeStep } from './steps/WelcomeStep';
 import { AIProviderStep } from './steps/AIProviderStep';
+import { TagCategoriesStep } from './steps/TagCategoriesStep';
 import { IntegrationsStep } from './steps/IntegrationsStep';
 import { TutorialStep } from './steps/TutorialStep';
 
@@ -18,6 +20,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const [state, dispatch] = useOnboardingState();
   const setSetting = useSettingsStore(s => s.setSetting);
   const testOpenRouterConnection = useSettingsStore(s => s.testOpenRouterConnection);
+  const configureAutotagTargets = useTagsStore(s => s.configureAutotagTargets);
 
   const currentStepDef = STEPS[state.currentStep];
   const isFirstStep = state.currentStep === 0;
@@ -103,6 +106,20 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
       await saveProviderSettings();
     }
 
+    // Save tag categories when leaving the tag-categories step (only if auto-tagging is enabled)
+    if (currentStepDef.id === 'tag-categories' && state.autoTaggingEnabled) {
+      dispatch({ type: 'SET_SAVING_CATEGORIES', value: true });
+      try {
+        await configureAutotagTargets(state.selectedDefaultCategories, state.customCategories);
+        dispatch({ type: 'SET_CATEGORIES_ERROR', error: null });
+      } catch (e) {
+        dispatch({ type: 'SET_CATEGORIES_ERROR', error: String(e) });
+        dispatch({ type: 'SET_SAVING_CATEGORIES', value: false });
+        return;
+      }
+      dispatch({ type: 'SET_SAVING_CATEGORIES', value: false });
+    }
+
     if (isLastStep) {
       onComplete();
     } else {
@@ -134,6 +151,8 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
         return <WelcomeStep state={state} dispatch={dispatch} onNext={handleNext} />;
       case 'ai-provider':
         return <AIProviderStep state={state} dispatch={dispatch} />;
+      case 'tag-categories':
+        return <TagCategoriesStep state={state} dispatch={dispatch} />;
       case 'integrations':
         return <IntegrationsStep state={state} dispatch={dispatch} />;
       case 'tutorial':

--- a/src/components/onboarding/steps/TagCategoriesStep.tsx
+++ b/src/components/onboarding/steps/TagCategoriesStep.tsx
@@ -1,0 +1,117 @@
+import type { OnboardingState, OnboardingAction } from '../useOnboardingState';
+import { DEFAULT_TAG_CATEGORIES } from '../useOnboardingState';
+
+interface TagCategoriesStepProps {
+  state: OnboardingState;
+  dispatch: React.Dispatch<OnboardingAction>;
+}
+
+export function TagCategoriesStep({ state, dispatch }: TagCategoriesStepProps) {
+  // If auto-tagging is disabled, this step is a no-op informational screen.
+  if (!state.autoTaggingEnabled) {
+    return (
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">Tag categories</h2>
+          <p className="text-sm text-[var(--color-text-secondary)] mt-1">
+            Auto-tagging is turned off, so there's nothing to configure here. You can come back to <strong>Settings → Tag Categories</strong> any time.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const isSelected = (name: string) => state.selectedDefaultCategories.includes(name);
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">Choose your tag categories</h2>
+        <p className="text-sm text-[var(--color-text-secondary)] mt-1">
+          The AI auto-tagger creates new sub-tags under categories you choose. Pick the ones that fit your knowledge base — you can change these later in Settings.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-tertiary)]">
+          Default categories
+        </div>
+        <div className="space-y-1">
+          {DEFAULT_TAG_CATEGORIES.map(name => (
+            <label
+              key={name}
+              className="flex items-center gap-3 px-3 py-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-main)] cursor-pointer hover:bg-[var(--color-bg-hover)]"
+            >
+              <input
+                type="checkbox"
+                checked={isSelected(name)}
+                onChange={() => dispatch({ type: 'TOGGLE_DEFAULT_CATEGORY', name })}
+                className="accent-[var(--color-accent)]"
+              />
+              <span className="text-sm text-[var(--color-text-primary)]">{name}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-tertiary)]">
+          Custom categories
+        </div>
+        {state.customCategories.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {state.customCategories.map(name => (
+              <span
+                key={name}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-[var(--color-accent)]/15 text-xs text-[var(--color-text-primary)] border border-[var(--color-accent)]/40"
+              >
+                {name}
+                <button
+                  type="button"
+                  onClick={() => dispatch({ type: 'REMOVE_CUSTOM_CATEGORY', name })}
+                  className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]"
+                  aria-label={`Remove ${name}`}
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={state.customCategoryInput}
+            onChange={e => dispatch({ type: 'SET_CUSTOM_CATEGORY_INPUT', value: e.target.value })}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                dispatch({ type: 'ADD_CUSTOM_CATEGORY' });
+              }
+            }}
+            placeholder="e.g., Methodologies, Projects, Books"
+            className="flex-1 bg-[var(--color-bg-main)] border border-[var(--color-border)] rounded px-3 py-1.5 text-sm text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent)]"
+          />
+          <button
+            type="button"
+            onClick={() => dispatch({ type: 'ADD_CUSTOM_CATEGORY' })}
+            disabled={!state.customCategoryInput.trim()}
+            className="px-3 py-1.5 text-sm rounded bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      {state.categoriesError && (
+        <div className="text-xs text-red-400">{state.categoriesError}</div>
+      )}
+
+      {state.selectedDefaultCategories.length === 0 && state.customCategories.length === 0 && (
+        <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-200">
+          No categories selected. Auto-tagging will be skipped until you add at least one in Settings.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/onboarding/useOnboardingState.ts
+++ b/src/components/onboarding/useOnboardingState.ts
@@ -4,8 +4,17 @@ import type { AvailableModel, OllamaModel } from '../../lib/api';
 export type StepId =
   | 'welcome'
   | 'ai-provider'
+  | 'tag-categories'
   | 'integrations'
   | 'tutorial';
+
+export const DEFAULT_TAG_CATEGORIES = [
+  'Topics',
+  'People',
+  'Locations',
+  'Organizations',
+  'Events',
+] as const;
 
 export interface OnboardingState {
   currentStep: number;
@@ -48,6 +57,13 @@ export interface OnboardingState {
   openaiCompatTimeoutSecs: string;
   openaiCompatStatus: 'idle' | 'checking' | 'connected' | 'error';
   openaiCompatError: string | null;
+
+  // Step 3: Tag categories (only shown if auto-tagging is enabled)
+  selectedDefaultCategories: string[]; // subset of DEFAULT_TAG_CATEGORIES
+  customCategories: string[];
+  customCategoryInput: string;
+  isSavingCategories: boolean;
+  categoriesError: string | null;
 
   // Step 4: Mobile setup
   mobileToken: string | null;
@@ -101,6 +117,13 @@ export type OnboardingAction =
   | { type: 'SET_OPENAI_COMPAT_CONTEXT_LENGTH'; value: string }
   | { type: 'SET_OPENAI_COMPAT_TIMEOUT_SECS'; value: string }
   | { type: 'SET_OPENAI_COMPAT_STATUS'; status: 'idle' | 'checking' | 'connected' | 'error'; error?: string }
+  // Tag categories
+  | { type: 'TOGGLE_DEFAULT_CATEGORY'; name: string }
+  | { type: 'SET_CUSTOM_CATEGORY_INPUT'; value: string }
+  | { type: 'ADD_CUSTOM_CATEGORY' }
+  | { type: 'REMOVE_CUSTOM_CATEGORY'; name: string }
+  | { type: 'SET_SAVING_CATEGORIES'; value: boolean }
+  | { type: 'SET_CATEGORIES_ERROR'; error: string | null }
   // Mobile
   | { type: 'SET_MOBILE_TOKEN'; token: string | null }
   // Data loading
@@ -147,6 +170,11 @@ const initialState: OnboardingState = {
   openaiCompatTimeoutSecs: '300',
   openaiCompatStatus: 'idle',
   openaiCompatError: null,
+  selectedDefaultCategories: [...DEFAULT_TAG_CATEGORIES],
+  customCategories: [],
+  customCategoryInput: '',
+  isSavingCategories: false,
+  categoriesError: null,
   mobileToken: null,
   mobileTokenName: 'mobile-setup',
   feedUrl: '',
@@ -235,6 +263,46 @@ function reducer(state: OnboardingState, action: OnboardingAction): OnboardingSt
       return { ...state, openaiCompatTimeoutSecs: action.value };
     case 'SET_OPENAI_COMPAT_STATUS':
       return { ...state, openaiCompatStatus: action.status, openaiCompatError: action.error || null };
+    case 'TOGGLE_DEFAULT_CATEGORY': {
+      const has = state.selectedDefaultCategories.includes(action.name);
+      return {
+        ...state,
+        selectedDefaultCategories: has
+          ? state.selectedDefaultCategories.filter(n => n !== action.name)
+          : [...state.selectedDefaultCategories, action.name],
+        categoriesError: null,
+      };
+    }
+    case 'SET_CUSTOM_CATEGORY_INPUT':
+      return { ...state, customCategoryInput: action.value, categoriesError: null };
+    case 'ADD_CUSTOM_CATEGORY': {
+      const trimmed = state.customCategoryInput.trim();
+      if (!trimmed) return state;
+      if (trimmed.includes('/')) {
+        return { ...state, categoriesError: 'Category names cannot contain "/".' };
+      }
+      const existsInDefaults = DEFAULT_TAG_CATEGORIES.some(d => d.toLowerCase() === trimmed.toLowerCase());
+      const existsInCustom = state.customCategories.some(c => c.toLowerCase() === trimmed.toLowerCase());
+      if (existsInDefaults || existsInCustom) {
+        return { ...state, categoriesError: `"${trimmed}" is already in the list.` };
+      }
+      return {
+        ...state,
+        customCategories: [...state.customCategories, trimmed],
+        customCategoryInput: '',
+        categoriesError: null,
+      };
+    }
+    case 'REMOVE_CUSTOM_CATEGORY':
+      return {
+        ...state,
+        customCategories: state.customCategories.filter(n => n !== action.name),
+        categoriesError: null,
+      };
+    case 'SET_SAVING_CATEGORIES':
+      return { ...state, isSavingCategories: action.value };
+    case 'SET_CATEGORIES_ERROR':
+      return { ...state, categoriesError: action.error };
     case 'SET_MOBILE_TOKEN':
       return { ...state, mobileToken: action.token };
     case 'SET_FEED_URL':
@@ -261,6 +329,7 @@ export function useOnboardingState() {
 export const STEPS: { id: StepId; label: string; required: boolean }[] = [
   { id: 'welcome', label: 'Welcome', required: true },
   { id: 'ai-provider', label: 'AI Provider', required: true },
+  { id: 'tag-categories', label: 'Tag Categories', required: false },
   { id: 'integrations', label: 'Integrations', required: false },
   { id: 'tutorial', label: 'Tutorial', required: false },
 ];

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -7,7 +7,7 @@ import { SearchableSelect } from '../ui/SearchableSelect';
 import { ConnectionStatus } from '../ui/ConnectionStatus';
 import { useSettingsStore } from '../../stores/settings';
 import { useAtomsStore } from '../../stores/atoms';
-import { useTagsStore } from '../../stores/tags';
+import { useTagsStore, type TagWithCount } from '../../stores/tags';
 import { THEMES, Theme } from '../../hooks/useTheme';
 import { FONTS, Font } from '../../hooks/useFont';
 import {
@@ -45,16 +45,166 @@ import { importMarkdownFolder, type ImportProgress } from '../../lib/import';
 import { formatRelativeDate } from '../../lib/date';
 import { useDatabasesStore, type DatabaseInfo, type DatabaseStats } from '../../stores/databases';
 
-type SettingsTab = 'general' | 'ai' | 'connection' | 'feeds' | 'integrations' | 'databases';
+export type SettingsTab = 'general' | 'ai' | 'tag-categories' | 'connection' | 'feeds' | 'integrations' | 'databases';
 
 const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: 'general', label: 'General' },
   { id: 'ai', label: 'AI Models' },
+  { id: 'tag-categories', label: 'Tags' },
   { id: 'connection', label: 'Connection' },
   { id: 'feeds', label: 'Feeds' },
   { id: 'integrations', label: 'Integrations' },
   { id: 'databases', label: 'Databases' },
 ];
+
+function TagCategoriesTab() {
+  const tags = useTagsStore(s => s.tags);
+  const fetchTags = useTagsStore(s => s.fetchTags);
+  const setTagAutotagTarget = useTagsStore(s => s.setTagAutotagTarget);
+  const createTag = useTagsStore(s => s.createTag);
+  const [newName, setNewName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchTags();
+  }, [fetchTags]);
+
+  // Top-level tags only — flag is currently constrained to root tags.
+  const topLevel = tags.filter(t => !t.parent_id);
+  const targets = topLevel.filter(t => t.is_autotag_target);
+  const available = topLevel.filter(t => !t.is_autotag_target);
+
+  const handleToggle = async (id: string, value: boolean) => {
+    setErrorMsg(null);
+    try {
+      await setTagAutotagTarget(id, value);
+    } catch (e) {
+      setErrorMsg(String(e));
+    }
+  };
+
+  const handleCreate = async () => {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    if (trimmed.includes('/')) {
+      setErrorMsg('Category names cannot contain "/".');
+      return;
+    }
+    if (topLevel.some(t => t.name.toLowerCase() === trimmed.toLowerCase())) {
+      setErrorMsg(`A top-level tag named "${trimmed}" already exists.`);
+      return;
+    }
+    setCreating(true);
+    setErrorMsg(null);
+    try {
+      const created = await createTag(trimmed);
+      await setTagAutotagTarget(created.id, true);
+      setNewName('');
+    } catch (e) {
+      setErrorMsg(String(e));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium text-[var(--color-text-primary)]">Auto-Tag Categories</h3>
+        <p className="text-xs text-[var(--color-text-secondary)]">
+          The AI auto-tagger only creates new sub-tags under categories you mark as targets.
+        </p>
+      </div>
+
+      {targets.length === 0 && (
+        <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-200">
+          No auto-tag targets configured. Auto-tagging will be skipped for new atoms until you mark at least one category.
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <div className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-tertiary)]">Active targets</div>
+        {targets.length === 0 ? (
+          <p className="text-xs text-[var(--color-text-secondary)] italic">None yet.</p>
+        ) : (
+          <div className="space-y-1">
+            {targets.map(tag => (
+              <div
+                key={tag.id}
+                className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-main)]"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-sm text-[var(--color-text-primary)] truncate">{tag.name}</span>
+                  <span className="text-[10px] text-[var(--color-text-tertiary)]">
+                    {(tag as TagWithCount).atom_count} atoms
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleToggle(tag.id, false)}
+                  className="px-2 py-1 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
+                >
+                  Unflag
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-tertiary)]">Available top-level tags</div>
+        {available.length === 0 ? (
+          <p className="text-xs text-[var(--color-text-secondary)] italic">All your top-level tags are already targets.</p>
+        ) : (
+          <div className="space-y-1">
+            {available.map(tag => (
+              <div
+                key={tag.id}
+                className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-main)]"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-sm text-[var(--color-text-primary)] truncate">{tag.name}</span>
+                  <span className="text-[10px] text-[var(--color-text-tertiary)]">
+                    {(tag as TagWithCount).atom_count} atoms
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleToggle(tag.id, true)}
+                  className="px-2 py-1 text-xs text-[var(--color-accent)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
+                >
+                  Mark as target
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-tertiary)]">Create new target</div>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newName}
+            onChange={e => setNewName(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') handleCreate(); }}
+            placeholder="e.g., Methodologies"
+            disabled={creating}
+            className="flex-1 bg-[var(--color-bg-main)] border border-[var(--color-border)] rounded px-3 py-1.5 text-sm text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent)]"
+          />
+          <Button onClick={handleCreate} disabled={creating || !newName.trim()}>
+            {creating ? 'Adding…' : 'Add'}
+          </Button>
+        </div>
+      </div>
+
+      {errorMsg && (
+        <div className="text-xs text-red-400">{errorMsg}</div>
+      )}
+    </>
+  );
+}
 
 function DatabasesTab() {
   const { databases, activeId, fetchDatabases, renameDatabase, deleteDatabase, setDefaultDatabase, getDatabaseStats } = useDatabasesStore();
@@ -237,9 +387,10 @@ function DatabasesTab() {
 interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
+  initialTab?: SettingsTab;
 }
 
-export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProps) {
   const settings = useSettingsStore(s => s.settings);
   const fetchSettings = useSettingsStore(s => s.fetchSettings);
   const setSetting = useSettingsStore(s => s.setSetting);
@@ -311,7 +462,14 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const [importProgress, setImportProgress] = useState<ImportProgress | null>(null);
 
   // Tab state
-  const [activeTab, setActiveTab] = useState<SettingsTab>('general');
+  const [activeTab, setActiveTab] = useState<SettingsTab>(initialTab ?? 'general');
+
+  // When the modal is reopened with a new initialTab, sync the active tab.
+  useEffect(() => {
+    if (isOpen && initialTab) {
+      setActiveTab(initialTab);
+    }
+  }, [isOpen, initialTab]);
 
   // MCP setup state
   const [showMcpSetup, setShowMcpSetup] = useState(false);
@@ -925,12 +1083,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
             </button>
           </div>
 
-          <div className="flex gap-1 mt-4 -mb-4 px-0">
+          <div className="flex gap-1 mt-4 -mb-4 px-0 overflow-x-auto">
               {SETTINGS_TABS.map((tab) => (
                 <button
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id)}
-                  className={`px-3 py-2 text-sm font-medium rounded-t-md transition-colors ${
+                  className={`px-3 py-2 text-sm font-medium rounded-t-md transition-colors whitespace-nowrap flex-shrink-0 ${
                     activeTab === tab.id
                       ? 'bg-[var(--color-bg-main)] text-[var(--color-text-primary)] border border-b-0 border-[var(--color-border)]'
                       : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
@@ -1697,6 +1855,11 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                     )}
                   </div>
                 </>
+              )}
+
+              {/* ===== TAG CATEGORIES TAB ===== */}
+              {activeTab === 'tag-categories' && (
+                <TagCategoriesTab />
               )}
 
               {/* ===== CONNECTION TAB ===== */}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,3 +1,4 @@
 export { SettingsModal } from './SettingsModal';
+export type { SettingsTab } from './SettingsModal';
 export { SettingsButton } from './SettingsButton';
 

--- a/src/components/tags/TagTree.tsx
+++ b/src/components/tags/TagTree.tsx
@@ -43,7 +43,12 @@ function flattenVisibleTags(
   return result;
 }
 
-export function TagTree() {
+interface TagTreeProps {
+  /** Called when the user clicks "Configure" in the empty-state notice. */
+  onOpenTagSettings?: () => void;
+}
+
+export function TagTree({ onOpenTagSettings }: TagTreeProps = {}) {
   const tags = useTagsStore(s => s.tags);
   const isLoading = useTagsStore(s => s.isLoading);
   const createTag = useTagsStore(s => s.createTag);
@@ -253,8 +258,18 @@ export function TagTree() {
             ))}
           </div>
         ) : tags.length === 0 ? (
-          <div className="px-3 py-4 text-sm text-[var(--color-text-tertiary)] text-center">
-            No tags yet
+          <div className="px-3 py-4 space-y-3">
+            <p className="text-xs text-[var(--color-text-secondary)] leading-relaxed">
+              No tag categories are configured for this database, so auto-tagging is off. Set up categories to let Atomic tag your atoms automatically.
+            </p>
+            {onOpenTagSettings && (
+              <button
+                onClick={onOpenTagSettings}
+                className="w-full px-3 py-1.5 text-xs font-medium rounded bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] transition-colors"
+              >
+                Configure categories
+              </button>
+            )}
           </div>
         ) : (
           <div

--- a/src/lib/transport/command-map.ts
+++ b/src/lib/transport/command-map.ts
@@ -125,6 +125,21 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
     method: 'DELETE',
     path: (a) => `/api/tags/${encodeURIComponent(a.id as string)}${a.recursive ? '?recursive=true' : ''}`,
   },
+  set_tag_autotag_target: {
+    method: 'PUT',
+    path: (a) => `/api/tags/${encodeURIComponent(a.id as string)}/autotag-target`,
+    argsMode: 'body',
+    transformArgs: (a) => ({ value: a.value }),
+  },
+  configure_autotag_targets: {
+    method: 'POST',
+    path: '/api/tags/configure-autotag-targets',
+    argsMode: 'body',
+    transformArgs: (a) => ({
+      keep_defaults: a.keepDefaults ?? [],
+      add_custom: a.addCustom ?? [],
+    }),
+  },
 
   // ==================== Search ====================
   search_atoms_semantic: {

--- a/src/stores/tags.ts
+++ b/src/stores/tags.ts
@@ -6,6 +6,7 @@ export interface Tag {
   name: string;
   parent_id: string | null;
   created_at: string;
+  is_autotag_target: boolean;
 }
 
 export interface TagWithCount extends Tag {
@@ -38,6 +39,8 @@ interface TagsStore {
   createTag: (name: string, parentId?: string) => Promise<Tag>;
   updateTag: (id: string, name: string, parentId?: string) => Promise<Tag>;
   deleteTag: (id: string, recursive?: boolean) => Promise<void>;
+  setTagAutotagTarget: (id: string, value: boolean) => Promise<void>;
+  configureAutotagTargets: (keepDefaults: string[], addCustom: string[]) => Promise<Tag[]>;
   compactTags: () => Promise<CompactionResult>;
   clearError: () => void;
   reset: () => void;
@@ -182,6 +185,34 @@ export const useTagsStore = create<TagsStore>((set, get) => ({
       // Refetch tags to get updated tree structure
       const tags = await getTransport().invoke<TagWithCount[]>('get_all_tags');
       set({ tags });
+    } catch (error) {
+      set({ error: String(error) });
+      throw error;
+    }
+  },
+
+  setTagAutotagTarget: async (id: string, value: boolean) => {
+    set({ error: null });
+    try {
+      await getTransport().invoke('set_tag_autotag_target', { id, value });
+      const tags = await getTransport().invoke<TagWithCount[]>('get_all_tags');
+      set({ tags });
+    } catch (error) {
+      set({ error: String(error) });
+      throw error;
+    }
+  },
+
+  configureAutotagTargets: async (keepDefaults: string[], addCustom: string[]) => {
+    set({ error: null });
+    try {
+      const created = await getTransport().invoke<Tag[]>('configure_autotag_targets', {
+        keepDefaults,
+        addCustom,
+      });
+      const tags = await getTransport().invoke<TagWithCount[]>('get_all_tags');
+      set({ tags });
+      return created;
     } catch (error) {
       set({ error: String(error) });
       throw error;


### PR DESCRIPTION
- Add first-run onboarding wizard (4-step modal: welcome, connect, index vault, done) with progress bar and live sync counters
- Add database selection setting (X-Atomic-Database header)
- Reset sync state and re-sync when database changes
- Switch bulk sync to size-based batching (~1.5MB) instead of fixed count of 50
- Fix AtomWithTags type to match server's flattened serde response
- Strip YAML frontmatter from notes before syncing (uses Obsidian metadataCache)
- Add SyncProgress callback to syncAll() for real-time progress reporting
- Default auto-sync to enabled
- Add "Setup Wizard" command to command palette
- Add scrape-gwern.sh script for generating a test markdown corpus