### PR TITLE
fix(chat): UTF-8-safe conversation preview truncation

### DIFF
--- a/crates/atomic-core/src/chat.rs
+++ b/crates/atomic-core/src/chat.rs
@@ -12,6 +12,20 @@ use rusqlite::Connection;
 
 // ==================== Helper Functions ====================
 
+/// Truncate a string to at most `max_chars` characters, appending `...` if truncated.
+///
+/// Operates on character boundaries (not bytes) so it is safe for any UTF-8 input,
+/// including multi-byte scripts like Cyrillic, CJK, or emoji.
+pub(crate) fn truncate_preview(s: &str, max_chars: usize) -> String {
+    let mut iter = s.chars();
+    let head: String = iter.by_ref().take(max_chars).collect();
+    if iter.next().is_some() {
+        format!("{}...", head)
+    } else {
+        head
+    }
+}
+
 /// Get tags for a conversation
 pub fn get_conversation_tags(
     conn: &Connection,
@@ -59,11 +73,7 @@ pub fn get_conversation_summary(
             [conversation_id],
             |row| {
                 let content: String = row.get(0)?;
-                Ok(if content.len() > 100 {
-                    { let mut e = 100; while e > 0 && !content.is_char_boundary(e) { e -= 1; } format!("{}...", &content[..e]) }
-                } else {
-                    content
-                })
+                Ok(truncate_preview(&content, 100))
             },
         )
         .ok();
@@ -339,11 +349,7 @@ fn batch_fetch_conversation_summaries(
     })?;
     for row in preview_rows {
         let (conv_id, content) = row?;
-        let preview = if content.len() > 100 {
-            format!("{}...", &content[..100])
-        } else {
-            content
-        };
+        let preview = truncate_preview(&content, 100);
         map.entry(conv_id).or_insert((0, None)).1 = Some(preview);
     }
 
@@ -1021,6 +1027,63 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result.tags.len(), 2);
+    }
+
+    #[test]
+    fn test_truncate_preview_utf8_safe() {
+        // ASCII shorter than limit — returned as-is
+        assert_eq!(truncate_preview("hello", 100), "hello");
+
+        // ASCII longer than limit — truncated with ellipsis
+        let long_ascii = "a".repeat(150);
+        let truncated = truncate_preview(&long_ascii, 100);
+        assert_eq!(truncated.len(), 103); // 100 'a' + "..."
+        assert!(truncated.ends_with("..."));
+
+        // Cyrillic that would panic with byte slicing at 100 — must not panic
+        // and must return a valid UTF-8 string.
+        let cyrillic = "Это пример длинного текста на русском языке, который содержит только обычные кириллические символы и несколько предложений подряд. Он нужен только для воспроизведения ошибки.";
+        let preview = truncate_preview(cyrillic, 100);
+        assert!(preview.ends_with("..."));
+        assert_eq!(preview.chars().count(), 103); // 100 chars + "..."
+
+        // Emoji (4-byte UTF-8) — must not panic
+        let emoji = "😀".repeat(150);
+        let preview = truncate_preview(&emoji, 100);
+        assert!(preview.ends_with("..."));
+        assert_eq!(preview.chars().count(), 103);
+    }
+
+    #[test]
+    fn test_get_conversations_with_cyrillic_message() {
+        // Regression test for crash on /api/conversations when an assistant message
+        // contains long Cyrillic text. The batch summary path used to byte-slice the
+        // message content at index 100, which falls inside a multi-byte UTF-8
+        // character and panicked.
+        let (db, _temp) = setup_db();
+        let conn = db.conn.lock().unwrap();
+
+        let conv = create_conversation(&conn, &[], Some("Russian chat")).unwrap();
+        save_message(&conn, &conv.conversation.id, "user", "Привет").unwrap();
+        save_message(
+            &conn,
+            &conv.conversation.id,
+            "assistant",
+            "Это пример длинного текста на русском языке, который содержит только обычные кириллические символы и несколько предложений подряд. Он нужен только для воспроизведения ошибки в обработке preview строки. Если система пытается обрезать такой текст по байтам, а не по корректной UTF-8 границе символа, сервер падает при загрузке списка разговоров.",
+        )
+        .unwrap();
+
+        // Must not panic.
+        let conversations = get_conversations(&conn, None, 10, 0).unwrap();
+        assert_eq!(conversations.len(), 1);
+        let preview = conversations[0]
+            .last_message_preview
+            .as_ref()
+            .expect("preview should be set");
+        assert!(preview.ends_with("..."));
+        // Preview must be valid UTF-8 (it is by Rust type guarantee, but assert
+        // it parses cleanly as Cyrillic content).
+        assert!(preview.starts_with("Это пример"));
     }
 
     #[test]

--- a/crates/atomic-core/src/storage/postgres/chat.rs
+++ b/crates/atomic-core/src/storage/postgres/chat.rs
@@ -1,4 +1,5 @@
 use super::PostgresStorage;
+use crate::chat::truncate_preview;
 use crate::error::AtomicCoreError;
 use crate::models::*;
 use crate::storage::traits::*;
@@ -64,13 +65,7 @@ async fn fetch_conversation_summary(
     .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?
     .flatten();
 
-    let preview = last_message_preview.map(|content| {
-        if content.len() > 100 {
-            { let mut e = 100; while e > 0 && !content.is_char_boundary(e) { e -= 1; } format!("{}...", &content[..e]) }
-        } else {
-            content
-        }
-    });
+    let preview = last_message_preview.map(|content| truncate_preview(&content, 100));
 
     Ok((message_count as i32, preview))
 }
@@ -195,11 +190,7 @@ async fn batch_fetch_conversation_summaries(
     .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
     for (conv_id, content) in preview_rows {
-        let preview = if content.len() > 100 {
-            { let mut e = 100; while e > 0 && !content.is_char_boundary(e) { e -= 1; } format!("{}...", &content[..e]) }
-        } else {
-            content
-        };
+        let preview = truncate_preview(&content, 100);
         map.entry(conv_id).or_insert((0, None)).1 = Some(preview);
     }
 

--- a/crates/atomic-core/src/wiki/mod.rs
+++ b/crates/atomic-core/src/wiki/mod.rs
@@ -655,10 +655,14 @@ pub(crate) async fn call_llm_for_wiki_typed<T: DeserializeOwned>(
                     Err(parse_err) => {
                         // Log the parse failure with enough context to debug, but don't retry —
                         // the same prompt will produce the same unparseable output.
-                        let preview = if content.len() > 500 {
-                            format!("{}...[truncated]", &content[..500])
-                        } else {
-                            content.clone()
+                        let preview = {
+                            let mut iter = content.chars();
+                            let head: String = iter.by_ref().take(500).collect();
+                            if iter.next().is_some() {
+                                format!("{}...[truncated]", head)
+                            } else {
+                                head
+                            }
                         };
                         tracing::error!(error = %parse_err, preview = %preview, "[wiki] Failed to parse LLM response as JSON");
                         return Err(format!("Failed to parse wiki result: {}", parse_err));


### PR DESCRIPTION
The batch path used by /api/conversations byte-sliced message content at index 100, panicking on multi-byte UTF-8 (Cyrillic, CJK, emoji) and crashing the server while loading the conversations list.

Replace the byte-slice and the duplicated inline char-boundary workaround with a single `truncate_preview` helper that truncates by character count. Apply it across all conversation summary paths (sqlite + postgres) and fix the same byte-slice in the wiki LLM-parse error logger.

Adds regression tests covering ASCII, Cyrillic, and emoji input plus an end-to-end test that exercises get_conversations with the exact long Cyrillic message from the bug report.