### PR TITLE
Fix: use adaptive batching in single-atom embedding path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "1.18.1"
+version = "1.19.0"
 dependencies = [
  "atomic-core",
  "reqwest 0.12.26",

--- a/crates/atomic-core/src/embedding.rs
+++ b/crates/atomic-core/src/embedding.rs
@@ -363,16 +363,29 @@ async fn process_embedding_only_inner(
         return Ok(());
     }
 
-    // Generate all embeddings in one batch (async, no lock)
-    let chunk_texts: Vec<String> = chunks.iter().map(|s| s.to_string()).collect();
-    let embeddings = generate_embeddings_with_config(&provider_config, &chunk_texts)
-        .await
-        .map_err(|e| format!("Failed to generate embeddings: {}", e.message))?;
+    // Use adaptive batching so provider batch-size limits (e.g. DashScope's
+    // max 10) are handled by splitting, same as the bulk embedding path.
+    let pending: Vec<PendingChunk> = chunks
+        .into_iter()
+        .enumerate()
+        .map(|(index, chunk)| PendingChunk {
+            atom_id: atom_id.to_string(),
+            chunk_index: index,
+            content: chunk,
+        })
+        .collect();
+
+    let (embedded, failed) = embed_chunks_batched(&provider_config, pending).await;
+
+    if !failed.is_empty() {
+        let error = failed.into_iter().next().map(|(_, e)| e).unwrap_or_default();
+        return Err(format!("Failed to generate embeddings: {}", error));
+    }
 
     // Store chunks and embeddings
-    let chunks_with_embeddings: Vec<(String, Vec<f32>)> = chunks
+    let chunks_with_embeddings: Vec<(String, Vec<f32>)> = embedded
         .into_iter()
-        .zip(embeddings.into_iter())
+        .map(|(chunk, emb)| (chunk.content, emb))
         .collect();
     storage.save_chunks_and_embeddings_sync(atom_id, &chunks_with_embeddings)
         .map_err(|e| format!("Failed to store chunks: {}", e))?;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atomic",
-  "version": "1.14.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atomic",
-      "version": "1.14.0",
+      "version": "1.19.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/theme-one-dark": "^6.1.3",
@@ -105,6 +105,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -511,6 +512,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
       "integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -606,6 +608,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -629,6 +632,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2269,6 +2273,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2525,6 +2530,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3500,7 +3506,8 @@
       "version": "0.24.8",
       "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
       "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/graphology-utils": {
       "version": "2.5.2",
@@ -5342,6 +5349,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5496,6 +5504,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5508,6 +5517,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5834,6 +5844,7 @@
       "resolved": "https://registry.npmjs.org/sigma/-/sigma-3.0.2.tgz",
       "integrity": "sha512-/BUbeOwPGruiBOm0YQQ6ZMcLIZ6tf/W+Jcm7dxZyAX0tK3WP9/sq7/NAWBxPIxVahdGjCJoGwej0Gdrv0DxlQQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "events": "^3.3.0",
         "graphology-utils": "^2.5.2"
@@ -6102,7 +6113,8 @@
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -6441,6 +6453,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6785,6 +6798,7 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },


### PR DESCRIPTION
This fixes #88 — the adaptive batch-splitting logic from #90 wasn't being used in the process_embedding_only_inner path.

PR #90 added embed_batch_adaptive with recursive batch halving for 400 errors, but only wired it into the bulk embedding path (embed_chunks_batched). The single-atom embedding path in process_embedding_only_inner still called generate_embeddings_with_config directly, bypassing the adaptive logic entirely. This meant providers with smaller batch limits (e.g. DashScope's max 10) still got a full batch of 30 and failed with a 400.

This change replaces the direct generate_embeddings_with_config call with embed_chunks_batched, so both embedding paths now share the same adaptive batching behavior.

Tested with DashScope text-embedding-v3 (batch limit: 10) — embeddings now succeed where they previously failed.