### PR TITLE
Fix mobile layout and skip onboarding for configured servers

### DIFF
--- a/src/components/atoms/FilterSheet.tsx
+++ b/src/components/atoms/FilterSheet.tsx
@@ -1,0 +1,214 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { useAtomsStore, SourceFilterType, SortField, SortOrder } from '../../stores/atoms';
+import { useUIStore, ViewMode } from '../../stores/ui';
+
+interface FilterSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  displayCount: number;
+}
+
+const SORT_OPTIONS: { field: SortField; order: SortOrder; label: string }[] = [
+  { field: 'updated', order: 'desc', label: 'Updated (newest)' },
+  { field: 'updated', order: 'asc', label: 'Updated (oldest)' },
+  { field: 'created', order: 'desc', label: 'Created (newest)' },
+  { field: 'created', order: 'asc', label: 'Created (oldest)' },
+  { field: 'published', order: 'desc', label: 'Published (newest)' },
+  { field: 'published', order: 'asc', label: 'Published (oldest)' },
+  { field: 'title', order: 'asc', label: 'Title (A-Z)' },
+  { field: 'title', order: 'desc', label: 'Title (Z-A)' },
+];
+
+const VIEW_MODES: { id: ViewMode; label: string }[] = [
+  { id: 'grid', label: 'Grid' },
+  { id: 'list', label: 'List' },
+  { id: 'canvas', label: 'Canvas' },
+  { id: 'wiki', label: 'Wiki' },
+];
+
+export function FilterSheet({ isOpen, onClose, displayCount }: FilterSheetProps) {
+  const viewMode = useUIStore(s => s.viewMode);
+  const setViewMode = useUIStore(s => s.setViewMode);
+
+  const sourceFilter = useAtomsStore(s => s.sourceFilter);
+  const sourceValue = useAtomsStore(s => s.sourceValue);
+  const sortBy = useAtomsStore(s => s.sortBy);
+  const sortOrder = useAtomsStore(s => s.sortOrder);
+  const availableSources = useAtomsStore(s => s.availableSources);
+  const setSourceFilter = useAtomsStore(s => s.setSourceFilter);
+  const setSourceValue = useAtomsStore(s => s.setSourceValue);
+  const setSortBy = useAtomsStore(s => s.setSortBy);
+  const setSortOrder = useAtomsStore(s => s.setSortOrder);
+  const fetchSources = useAtomsStore(s => s.fetchSources);
+
+  useEffect(() => {
+    if (isOpen) fetchSources();
+  }, [isOpen, fetchSources]);
+
+  // Lock body scroll while the sheet is open
+  useEffect(() => {
+    if (!isOpen) return;
+    const original = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = original; };
+  }, [isOpen]);
+
+  const handleSortChange = (field: SortField, order: SortOrder) => {
+    setSortBy(field);
+    setSortOrder(order);
+  };
+
+  return createPortal(
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 bg-black/50 z-40 transition-opacity duration-200 ${
+          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={onClose}
+      />
+
+      {/* Sheet */}
+      <div
+        className={`fixed inset-x-0 bottom-0 z-50 bg-[var(--color-bg-panel)] border-t border-[var(--color-border)] rounded-t-2xl shadow-2xl max-h-[85vh] flex flex-col transition-transform duration-300 ease-out ${
+          isOpen ? 'translate-y-0' : 'translate-y-full'
+        }`}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Filter and sort"
+      >
+        {/* Drag handle */}
+        <div className="flex justify-center pt-2 pb-1 shrink-0">
+          <div className="w-10 h-1 rounded-full bg-[var(--color-border)]" />
+        </div>
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--color-border)] shrink-0">
+          <div>
+            <h2 className="text-base font-semibold text-[var(--color-text-primary)]">
+              View & filter
+            </h2>
+            <p className="text-xs text-[var(--color-text-secondary)]">
+              {displayCount} atom{displayCount !== 1 ? 's' : ''}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-6">
+          {/* View mode */}
+          <section>
+            <h3 className="text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)] mb-2">
+              View
+            </h3>
+            <div className="grid grid-cols-4 gap-2">
+              {VIEW_MODES.map(vm => (
+                <button
+                  key={vm.id}
+                  onClick={() => setViewMode(vm.id)}
+                  className={`py-2 px-3 rounded-md text-sm transition-colors border ${
+                    viewMode === vm.id
+                      ? 'bg-[var(--color-accent)] text-white border-[var(--color-accent)]'
+                      : 'bg-[var(--color-bg-card)] text-[var(--color-text-primary)] border-[var(--color-border)] hover:bg-[var(--color-bg-hover)]'
+                  }`}
+                >
+                  {vm.label}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          {/* Source filter */}
+          <section>
+            <h3 className="text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)] mb-2">
+              Source
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {(['all', 'manual', 'external'] as SourceFilterType[]).map(f => (
+                <button
+                  key={f}
+                  onClick={() => { setSourceFilter(f); if (f !== 'external') setSourceValue(null); }}
+                  className={`py-1.5 px-3 rounded-full text-sm transition-colors border ${
+                    sourceFilter === f && !sourceValue
+                      ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent-light)] border-[var(--color-accent)]/40'
+                      : 'bg-[var(--color-bg-card)] text-[var(--color-text-primary)] border-[var(--color-border)] hover:bg-[var(--color-bg-hover)]'
+                  }`}
+                >
+                  {f === 'all' ? 'All' : f === 'manual' ? 'Manual' : 'External'}
+                </button>
+              ))}
+            </div>
+
+            {availableSources.length > 0 && (
+              <div className="mt-3">
+                <div className="text-xs text-[var(--color-text-tertiary)] mb-1.5">
+                  Specific source
+                </div>
+                <div className="flex flex-wrap gap-1.5 max-h-40 overflow-y-auto">
+                  {availableSources.map(s => (
+                    <button
+                      key={s.source}
+                      onClick={() => setSourceValue(sourceValue === s.source ? null : s.source)}
+                      className={`flex items-center gap-1 text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                        sourceValue === s.source
+                          ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent-light)] border-[var(--color-accent)]/40'
+                          : 'bg-[var(--color-bg-card)] text-[var(--color-text-primary)] border-[var(--color-border)] hover:bg-[var(--color-bg-hover)]'
+                      }`}
+                    >
+                      <span className="truncate max-w-[140px]">{s.source}</span>
+                      <span className="text-[var(--color-text-tertiary)]">{s.atom_count}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+
+          {/* Sort */}
+          <section>
+            <h3 className="text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)] mb-2">
+              Sort by
+            </h3>
+            <div className="flex flex-col divide-y divide-[var(--color-border)] border border-[var(--color-border)] rounded-md overflow-hidden bg-[var(--color-bg-card)]">
+              {SORT_OPTIONS.map(opt => {
+                const isActive = sortBy === opt.field && sortOrder === opt.order;
+                return (
+                  <button
+                    key={`${opt.field}-${opt.order}`}
+                    onClick={() => handleSortChange(opt.field, opt.order)}
+                    className={`flex items-center justify-between px-3 py-2.5 text-sm text-left transition-colors ${
+                      isActive
+                        ? 'text-[var(--color-accent-light)] bg-[var(--color-accent)]/10'
+                        : 'text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
+                    }`}
+                  >
+                    <span>{opt.label}</span>
+                    {isActive && (
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+
+        {/* Safe area padding for iOS home bar */}
+        <div className="shrink-0" style={{ height: 'env(safe-area-inset-bottom)' }} />
+      </div>
+    </>,
+    document.body,
+  );
+}

--- a/src/components/layout/LeftPanel.tsx
+++ b/src/components/layout/LeftPanel.tsx
@@ -52,11 +52,10 @@ export function LeftPanel() {
       <aside
         ref={panelRef}
         className={`
-          h-full bg-[var(--color-bg-panel)]/80 border-r border-[var(--color-border)] flex-col transition-all duration-300 ease-in-out backdrop-blur-xl z-10 overflow-hidden flex-shrink-0
+          h-full bg-[var(--color-bg-panel)]/80 border-r border-[var(--color-border)] flex flex-col transition-all duration-300 ease-in-out backdrop-blur-xl z-10 overflow-hidden flex-shrink-0
           max-md:fixed max-md:top-0 max-md:left-0 max-md:z-40 max-md:shadow-2xl max-md:w-[250px]
           ${leftPanelOpen ? 'max-md:translate-x-0' : 'max-md:-translate-x-full'}
           ${leftPanelOpen ? 'md:w-[250px] md:border-r' : 'md:w-0 md:border-r-0'}
-          hidden md:flex
         `}
       >
         <div className="w-[250px] h-full flex flex-col">

--- a/src/components/layout/MainView.tsx
+++ b/src/components/layout/MainView.tsx
@@ -4,6 +4,7 @@ import { AtomGrid } from '../atoms/AtomGrid';
 import { AtomList } from '../atoms/AtomList';
 import { AtomReader } from '../atoms/AtomReader';
 import { FilterBar } from '../atoms/FilterBar';
+import { FilterSheet } from '../atoms/FilterSheet';
 import { SigmaCanvas } from '../canvas/SigmaCanvas';
 import { LocalGraphView } from '../canvas/LocalGraphView';
 import { FAB } from '../ui/FAB';
@@ -16,6 +17,7 @@ import { useAtomsStore } from '../../stores/atoms';
 import { useTagsStore } from '../../stores/tags';
 import { useUIStore } from '../../stores/ui';
 import { isTauri } from '../../lib/platform';
+import { useIsMobile } from '../../hooks';
 import { readerEditorActions } from '../../lib/reader-editor-bridge';
 
 export function MainView() {
@@ -66,7 +68,34 @@ export function MainView() {
   const [filterBarOpen, setFilterBarOpen] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [readerMenuOpen, setReaderMenuOpen] = useState(false);
+  const readerMenuRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
   const hasActiveFilter = sourceFilter !== 'all' || !!sourceValue || sortBy !== 'updated' || sortOrder !== 'desc';
+
+  // Close reader overflow menu on outside click / escape
+  useEffect(() => {
+    if (!readerMenuOpen) return;
+    const onClick = (e: MouseEvent) => {
+      if (readerMenuRef.current && !readerMenuRef.current.contains(e.target as Node)) {
+        setReaderMenuOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setReaderMenuOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [readerMenuOpen]);
+
+  // Auto-close the menu when the reader closes
+  useEffect(() => {
+    if (!readerState.atomId) setReaderMenuOpen(false);
+  }, [readerState.atomId]);
 
   // Debounced server-side search when searchQuery changes
   const searchTimerRef = useRef<ReturnType<typeof setTimeout>>();
@@ -283,8 +312,8 @@ export function MainView() {
 
             <div data-tauri-drag-region className="flex-1 h-full drag-region" />
 
-            {/* Action buttons for atom reader */}
-            {readerState.atomId && (
+            {/* Action buttons for atom reader — inline on desktop, overflow menu on mobile */}
+            {readerState.atomId && !isMobile && (
               <div className="flex items-center gap-1">
                 {/* Theme toggle */}
                 <button
@@ -338,10 +367,88 @@ export function MainView() {
               </div>
             )}
 
+            {/* Mobile reader overflow menu: edit is the primary inline action,
+                theme + delete hide behind a ⋯ button. */}
+            {readerState.atomId && isMobile && (
+              <div className="flex items-center gap-1">
+                {/* Edit / Done toggle (kept inline — primary action) */}
+                <button
+                  onClick={() => readerState.editing
+                    ? readerEditorActions.current?.stopEditing()
+                    : readerEditorActions.current?.startEditing(0)
+                  }
+                  className={`p-1.5 rounded-md transition-colors ${
+                    readerState.editing
+                      ? 'text-[var(--color-accent)] hover:bg-[var(--color-accent)]/20'
+                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
+                  }`}
+                  title={readerState.editing ? 'Done (Esc)' : 'Edit'}
+                >
+                  {readerState.editing ? (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
+                  )}
+                </button>
+
+                {/* Overflow menu */}
+                <div className="relative" ref={readerMenuRef}>
+                  <button
+                    onClick={() => setReaderMenuOpen(v => !v)}
+                    className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
+                    title="More actions"
+                    aria-haspopup="menu"
+                    aria-expanded={readerMenuOpen}
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <circle cx="5" cy="12" r="1.5" fill="currentColor" />
+                      <circle cx="12" cy="12" r="1.5" fill="currentColor" />
+                      <circle cx="19" cy="12" r="1.5" fill="currentColor" />
+                    </svg>
+                  </button>
+                  {readerMenuOpen && (
+                    <div
+                      role="menu"
+                      className="absolute top-full right-0 mt-1 w-48 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-md shadow-lg z-50 overflow-hidden"
+                    >
+                      <button
+                        role="menuitem"
+                        onClick={() => { toggleReaderTheme(); setReaderMenuOpen(false); }}
+                        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          {readerTheme === 'dark' ? (
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                          ) : (
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                          )}
+                        </svg>
+                        {readerTheme === 'dark' ? 'Light mode' : 'Dark mode'}
+                      </button>
+                      <button
+                        role="menuitem"
+                        onClick={() => { setShowDeleteModal(true); setReaderMenuOpen(false); }}
+                        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left text-red-400 hover:bg-[var(--color-bg-hover)] transition-colors"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                        Delete
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
             {/* Chat sidebar toggle */}
             <button
               onClick={handleOpenChat}
-              className={`hidden md:block p-1.5 rounded-md transition-colors ${
+              className={`p-1.5 rounded-md transition-colors ${
                 chatSidebarOpen
                   ? 'text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
                   : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
@@ -356,66 +463,68 @@ export function MainView() {
         ) : (
           /* Normal browsing titlebar */
           <>
-            {/* View Mode Toggle */}
-            <div className="flex items-center bg-[var(--color-bg-card)] rounded-md border border-[var(--color-border)] shrink-0">
-              <button
-                onClick={() => setViewMode('grid')}
-                className={`p-1.5 rounded-l-md transition-colors ${
-                  viewMode === 'grid'
-                    ? 'bg-[var(--color-accent)] text-white'
-                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-                }`}
-                title="Grid view"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-                </svg>
-              </button>
-              <button
-                onClick={() => setViewMode('list')}
-                className={`p-1.5 transition-colors ${
-                  viewMode === 'list'
-                    ? 'bg-[var(--color-accent)] text-white'
-                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-                }`}
-                title="List view"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-              </button>
-              <button
-                onClick={() => setViewMode('canvas')}
-                className={`p-1.5 transition-colors ${
-                  viewMode === 'canvas'
-                    ? 'bg-[var(--color-accent)] text-white'
-                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-                }`}
-                title="Canvas view"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                  <circle cx="6" cy="6" r="2" />
-                  <circle cx="18" cy="6" r="2" />
-                  <circle cx="6" cy="18" r="2" />
-                  <circle cx="18" cy="18" r="2" />
-                  <circle cx="12" cy="12" r="2" />
-                  <path strokeLinecap="round" d="M8 7l2.5 3.5M16 7l-2.5 3.5M8 17l2.5-3.5M16 17l-2.5-3.5" />
-                </svg>
-              </button>
-              <button
-                onClick={() => setViewMode('wiki')}
-                className={`p-1.5 rounded-r-md transition-colors ${
-                  viewMode === 'wiki'
-                    ? 'bg-[var(--color-accent)] text-white'
-                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-                }`}
-                title="Wiki view"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                </svg>
-              </button>
-            </div>
+            {/* View Mode Toggle — desktop only; mobile accesses view mode via the filter sheet */}
+            {!isMobile && (
+              <div className="flex items-center bg-[var(--color-bg-card)] rounded-md border border-[var(--color-border)] shrink-0">
+                <button
+                  onClick={() => setViewMode('grid')}
+                  className={`p-1.5 rounded-l-md transition-colors ${
+                    viewMode === 'grid'
+                      ? 'bg-[var(--color-accent)] text-white'
+                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                  }`}
+                  title="Grid view"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+                  </svg>
+                </button>
+                <button
+                  onClick={() => setViewMode('list')}
+                  className={`p-1.5 transition-colors ${
+                    viewMode === 'list'
+                      ? 'bg-[var(--color-accent)] text-white'
+                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                  }`}
+                  title="List view"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                  </svg>
+                </button>
+                <button
+                  onClick={() => setViewMode('canvas')}
+                  className={`p-1.5 transition-colors ${
+                    viewMode === 'canvas'
+                      ? 'bg-[var(--color-accent)] text-white'
+                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                  }`}
+                  title="Canvas view"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                    <circle cx="6" cy="6" r="2" />
+                    <circle cx="18" cy="6" r="2" />
+                    <circle cx="6" cy="18" r="2" />
+                    <circle cx="18" cy="18" r="2" />
+                    <circle cx="12" cy="12" r="2" />
+                    <path strokeLinecap="round" d="M8 7l2.5 3.5M16 7l-2.5 3.5M8 17l2.5-3.5M16 17l-2.5-3.5" />
+                  </svg>
+                </button>
+                <button
+                  onClick={() => setViewMode('wiki')}
+                  className={`p-1.5 rounded-r-md transition-colors ${
+                    viewMode === 'wiki'
+                      ? 'bg-[var(--color-accent)] text-white'
+                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                  }`}
+                  title="Wiki view"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+                  </svg>
+                </button>
+              </div>
+            )}
 
             {/* Search button */}
             <button
@@ -430,8 +539,9 @@ export function MainView() {
 
             <div data-tauri-drag-region className="flex-1 h-full drag-region" />
 
-            {/* Filter toggle + atom count — right-aligned, hide for canvas/wiki */}
-            {viewMode !== 'canvas' && viewMode !== 'wiki' && (
+            {/* Filter toggle + atom count — right-aligned. On mobile, always show the
+                filter button (it opens the filter sheet which hosts view mode too). */}
+            {(isMobile || (viewMode !== 'canvas' && viewMode !== 'wiki')) && (
               <div className="flex items-center gap-2 shrink-0">
                 <button
                   onClick={() => setFilterBarOpen(!filterBarOpen)}
@@ -449,16 +559,18 @@ export function MainView() {
                     <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 bg-[var(--color-accent)] rounded-full" />
                   )}
                 </button>
-                <span className="text-sm text-[var(--color-text-secondary)]">
-                  {displayCount} atom{displayCount !== 1 ? 's' : ''}
-                </span>
+                {!isMobile && (
+                  <span className="text-sm text-[var(--color-text-secondary)]">
+                    {displayCount} atom{displayCount !== 1 ? 's' : ''}
+                  </span>
+                )}
               </div>
             )}
 
             {/* Chat sidebar toggle — right-aligned */}
             <button
               onClick={handleOpenChat}
-              className={`hidden md:block p-1.5 rounded-md transition-colors ${
+              className={`p-1.5 rounded-md transition-colors ${
                 chatSidebarOpen
                   ? 'text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
                   : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
@@ -486,8 +598,17 @@ export function MainView() {
         </div>
       )}
 
-      {/* Filter bar - visible for grid/list views when toggled open */}
-      {!isSemanticSearch && viewMode !== 'canvas' && viewMode !== 'wiki' && filterBarOpen && <FilterBar />}
+      {/* Filter bar — desktop inline strip, grid/list views only */}
+      {!isMobile && !isSemanticSearch && viewMode !== 'canvas' && viewMode !== 'wiki' && filterBarOpen && <FilterBar />}
+
+      {/* Filter sheet — mobile bottom sheet hosts view mode + filter + sort */}
+      {isMobile && (
+        <FilterSheet
+          isOpen={filterBarOpen}
+          onClose={() => setFilterBarOpen(false)}
+          displayCount={displayCount}
+        />
+      )}
 
       {/* Content */}
       <div className="flex-1 overflow-hidden relative">
@@ -558,13 +679,27 @@ export function MainView() {
       </Modal>
     </main>
 
-    {/* Chat sidebar — available in all views */}
+    {/* Chat sidebar backdrop — mobile only */}
     <div
-      className={`hidden md:block flex-shrink-0 border-l border-[var(--color-border)] overflow-hidden bg-[var(--color-bg-panel)] transition-[width] duration-300 ease-in-out ${
-        chatSidebarOpen ? 'w-96' : 'w-0 border-l-0'
+      className={`fixed inset-0 bg-black/40 z-30 md:hidden transition-opacity duration-200 ${
+        chatSidebarOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
       }`}
+      onClick={() => chatSidebarOpen && toggleChatSidebar()}
+    />
+
+    {/* Chat sidebar — available in all views.
+        Desktop: flex sibling that animates width.
+        Mobile: fixed overlay that slides in from the right. */}
+    <div
+      className={`
+        flex-shrink-0 border-l border-[var(--color-border)] bg-[var(--color-bg-panel)] overflow-hidden
+        max-md:fixed max-md:top-0 max-md:right-0 max-md:h-full max-md:w-full max-md:z-40 max-md:shadow-2xl
+        transition-[width,transform] duration-300 ease-in-out
+        ${chatSidebarOpen ? 'max-md:translate-x-0' : 'max-md:translate-x-full'}
+        ${chatSidebarOpen ? 'md:w-96' : 'md:w-0 md:border-l-0'}
+      `}
     >
-      <div className="w-96 h-full">
+      <div className="w-full md:w-96 h-full">
         <ChatViewer />
       </div>
     </div>

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -131,7 +131,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   const renderStep = () => {
     switch (currentStepDef.id) {
       case 'welcome':
-        return <WelcomeStep state={state} dispatch={dispatch} onNext={handleNext} />;
+        return <WelcomeStep state={state} dispatch={dispatch} onNext={handleNext} onComplete={onComplete} />;
       case 'ai-provider':
         return <AIProviderStep state={state} dispatch={dispatch} />;
       case 'integrations':

--- a/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/src/components/onboarding/steps/WelcomeStep.tsx
@@ -1,17 +1,19 @@
 import { useState, useEffect } from 'react';
 import { Button } from '../../ui/Button';
 import { isDesktopApp, getTransport, switchTransport } from '../../../lib/transport';
+import { verifyProviderConfigured } from '../../../lib/api';
 import type { OnboardingState, OnboardingAction } from '../useOnboardingState';
 
 interface WelcomeStepProps {
   state: OnboardingState;
   dispatch: React.Dispatch<OnboardingAction>;
   onNext: () => void;
+  onComplete: () => void;
 }
 
 type SetupMode = 'checking' | 'claim' | 'manual';
 
-export function WelcomeStep({ state, dispatch, onNext }: WelcomeStepProps) {
+export function WelcomeStep({ state, dispatch, onNext, onComplete }: WelcomeStepProps) {
   const isDesktop = isDesktopApp();
   const [setupMode, setSetupMode] = useState<SetupMode>('checking');
   const [isClaiming, setIsClaiming] = useState(false);
@@ -92,6 +94,22 @@ export function WelcomeStep({ state, dispatch, onNext }: WelcomeStepProps) {
         baseUrl: state.serverUrl.trim().replace(/\/$/, ''),
         authToken: state.serverToken.trim(),
       });
+      // If the server is already fully set up, skip the rest of the
+      // onboarding wizard and drop the user straight into the app.
+      try {
+        const configured = await verifyProviderConfigured();
+        if (configured) {
+          onComplete();
+          return;
+        }
+      } catch (e) {
+        dispatch({
+          type: 'SET_SERVER_TEST',
+          result: 'error',
+          error: String(e instanceof Error ? e.message : e),
+        });
+        return;
+      }
       onNext();
     } catch (e) {
       dispatch({ type: 'SET_SERVER_TEST', result: 'error', error: String(e) });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useTheme } from './useTheme';
 export { useFont } from './useFont';
 export { useContentSearch } from './useContentSearch';
 export { useInlineEditor } from './useInlineEditor';
+export { useIsMobile } from './useIsMobile';

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+// Matches Tailwind's default `md:` breakpoint. Anything narrower is considered mobile.
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`).matches;
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
- Skip the onboarding wizard when logging into an already-configured server: WelcomeStep re-checks verify_provider_configured after a successful manual connect and calls onComplete directly.
- Fix left sidebar on mobile: it had full mobile slide-in styling but hidden md:flex clobbered it, so the panel was display:none below 768px. Now flex always, slides via translate-x.
- Show chat toggle on mobile in both browse and reader titlebars (was hidden md:block on both buttons and the sidebar itself).
- Turn the chat sidebar into a fixed, full-width overlay on mobile with a click-to-dismiss backdrop; desktop keeps the flex-sibling width animation.
- Introduce useIsMobile hook and a FilterSheet bottom-sheet so the mobile titlebar can drop the 4-way view toggle and inline count. Filter button opens a sheet hosting view mode, source filter, sort and the atom count; desktop retains the inline FilterBar strip.
- Collapse reader titlebar actions on mobile: edit stays inline, theme + delete move behind a ⋯ overflow menu with outside-click and Escape handling.