### PR TITLE
Cache global canvas payload with debounced rebuild

### DIFF
--- a/crates/atomic-core/src/embedding.rs
+++ b/crates/atomic-core/src/embedding.rs
@@ -11,6 +11,7 @@ use crate::extraction::extract_tags_from_content;
 use crate::providers::traits::EmbeddingConfig;
 use crate::providers::{get_embedding_provider, get_model_capabilities, ProviderConfig, ProviderType};
 use crate::storage::StorageBackend;
+use crate::CanvasCache;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -796,10 +797,11 @@ pub async fn process_embedding_batch<F>(
     input: AtomInput,
     skip_tagging: bool,
     on_event: F,
+    canvas_cache: Option<CanvasCache>,
 ) where
     F: Fn(EmbeddingEvent) + Send + Sync + Clone + 'static,
 {
-    process_embedding_batch_inner(storage, input, skip_tagging, on_event, None).await
+    process_embedding_batch_inner(storage, input, skip_tagging, on_event, None, canvas_cache).await
 }
 
 /// Process embedding batch with externally-provided settings (from registry).
@@ -809,10 +811,11 @@ pub async fn process_embedding_batch_with_settings<F>(
     skip_tagging: bool,
     on_event: F,
     settings_map: HashMap<String, String>,
+    canvas_cache: Option<CanvasCache>,
 ) where
     F: Fn(EmbeddingEvent) + Send + Sync + Clone + 'static,
 {
-    process_embedding_batch_inner(storage, input, skip_tagging, on_event, Some(settings_map)).await
+    process_embedding_batch_inner(storage, input, skip_tagging, on_event, Some(settings_map), canvas_cache).await
 }
 
 async fn process_embedding_batch_inner<F>(
@@ -821,6 +824,7 @@ async fn process_embedding_batch_inner<F>(
     skip_tagging: bool,
     on_event: F,
     external_settings: Option<HashMap<String, String>>,
+    canvas_cache: Option<CanvasCache>,
 ) where
     F: Fn(EmbeddingEvent) + Send + Sync + Clone + 'static,
 {
@@ -1190,7 +1194,7 @@ async fn process_embedding_batch_inner<F>(
 
     // === Kick off edge computation in the background ===
     if !completed_atom_ids.is_empty() {
-        match process_pending_edges(storage) {
+        match process_pending_edges(storage, canvas_cache) {
             Ok(count) if count > 0 => tracing::info!(count, "Started background edge computation"),
             Ok(_) => {}
             Err(e) => tracing::warn!(error = %e, "Failed to start edge computation"),
@@ -1374,11 +1378,12 @@ pub fn compute_semantic_edges_for_atom(
 pub fn process_pending_embeddings<F>(
     storage: StorageBackend,
     on_event: F,
+    canvas_cache: Option<CanvasCache>,
 ) -> Result<i32, String>
 where
     F: Fn(EmbeddingEvent) + Send + Sync + Clone + 'static,
 {
-    process_pending_embeddings_inner(storage, on_event, None)
+    process_pending_embeddings_inner(storage, on_event, None, canvas_cache)
 }
 
 /// Process pending embeddings with externally-provided settings (from registry).
@@ -1386,11 +1391,12 @@ pub fn process_pending_embeddings_with_settings<F>(
     storage: StorageBackend,
     on_event: F,
     settings_map: HashMap<String, String>,
+    canvas_cache: Option<CanvasCache>,
 ) -> Result<i32, String>
 where
     F: Fn(EmbeddingEvent) + Send + Sync + Clone + 'static,
 {
-    process_pending_embeddings_inner(storage, on_event, Some(settings_map))
+    process_pending_embeddings_inner(storage, on_event, Some(settings_map), canvas_cache)
 }
 
 /// Max atoms to process per background embedding batch (limits memory usage).
@@ -1400,6 +1406,7 @@ fn process_pending_embeddings_inner<F>(
     storage: StorageBackend,
     on_event: F,
     external_settings: Option<HashMap<String, String>>,
+    canvas_cache: Option<CanvasCache>,
 ) -> Result<i32, String>
 where
     F: Fn(EmbeddingEvent) + Send + Sync + Clone + 'static,
@@ -1421,6 +1428,7 @@ where
         let storage = storage.clone();
         let on_event = on_event.clone();
         let settings = external_settings.clone();
+        let canvas_cache = canvas_cache.clone();
 
         crate::executor::spawn(async move {
             // Limit concurrent batch tasks to bound memory
@@ -1437,12 +1445,14 @@ where
                     false,
                     on_event,
                     s,
+                    canvas_cache,
                 ).await,
                 None => process_embedding_batch(
                     storage,
                     input,
                     false,
                     on_event,
+                    canvas_cache,
                 ).await,
             };
         });
@@ -1720,7 +1730,10 @@ const EDGE_BATCH_SIZE: i32 = 500;
 /// Claims atoms in batches, computes edges in a single transaction, marks them
 /// complete, and repeats. Each batch is checkpointed so progress survives restarts.
 /// Returns the total number of atoms processed.
-pub fn process_pending_edges(storage: StorageBackend) -> Result<i32, String> {
+pub fn process_pending_edges(
+    storage: StorageBackend,
+    canvas_cache: Option<CanvasCache>,
+) -> Result<i32, String> {
     let pending_count = storage.count_pending_edges_sync()
         .map_err(|e| e.to_string())?;
 
@@ -1762,6 +1775,13 @@ pub fn process_pending_edges(storage: StorageBackend) -> Result<i32, String> {
             if let Err(e) = storage_clone.set_edges_status_batch_sync(&batch, "complete") {
                 tracing::error!(error = %e, "Failed to mark edges as complete");
                 break;
+            }
+
+            // Schedule a debounced canvas rebuild so subsequent reads pick
+            // up the new edges without thrashing when many batches land in
+            // quick succession — successive calls collapse into one rebuild.
+            if let Some(cache) = &canvas_cache {
+                cache.invalidate_debounced();
             }
 
             total_processed += batch_size;

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -127,6 +127,10 @@ struct CanvasCacheInner {
     data: std::sync::RwLock<Option<Arc<GlobalCanvasData>>>,
     rebuild_gen: std::sync::atomic::AtomicU64,
     rebuilder: std::sync::OnceLock<CanvasRebuilder>,
+    /// Serializes concurrent cold-cache computes so N simultaneous misses
+    /// don't all pay the full PCA + edge-load cost. Paired with a
+    /// double-checked read of `data` on either side of the lock acquire.
+    compute_lock: std::sync::Mutex<()>,
 }
 
 impl CanvasCache {
@@ -160,6 +164,16 @@ impl CanvasCache {
     /// First call wins (backed by `OnceLock`); subsequent calls are no-ops.
     pub(crate) fn set_rebuilder(&self, rebuilder: CanvasRebuilder) {
         let _ = self.inner.rebuilder.set(rebuilder);
+    }
+
+    /// Acquire the compute guard used by [`AtomicCore::compute_and_get_canvas_data`]
+    /// to serialize cold-cache rebuilds. The caller double-checks the cache
+    /// after acquiring so only the first waiter pays the compute cost.
+    pub(crate) fn compute_guard(&self) -> Result<std::sync::MutexGuard<'_, ()>, AtomicCoreError> {
+        self.inner
+            .compute_lock
+            .lock()
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))
     }
 
     /// Debounced invalidation: schedule a background rebuild after
@@ -1698,8 +1712,18 @@ impl AtomicCore {
     /// Works with both SQLite and Postgres backends via storage dispatch.
     ///
     /// Results are memoized via `canvas_cache`; subsequent calls return the
-    /// cached `Arc` until a mutation invalidates it.
+    /// cached `Arc` until a mutation invalidates it. Cold-cache rebuilds are
+    /// serialized by a compute guard so N simultaneous misses collapse into
+    /// one compute (the first waiter runs it; the rest re-read the cache).
     pub fn compute_and_get_canvas_data(&self) -> Result<Arc<GlobalCanvasData>, AtomicCoreError> {
+        if let Some(cached) = self.canvas_cache.get() {
+            return Ok(cached);
+        }
+        // Serialize the first compute so concurrent misses don't all pay the
+        // full PCA + edge-load cost. Double-checked after acquiring the
+        // guard — if another waiter already populated the cache while we
+        // blocked, use theirs.
+        let _guard = self.canvas_cache.compute_guard()?;
         if let Some(cached) = self.canvas_cache.get() {
             return Ok(cached);
         }
@@ -1872,7 +1896,14 @@ impl AtomicCore {
         self.storage.get_atom_neighborhood_sync(atom_id, depth, min_similarity)
     }
 
-    /// Rebuild semantic edges for all atoms with embeddings
+    /// Rebuild semantic edges for all atoms with embeddings.
+    ///
+    /// Returns the number of atoms **queued** for edge recomputation, not
+    /// the number of edges written. This call returns as soon as the edge
+    /// pipeline is spawned — actual edge computation runs in the background
+    /// and completes asynchronously. Callers watching for completion should
+    /// subscribe to pipeline events rather than treating the return value
+    /// as a completion signal.
     pub fn rebuild_semantic_edges(&self) -> Result<i32, AtomicCoreError> {
         let count = self.storage.rebuild_semantic_edges_sync()?;
         self.canvas_cache.invalidate();

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -92,6 +92,119 @@ pub struct UpdateAtomRequest {
     pub tag_ids: Option<Vec<String>>,
 }
 
+/// Rebuilder closure registered by `AtomicCore` so the cache can recompute
+/// itself in the background during debounced invalidations. Captures
+/// `StorageBackend` only (not `AtomicCore`) to avoid a reference cycle.
+type CanvasRebuilder = Box<dyn Fn() -> Result<Arc<GlobalCanvasData>, AtomicCoreError> + Send + Sync + 'static>;
+
+/// How long `invalidate_debounced` waits after the last invalidation before
+/// kicking off a background rebuild. Sized so that bulk-event storms (e.g.
+/// a 100-atom embedding batch) collapse into a single rebuild.
+const CANVAS_CACHE_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// In-memory cache for the global canvas payload.
+///
+/// `compute_and_get_canvas_data` is expensive: it runs PCA on every atom
+/// embedding, materializes metadata + edges, and re-clusters from scratch.
+/// The cache holds the last computed `GlobalCanvasData` behind an `Arc` so
+/// subsequent reads are a lock-free-ish pointer clone.
+///
+/// Two invalidation flavors:
+/// - `invalidate()` — eager clear for direct user mutations. Next read pays
+///   full compute cost.
+/// - `invalidate_debounced()` — keeps the stale payload visible and spawns
+///   a background rebuild after [`CANVAS_CACHE_DEBOUNCE`]. Only the latest
+///   request wins (via a generation counter), so bursts of background events
+///   coalesce into a single rebuild. Used by the batch embedding and edge
+///   pipelines so streaming updates don't thrash the cache.
+#[derive(Clone, Default)]
+pub struct CanvasCache {
+    inner: Arc<CanvasCacheInner>,
+}
+
+#[derive(Default)]
+struct CanvasCacheInner {
+    data: std::sync::RwLock<Option<Arc<GlobalCanvasData>>>,
+    rebuild_gen: std::sync::atomic::AtomicU64,
+    rebuilder: std::sync::OnceLock<CanvasRebuilder>,
+}
+
+impl CanvasCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the cached payload if present.
+    pub fn get(&self) -> Option<Arc<GlobalCanvasData>> {
+        self.inner.data.read().ok().and_then(|g| g.clone())
+    }
+
+    /// Store a freshly computed payload.
+    pub fn set(&self, data: Arc<GlobalCanvasData>) {
+        if let Ok(mut g) = self.inner.data.write() {
+            *g = Some(data);
+        }
+    }
+
+    /// Eager invalidation: drop the cached payload immediately and bump the
+    /// rebuild generation so any in-flight debounced rebuild no-ops on
+    /// completion. Next read pays full compute cost.
+    pub fn invalidate(&self) {
+        self.inner.rebuild_gen.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if let Ok(mut g) = self.inner.data.write() {
+            *g = None;
+        }
+    }
+
+    /// Register the rebuilder closure used by debounced invalidations.
+    /// First call wins (backed by `OnceLock`); subsequent calls are no-ops.
+    pub(crate) fn set_rebuilder(&self, rebuilder: CanvasRebuilder) {
+        let _ = self.inner.rebuilder.set(rebuilder);
+    }
+
+    /// Debounced invalidation: schedule a background rebuild after
+    /// [`CANVAS_CACHE_DEBOUNCE`], keeping the current (stale) payload visible
+    /// to readers in the meantime. Only the latest scheduled rebuild wins —
+    /// rapid successive calls collapse into a single rebuild. No-op if no
+    /// rebuilder has been registered.
+    pub fn invalidate_debounced(&self) {
+        use std::sync::atomic::Ordering;
+        let my_gen = self.inner.rebuild_gen.fetch_add(1, Ordering::SeqCst) + 1;
+        let cache = self.clone();
+        crate::executor::spawn(async move {
+            tokio::time::sleep(CANVAS_CACHE_DEBOUNCE).await;
+            if cache.inner.rebuild_gen.load(Ordering::SeqCst) != my_gen {
+                return;
+            }
+            let cache_compute = cache.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                cache_compute
+                    .inner
+                    .rebuilder
+                    .get()
+                    .map(|f| f())
+            })
+            .await;
+            match result {
+                Ok(Some(Ok(fresh))) => {
+                    if cache.inner.rebuild_gen.load(Ordering::SeqCst) == my_gen {
+                        cache.set(fresh);
+                    }
+                }
+                Ok(Some(Err(e))) => {
+                    tracing::warn!(error = %e, "Debounced canvas rebuild failed");
+                }
+                Ok(None) => {
+                    tracing::debug!("Debounced canvas rebuild skipped: no rebuilder registered");
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Debounced canvas rebuild panicked");
+                }
+            }
+        });
+    }
+}
+
 /// Main library facade providing high-level operations
 #[derive(Clone)]
 pub struct AtomicCore {
@@ -109,6 +222,9 @@ pub struct AtomicCore {
     /// created lazily and persist for the lifetime of the process — the
     /// working set is bounded by the number of wiki articles touched.
     wiki_tag_locks: Arc<std::sync::Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// In-memory cache for `compute_and_get_canvas_data`. Shared across clones
+    /// so every handle sees the same cached payload.
+    canvas_cache: CanvasCache,
 }
 
 impl AtomicCore {
@@ -116,11 +232,14 @@ impl AtomicCore {
     pub fn open(db_path: impl AsRef<Path>) -> Result<Self, AtomicCoreError> {
         let db = Arc::new(Database::open(db_path)?);
         let storage = storage::StorageBackend::Sqlite(storage::SqliteStorage::new(db));
-        Ok(Self {
+        let core = Self {
             storage,
             registry: None,
             wiki_tag_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-        })
+            canvas_cache: CanvasCache::new(),
+        };
+        core.register_canvas_rebuilder();
+        Ok(core)
     }
 
     /// Open an existing database with a larger read pool sized for server workloads.
@@ -183,21 +302,27 @@ impl AtomicCore {
             }
         }
 
-        Ok(Self {
+        let core = Self {
             storage,
             registry,
             wiki_tag_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-        })
+            canvas_cache: CanvasCache::new(),
+        };
+        core.register_canvas_rebuilder();
+        Ok(core)
     }
 
     /// Create an AtomicCore from an existing PostgresStorage (for multi-db in Postgres mode).
     #[cfg(feature = "postgres")]
     pub fn from_postgres_storage(pg: storage::PostgresStorage) -> Self {
-        Self {
+        let core = Self {
             storage: storage::StorageBackend::Postgres(pg),
             registry: None,
             wiki_tag_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-        }
+            canvas_cache: CanvasCache::new(),
+        };
+        core.register_canvas_rebuilder();
+        core
     }
 
     /// Open an existing database or create a new one
@@ -299,11 +424,14 @@ impl AtomicCore {
 
         let db = Arc::new(db);
         let storage = storage::StorageBackend::Sqlite(storage::SqliteStorage::new(db));
-        Ok(Self {
+        let core = Self {
             storage,
             registry,
             wiki_tag_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-        })
+            canvas_cache: CanvasCache::new(),
+        };
+        core.register_canvas_rebuilder();
+        Ok(core)
     }
 
     /// Get settings map for passing to background tasks when registry is present.
@@ -462,13 +590,14 @@ impl AtomicCore {
         let content = request.content.clone();
 
         let atom_with_tags = self.storage.insert_atom_impl(&id, &request, &now)?;
+        self.canvas_cache.invalidate();
 
         // Spawn embedding task (non-blocking)
         embedding::spawn_embedding_task_single_with_settings(
             self.storage.clone(),
             id,
             content,
-            on_event,
+            self.wrap_event_for_cache(on_event),
             self.settings_for_background(),
         );
 
@@ -533,6 +662,7 @@ impl AtomicCore {
 
         // Bulk insert via storage
         let atoms_with_tags = self.storage.insert_atoms_bulk_impl(&atoms_to_insert)?;
+        self.canvas_cache.invalidate();
 
         // Collect atom IDs for background embedding (don't clone content — read from DB later)
         let atom_ids: Vec<String> = atoms_with_tags
@@ -548,6 +678,8 @@ impl AtomicCore {
 
             let storage_clone = self.storage.clone();
             let bg_settings = self.settings_for_background();
+            let on_event = self.wrap_event_for_cache(on_event);
+            let canvas_cache = Some(self.canvas_cache.clone());
             executor::spawn(async move {
                 // Limit concurrent batch tasks to bound memory from queued work
                 let _permit = executor::EMBEDDING_BATCH_SEMAPHORE
@@ -582,8 +714,8 @@ impl AtomicCore {
                 if !embedding_pairs.is_empty() {
                     let input = embedding::AtomInput::Preloaded(embedding_pairs);
                     match bg_settings {
-                        Some(s) => embedding::process_embedding_batch_with_settings(storage_clone, input, false, on_event, s).await,
-                        None => embedding::process_embedding_batch(storage_clone, input, false, on_event).await,
+                        Some(s) => embedding::process_embedding_batch_with_settings(storage_clone, input, false, on_event, s, canvas_cache).await,
+                        None => embedding::process_embedding_batch(storage_clone, input, false, on_event, canvas_cache).await,
                     };
                 }
             });
@@ -611,13 +743,14 @@ impl AtomicCore {
         let content = request.content.clone();
 
         let atom_with_tags = self.storage.update_atom_impl(id, &request, &now)?;
+        self.canvas_cache.invalidate();
 
         // Spawn embedding task (non-blocking)
         embedding::spawn_embedding_task_single_with_settings(
             self.storage.clone(),
             id.to_string(),
             content,
-            on_event,
+            self.wrap_event_for_cache(on_event),
             self.settings_for_background(),
         );
 
@@ -634,12 +767,16 @@ impl AtomicCore {
         request: UpdateAtomRequest,
     ) -> Result<AtomWithTags, AtomicCoreError> {
         let now = Utc::now().to_rfc3339();
-        self.storage.update_atom_content_only_impl(id, &request, &now)
+        let result = self.storage.update_atom_content_only_impl(id, &request, &now)?;
+        self.canvas_cache.invalidate();
+        Ok(result)
     }
 
     /// Delete an atom
     pub fn delete_atom(&self, id: &str) -> Result<(), AtomicCoreError> {
-        self.storage.delete_atom_impl(id)
+        self.storage.delete_atom_impl(id)?;
+        self.canvas_cache.invalidate();
+        Ok(())
     }
 
     /// Get atoms by tag (includes atoms with descendant tags)
@@ -709,12 +846,16 @@ impl AtomicCore {
         name: &str,
         parent_id: Option<&str>,
     ) -> Result<Tag, AtomicCoreError> {
-        self.storage.update_tag_impl(id, name, parent_id)
+        let tag = self.storage.update_tag_impl(id, name, parent_id)?;
+        self.canvas_cache.invalidate();
+        Ok(tag)
     }
 
     /// Delete a tag
     pub fn delete_tag(&self, id: &str, recursive: bool) -> Result<(), AtomicCoreError> {
-        self.storage.delete_tag_impl(id, recursive)
+        self.storage.delete_tag_impl(id, recursive)?;
+        self.canvas_cache.invalidate();
+        Ok(())
     }
 
     /// Mark or unmark a top-level tag as a candidate for AI auto-tagging to extend.
@@ -1178,10 +1319,12 @@ impl AtomicCore {
     where
         F: Fn(EmbeddingEvent) + Send + Sync + Clone + 'static,
     {
+        let on_event = self.wrap_event_for_cache(on_event);
+        let canvas_cache = Some(self.canvas_cache.clone());
         match self.settings_for_background() {
-            Some(s) => embedding::process_pending_embeddings_with_settings(self.storage.clone(), on_event, s)
+            Some(s) => embedding::process_pending_embeddings_with_settings(self.storage.clone(), on_event, s, canvas_cache)
                 .map_err(|e| AtomicCoreError::Embedding(e)),
-            None => embedding::process_pending_embeddings(self.storage.clone(), on_event)
+            None => embedding::process_pending_embeddings(self.storage.clone(), on_event, canvas_cache)
                 .map_err(|e| AtomicCoreError::Embedding(e)),
         }
     }
@@ -1189,7 +1332,7 @@ impl AtomicCore {
     /// Process all atoms with pending edge computation in batches.
     /// Runs in the background with checkpointing so it survives restarts.
     pub fn process_pending_edges(&self) -> Result<i32, AtomicCoreError> {
-        embedding::process_pending_edges(self.storage.clone())
+        embedding::process_pending_edges(self.storage.clone(), Some(self.canvas_cache.clone()))
             .map_err(|e| AtomicCoreError::Embedding(e))
     }
 
@@ -1218,7 +1361,7 @@ impl AtomicCore {
             self.storage.clone(),
             atom_id.to_string(),
             content,
-            on_event,
+            self.wrap_event_for_cache(on_event),
             self.settings_for_background(),
         );
 
@@ -1240,6 +1383,8 @@ impl AtomicCore {
             let storage_clone = self.storage.clone();
             let bg_settings = self.settings_for_background();
             let input = embedding::AtomInput::IdsOnly(pending_ids);
+            let on_event = self.wrap_event_for_cache(on_event);
+            let canvas_cache = Some(self.canvas_cache.clone());
             executor::spawn(async move {
                 match bg_settings {
                     Some(s) => embedding::process_embedding_batch_with_settings(
@@ -1248,12 +1393,14 @@ impl AtomicCore {
                         true, // skip tagging - re-embedding only
                         on_event,
                         s,
+                        canvas_cache,
                     ).await,
                     None => embedding::process_embedding_batch(
                         storage_clone,
                         input,
                         true,
                         on_event,
+                        canvas_cache,
                     ).await,
                 };
             });
@@ -1268,12 +1415,18 @@ impl AtomicCore {
         F: Fn(EmbeddingEvent) + Send + Sync + Clone + 'static,
     {
         let atom_ids = self.storage.claim_all_for_reembedding_sync()?;
+        // The claim flips every atom 'complete' → 'processing' unconditionally,
+        // so atoms disappear from the canvas query immediately. Drop any warm
+        // cache so reads during the re-embed window don't serve stale data.
+        self.canvas_cache.invalidate();
         let count = atom_ids.len() as i32;
 
         if count > 0 {
             let storage_clone = self.storage.clone();
             let bg_settings = self.settings_for_background();
             let input = embedding::AtomInput::IdsOnly(atom_ids);
+            let on_event = self.wrap_event_for_cache(on_event);
+            let canvas_cache = Some(self.canvas_cache.clone());
             executor::spawn(async move {
                 match bg_settings {
                     Some(s) => embedding::process_embedding_batch_with_settings(
@@ -1282,12 +1435,14 @@ impl AtomicCore {
                         false,
                         on_event,
                         s,
+                        canvas_cache,
                     ).await,
                     None => embedding::process_embedding_batch(
                         storage_clone,
                         input,
                         false,
                         on_event,
+                        canvas_cache,
                     ).await,
                 };
             });
@@ -1317,6 +1472,7 @@ impl AtomicCore {
         let storage = self.storage.clone();
         let atom_id = atom_id.to_string();
         let bg_settings = self.settings_for_background();
+        let on_event = self.wrap_event_for_cache(on_event);
         executor::spawn(async move {
             let settings = bg_settings.unwrap_or_default();
             embedding::process_tagging_batch_with_settings(storage, vec![atom_id], on_event, settings).await;
@@ -1361,7 +1517,9 @@ impl AtomicCore {
         &self,
         merges: &[compaction::TagMerge],
     ) -> Result<compaction::CompactionResult, AtomicCoreError> {
-        self.storage.apply_tag_merges_impl(merges)
+        let result = self.storage.apply_tag_merges_impl(merges)?;
+        self.canvas_cache.invalidate();
+        Ok(result)
     }
 
     // ==================== Chat Operations ====================
@@ -1499,15 +1657,73 @@ impl AtomicCore {
         self.storage.get_atoms_with_embeddings_impl()
     }
 
+    /// Return a handle to the canvas cache so background tasks (e.g. embedding
+    /// pipeline completion) can invalidate it from outside this facade.
+    pub fn canvas_cache(&self) -> CanvasCache {
+        self.canvas_cache.clone()
+    }
+
+    /// Invalidate the in-memory canvas cache. Called by every mutation path
+    /// that could change canvas output.
+    pub fn invalidate_canvas_cache(&self) {
+        self.canvas_cache.invalidate();
+    }
+
+    /// Wrap a user-provided embedding/tagging event callback so that
+    /// visibility-changing events (`EmbeddingComplete`, `TaggingComplete`)
+    /// schedule a debounced canvas cache rebuild. The returned closure is
+    /// `Clone` so it can be passed to both single-atom and batch spawn sites.
+    /// Debounced (not eager) so streaming batches collapse into one rebuild.
+    fn wrap_event_for_cache<F>(&self, on_event: F) -> impl Fn(EmbeddingEvent) + Send + Sync + Clone + 'static
+    where
+        F: Fn(EmbeddingEvent) + Send + Sync + 'static,
+    {
+        let cache = self.canvas_cache.clone();
+        let on_event = Arc::new(on_event);
+        move |event: EmbeddingEvent| {
+            if matches!(
+                &event,
+                EmbeddingEvent::EmbeddingComplete { .. }
+                    | EmbeddingEvent::TaggingComplete { .. }
+            ) {
+                cache.invalidate_debounced();
+            }
+            on_event(event);
+        }
+    }
+
     /// Compute PCA 2D projection of all atom embeddings and return positioned atoms,
     /// top-K edges per atom, and cluster centroid labels.
     /// Pure read operation — does not persist positions to the database.
     /// Works with both SQLite and Postgres backends via storage dispatch.
-    pub fn compute_and_get_canvas_data(&self) -> Result<GlobalCanvasData, AtomicCoreError> {
+    ///
+    /// Results are memoized via `canvas_cache`; subsequent calls return the
+    /// cached `Arc` until a mutation invalidates it.
+    pub fn compute_and_get_canvas_data(&self) -> Result<Arc<GlobalCanvasData>, AtomicCoreError> {
+        if let Some(cached) = self.canvas_cache.get() {
+            return Ok(cached);
+        }
+        let data = Self::compute_canvas_data_impl(&self.storage)?;
+        self.canvas_cache.set(Arc::clone(&data));
+        Ok(data)
+    }
+
+    /// The pure compute path for the global canvas payload. No cache
+    /// interaction — callers decide whether to read/write the cache. Takes
+    /// `&StorageBackend` instead of `&self` so the debounced rebuilder
+    /// closure (registered on `CanvasCache`) can invoke it without needing
+    /// a full `AtomicCore` handle.
+    fn compute_canvas_data_impl(
+        storage: &storage::StorageBackend,
+    ) -> Result<Arc<GlobalCanvasData>, AtomicCoreError> {
         // Load all average embeddings via storage abstraction (single scan of atom_chunks)
-        let embeddings = self.storage.get_all_embedding_pairs_sync()?;
+        let embeddings = storage.get_all_embedding_pairs_sync()?;
         if embeddings.is_empty() {
-            return Ok(GlobalCanvasData { atoms: vec![], edges: vec![], clusters: vec![] });
+            return Ok(Arc::new(GlobalCanvasData {
+                atoms: vec![],
+                edges: vec![],
+                clusters: vec![],
+            }));
         }
 
         // Run PCA projection (pure math, backend-agnostic)
@@ -1520,8 +1736,8 @@ impl AtomicCore {
 
         // Load lightweight canvas metadata (id, title, first tag, tag count, tag_ids)
         // — no full content, no embedding blobs, single query with LEFT JOIN
-        let atom_metadata = self.storage.get_canvas_atom_metadata_light_sync()?;
-        let mut atom_tag_map = self.storage.get_all_atom_tag_ids_sync()?;
+        let atom_metadata = storage.get_canvas_atom_metadata_light_sync()?;
+        let mut atom_tag_map = storage.get_all_atom_tag_ids_sync()?;
 
         let atoms: Vec<CanvasAtomPosition> = atom_metadata.into_iter()
             .filter_map(|(atom_id, title, primary_tag, tag_count)| {
@@ -1540,7 +1756,7 @@ impl AtomicCore {
             .collect();
 
         // Load semantic edges once, use for both canvas edges and clustering
-        let all_edges = self.storage.get_semantic_edges_raw_sync(0.5)?;
+        let all_edges = storage.get_semantic_edges_raw_sync(0.5)?;
 
         // Build top-k canvas edges from the loaded data
         let edges = Self::filter_top_k_edges(&all_edges, 2);
@@ -1548,10 +1764,20 @@ impl AtomicCore {
         // Compute clusters from the same edge data (no second DB scan)
         let cluster_data = clustering::compute_clusters_from_edges(&all_edges, 3);
         // Enrich clusters with dominant tag names
-        let cluster_data = self.storage.enrich_clusters_with_tags_sync(cluster_data)?;
+        let cluster_data = storage.enrich_clusters_with_tags_sync(cluster_data)?;
         let clusters = Self::build_cluster_centroids(&cluster_data, &position_map);
 
-        Ok(GlobalCanvasData { atoms, edges, clusters })
+        Ok(Arc::new(GlobalCanvasData { atoms, edges, clusters }))
+    }
+
+    /// Register the canvas cache rebuilder so background-debounced
+    /// invalidations can recompute the payload. Called once per constructor.
+    /// Captures a `StorageBackend` clone — no reference cycle.
+    fn register_canvas_rebuilder(&self) {
+        let storage = self.storage.clone();
+        self.canvas_cache.set_rebuilder(Box::new(move || {
+            Self::compute_canvas_data_impl(&storage)
+        }));
     }
 
     /// Filter edges to keep at most top_k per atom, input must be sorted by score DESC.
@@ -1648,7 +1874,18 @@ impl AtomicCore {
 
     /// Rebuild semantic edges for all atoms with embeddings
     pub fn rebuild_semantic_edges(&self) -> Result<i32, AtomicCoreError> {
-        self.storage.rebuild_semantic_edges_sync()
+        let count = self.storage.rebuild_semantic_edges_sync()?;
+        self.canvas_cache.invalidate();
+        if count > 0 {
+            // Kick off the background edge pipeline with the cache handle so
+            // each completed batch invalidates the cache as edges land on disk.
+            embedding::process_pending_edges(
+                self.storage.clone(),
+                Some(self.canvas_cache.clone()),
+            )
+            .map_err(|e| AtomicCoreError::Embedding(e))?;
+        }
+        Ok(count)
     }
 
     // ==================== Hierarchical Canvas ====================
@@ -1690,6 +1927,7 @@ impl AtomicCore {
         if count > 0 {
             let storage = self.storage.clone();
             let bg_settings = self.settings_for_background();
+            let on_event = self.wrap_event_for_cache(on_event);
             executor::spawn(async move {
                 match bg_settings {
                     Some(s) => embedding::process_tagging_batch_with_settings(storage, pending_atoms, on_event, s).await,
@@ -1764,6 +2002,7 @@ impl AtomicCore {
             // This drops vec_chunks, recreates it, clears atom_chunks/semantic_edges,
             // and resets every atom's embedding_status to 'pending'.
             self.storage.recreate_vector_index_sync(new_dim)?;
+            self.canvas_cache.invalidate();
             tracing::info!(new_dim, "Recreated active database vector index for dimension change");
             // Now spawn re-embedding — atoms are in 'pending' status after the recreate.
             let queued = self.spawn_reembed_pending(on_event.clone())?;
@@ -2053,14 +2292,17 @@ impl AtomicCore {
             for (atom_id, _) in &imported_atoms {
                 self.storage.set_embedding_status_sync(atom_id, "processing", None).ok();
             }
+            self.canvas_cache.invalidate();
 
             let storage_clone = self.storage.clone();
             let bg_settings = self.settings_for_background();
             let input = embedding::AtomInput::Preloaded(imported_atoms);
+            let on_event = self.wrap_event_for_cache(on_event);
+            let canvas_cache = Some(self.canvas_cache.clone());
             executor::spawn(async move {
                 match bg_settings {
-                    Some(s) => embedding::process_embedding_batch_with_settings(storage_clone, input, false, on_event, s).await,
-                    None => embedding::process_embedding_batch(storage_clone, input, false, on_event).await,
+                    Some(s) => embedding::process_embedding_batch_with_settings(storage_clone, input, false, on_event, s, canvas_cache).await,
+                    None => embedding::process_embedding_batch(storage_clone, input, false, on_event, canvas_cache).await,
                 };
             });
         }

--- a/crates/atomic-core/src/storage/postgres/atoms.rs
+++ b/crates/atomic-core/src/storage/postgres/atoms.rs
@@ -1205,12 +1205,12 @@ impl AtomStore for PostgresStorage {
 
     async fn get_canvas_atom_metadata_light(&self) -> StorageResult<Vec<(String, String, Option<String>, i32)>> {
         let rows: Vec<(String, String, Option<String>, i64)> = sqlx::query_as(
-            "SELECT a.id, a.title,
-                    (SELECT t.name FROM atom_tags at JOIN tags t ON at.tag_id = t.id
-                     WHERE at.atom_id = a.id AND at.db_id = $1 AND t.db_id = $1 LIMIT 1) as primary_tag,
-                    (SELECT COUNT(*) FROM atom_tags at WHERE at.atom_id = a.id AND at.db_id = $1) as tag_count
+            "SELECT a.id, a.title, MIN(t.name) AS primary_tag, COUNT(at.tag_id) AS tag_count
              FROM atoms a
-             WHERE a.db_id = $1 AND a.embedding_status = 'complete'",
+             LEFT JOIN atom_tags at ON at.atom_id = a.id AND at.db_id = $1
+             LEFT JOIN tags t ON t.id = at.tag_id AND t.db_id = $1
+             WHERE a.db_id = $1 AND a.embedding_status = 'complete'
+             GROUP BY a.id, a.title",
         )
         .bind(&self.db_id)
         .fetch_all(&self.pool)

--- a/crates/atomic-core/src/storage/sqlite/atoms.rs
+++ b/crates/atomic-core/src/storage/sqlite/atoms.rs
@@ -996,17 +996,22 @@ impl SqliteStorage {
 
     /// Lightweight canvas metadata: (atom_id, title, primary_tag_name, tag_count).
     /// No full content, no embedding blobs — just what the canvas needs.
+    ///
+    /// Uses a single LEFT JOIN + GROUP BY instead of correlated subqueries so
+    /// the query is O(atoms + tag_links) rather than O(atoms × 2) index lookups.
+    /// `primary_tag` is MIN(name) — alphabetically stable, unlike the previous
+    /// LIMIT-1 nondeterministic pick.
     pub(crate) fn get_canvas_atom_metadata_light_sync(
         &self,
     ) -> StorageResult<Vec<(String, String, Option<String>, i32)>> {
         let conn = self.db.read_conn()?;
         let mut stmt = conn.prepare(
-            "SELECT a.id, a.title,
-                    (SELECT t.name FROM atom_tags at JOIN tags t ON at.tag_id = t.id
-                     WHERE at.atom_id = a.id LIMIT 1) as primary_tag,
-                    (SELECT COUNT(*) FROM atom_tags at WHERE at.atom_id = a.id) as tag_count
+            "SELECT a.id, a.title, MIN(t.name) AS primary_tag, COUNT(at.tag_id) AS tag_count
              FROM atoms a
-             WHERE a.embedding_status = 'complete'"
+             LEFT JOIN atom_tags at ON at.atom_id = a.id
+             LEFT JOIN tags t ON t.id = at.tag_id
+             WHERE a.embedding_status = 'complete'
+             GROUP BY a.id, a.title"
         )?;
 
         let rows = stmt.query_map([], |row| {

--- a/crates/atomic-core/src/storage/sqlite/chunks.rs
+++ b/crates/atomic-core/src/storage/sqlite/chunks.rs
@@ -279,22 +279,18 @@ impl SqliteStorage {
             .lock()
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
 
-        // Clear all existing edges and mark all embedded atoms as needing edge recomputation
+        // Clear all existing edges and mark all embedded atoms as needing edge recomputation.
+        // The facade (`AtomicCore::rebuild_semantic_edges`) kicks off
+        // `process_pending_edges` afterwards so it can supply the canvas cache
+        // handle — storage has no knowledge of the cache.
         conn.execute("DELETE FROM semantic_edges", [])?;
         let count = conn.execute(
             "UPDATE atoms SET edges_status = 'pending' WHERE embedding_status = 'complete'",
             [],
         )? as i32;
 
-        drop(conn);
-
-        // Kick off the batched edge computation pipeline
         if count > 0 {
-            tracing::info!(count, "Marked atoms for edge recomputation, starting pipeline");
-            embedding::process_pending_edges(
-                crate::storage::StorageBackend::Sqlite(self.clone()),
-            )
-            .map_err(|e| AtomicCoreError::Embedding(e))?;
+            tracing::info!(count, "Marked atoms for edge recomputation");
         }
 
         Ok(count)

--- a/crates/atomic-server/src/main.rs
+++ b/crates/atomic-server/src/main.rs
@@ -268,6 +268,49 @@ async fn run_server(
         }
     }
 
+    // Canvas cache warmup: compute the global canvas payload for every
+    // database in the background so the first request after startup hits a
+    // warm cache. Sequenced across databases (not parallel) to avoid an
+    // N-way PCA spike on startup, and off-loaded to the blocking pool so it
+    // never ties up an async worker.
+    {
+        let warm_manager = Arc::clone(&manager);
+        tokio::spawn(async move {
+            let (databases, _) = match warm_manager.list_databases() {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::warn!(error = %e, "canvas warmup: failed to list databases");
+                    return;
+                }
+            };
+            for db_info in &databases {
+                let db_core = match warm_manager.get_core(&db_info.id) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::warn!(db = %db_info.name, error = %e, "canvas warmup: failed to load database");
+                        continue;
+                    }
+                };
+                let db_name = db_info.name.clone();
+                let started = std::time::Instant::now();
+                let result = tokio::task::spawn_blocking(move || {
+                    db_core.compute_and_get_canvas_data().map(|d| d.atoms.len())
+                })
+                .await;
+                match result {
+                    Ok(Ok(atom_count)) => tracing::info!(
+                        db = %db_name,
+                        atoms = atom_count,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "canvas cache warmed"
+                    ),
+                    Ok(Err(e)) => tracing::warn!(db = %db_name, error = %e, "canvas cache warmup failed"),
+                    Err(e) => tracing::warn!(db = %db_name, error = %e, "canvas cache warmup panicked"),
+                }
+            }
+        });
+    }
+
     // Spawn feed polling scheduler (ticks every 60 seconds, polls all databases)
     {
         let poll_manager = Arc::clone(&manager);

--- a/crates/atomic-server/src/routes/graph.rs
+++ b/crates/atomic-server/src/routes/graph.rs
@@ -45,7 +45,14 @@ pub async fn get_atom_neighborhood(
     blocking_ok(move || core.get_atom_neighborhood(&atom_id, depth, min_similarity)).await
 }
 
-#[utoipa::path(post, path = "/api/graph/rebuild-edges", responses((status = 200, description = "Edges rebuilt")), tag = "graph")]
+/// Queue a full rebuild of the semantic-edge graph.
+///
+/// Returns the number of atoms **queued** for edge recomputation, not the
+/// number of edges written. The actual edge computation runs asynchronously
+/// on the background pipeline; this endpoint returns as soon as the work
+/// is spawned. Clients that need completion should subscribe to pipeline
+/// events over WebSocket.
+#[utoipa::path(post, path = "/api/graph/rebuild-edges", responses((status = 200, description = "Edge rebuild queued; returns the number of atoms queued for recomputation")), tag = "graph")]
 pub async fn rebuild_semantic_edges(db: Db) -> HttpResponse {
     let core = db.0;
     blocking_ok(move || core.rebuild_semantic_edges()).await


### PR DESCRIPTION
The /api/canvas/global endpoint recomputes PCA, metadata, edges, and clustering on every request. At high atom counts this is expensive (embedding blob scan + power iteration + edge load + label propagation).

Changes:

- Rewrite get_canvas_atom_metadata_light to a single LEFT JOIN + GROUP BY in both SQLite and Postgres, replacing two correlated subqueries per row. primary_tag is now MIN(name) (deterministic) instead of an unordered LIMIT 1.

- Introduce CanvasCache on AtomicCore, holding Arc<GlobalCanvasData> behind an RwLock with a generation counter and an optional rebuilder closure registered at construction. compute_and_get_canvas_data now returns Arc<GlobalCanvasData>, reads the cache on entry and populates on miss.

- Two invalidation flavors:
  * invalidate() — eager clear for direct user mutations (atom/tag CRUD, rebuild_semantic_edges, reembed_all_atoms, recreate_vector_index).
  * invalidate_debounced() — keeps stale payload visible and spawns a background rebuild after 500ms via spawn_blocking; only the latest request wins via the gen counter so batch event storms collapse into one rebuild. Used by wrap_event_for_cache on EmbeddingComplete and TaggingComplete, and by the per-batch edge pipeline.

- Thread Option<CanvasCache> through process_embedding_batch, process_pending_embeddings, and process_pending_edges so each completed edge batch can invalidate the cache as edges land. Move the edge-pipeline kickoff out of storage::rebuild_semantic_edges_sync into the facade so the cache handle can be supplied.

- Warm the cache per-database on atomic-server startup, sequenced via spawn_blocking to avoid an N-way PCA spike.