### PR TITLE
Add dashboard view, scheduler framework, and daily briefing

### DIFF
--- a/crates/atomic-core/Cargo.toml
+++ b/crates/atomic-core/Cargo.toml
@@ -63,5 +63,8 @@ postgres = ["sqlx", "pgvector"]
 tempfile = "3"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+# test-util is required for #[tokio::test(start_paused = true)] so retry/backoff
+# tests don't sleep real wall-clock seconds — time auto-advances to the next
+# pending Sleep deadline when the runtime has no other work.
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls"] }

--- a/crates/atomic-core/src/briefing/agentic.rs
+++ b/crates/atomic-core/src/briefing/agentic.rs
@@ -8,10 +8,8 @@
 //! via `semantic_search` are for context only and cannot be cited.
 
 use crate::models::AtomWithTags;
-use crate::providers::types::{
-    CompletionResponse, GenerationParams, Message, MessageRole, StructuredOutputSchema,
-    ToolDefinition,
-};
+use crate::providers::structured::{call_structured, StructuredCall};
+use crate::providers::types::{CompletionResponse, Message, MessageRole, ToolDefinition};
 use crate::providers::{get_llm_provider, LlmConfig, ProviderConfig, ProviderType};
 use crate::search::{SearchMode, SearchOptions};
 use crate::AtomicCore;
@@ -36,15 +34,6 @@ const MAX_SEARCH_LIMIT: i64 = 10;
 const DEFAULT_READ_LIMIT: i64 = 500;
 const MAX_READ_LIMIT: i64 = 500;
 
-/// Temperature for the final structured-output pass. Matches wiki synthesis —
-/// low enough to be deterministic, high enough to preserve prose voice.
-const FINAL_PASS_TEMPERATURE: f32 = 0.3;
-
-/// Retries on transient errors for the final structured-output pass. Matches
-/// wiki synthesis: only retries rate-limit / network failures, never parse
-/// errors (the same prompt will produce the same unparseable output).
-const FINAL_PASS_MAX_RETRIES: usize = 2;
-
 /// Structured-output envelope for the final briefing pass. Mirrors
 /// `WikiGenerationResult` in the wiki module so both synthesis paths use the
 /// same "prose + citation list" shape.
@@ -56,7 +45,7 @@ struct BriefingGenerationResult {
     citations_used: Vec<i32>,
 }
 
-fn briefing_schema() -> serde_json::Value {
+pub(crate) fn briefing_schema() -> serde_json::Value {
     serde_json::json!({
         "type": "object",
         "properties": {
@@ -429,76 +418,29 @@ async fn run_research(
     Ok(())
 }
 
-/// Final pass: call the LLM with the accumulated research conversation, no
-/// tools, and a structured-output schema so the response is guaranteed-parsable
-/// JSON with a `briefing_content` field. Retries transient errors with
-/// exponential backoff, mirroring `call_llm_for_wiki_typed`.
+/// Final pass: hand the accumulated research conversation to the shared
+/// `call_structured` helper. Everything about retries, tolerant parsing, and
+/// the prompt-based fallback lives there — this function is now just glue.
 async fn final_briefing_call(
     provider_config: &ProviderConfig,
     model: &str,
     messages: &[Message],
 ) -> Result<String, String> {
-    let provider = get_llm_provider(provider_config).map_err(|e| e.to_string())?;
-
-    let llm_config = LlmConfig::new(model).with_params(
-        GenerationParams::new()
-            .with_temperature(FINAL_PASS_TEMPERATURE)
-            .with_structured_output(StructuredOutputSchema::new(
-                "briefing_generation_result",
-                briefing_schema(),
-            )),
+    let call = StructuredCall::<BriefingGenerationResult>::new(
+        provider_config,
+        model,
+        messages,
+        "briefing_generation_result",
+        briefing_schema(),
     );
 
-    let mut last_error = String::new();
-    for attempt in 0..=FINAL_PASS_MAX_RETRIES {
-        if attempt > 0 {
-            let delay = 1u64 << attempt;
-            tracing::warn!(
-                attempt,
-                max_retries = FINAL_PASS_MAX_RETRIES,
-                delay_secs = delay,
-                last_error = %last_error,
-                "[briefing] Retrying final pass"
-            );
-            tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
-        }
-
-        match provider.complete(messages, &llm_config).await {
-            Ok(response) => {
-                if response.content.is_empty() {
-                    return Err("Briefing LLM returned empty content".to_string());
-                }
-                match serde_json::from_str::<BriefingGenerationResult>(&response.content) {
-                    Ok(result) => return Ok(result.briefing_content),
-                    Err(parse_err) => {
-                        // Don't retry on parse errors — the same prompt would produce
-                        // the same unparseable output. Log a preview for debugging.
-                        let preview: String = response.content.chars().take(500).collect();
-                        tracing::error!(
-                            error = %parse_err,
-                            preview = %preview,
-                            "[briefing] Failed to parse structured briefing output"
-                        );
-                        return Err(format!("Failed to parse briefing result: {}", parse_err));
-                    }
-                }
-            }
-            Err(e) => {
-                last_error = e.to_string();
-                if e.is_retryable() && attempt < FINAL_PASS_MAX_RETRIES {
-                    continue;
-                }
-                if !e.is_retryable() {
-                    tracing::error!("[briefing] Non-retryable error on final pass");
-                } else {
-                    tracing::error!("[briefing] Max retries exhausted on final pass");
-                }
-                return Err(format!("Briefing final LLM call failed: {}", e));
-            }
+    match call_structured::<BriefingGenerationResult>(call).await {
+        Ok(result) => Ok(result.briefing_content),
+        Err(e) => {
+            tracing::error!(error = %e, "[briefing] Final structured pass failed");
+            Err(e.to_compact_string())
         }
     }
-
-    Err(last_error)
 }
 
 // ==================== Citation extraction ====================
@@ -604,4 +546,111 @@ pub(crate) async fn generate(
     );
 
     Ok((content, citations))
+}
+
+// ==================== Tests ====================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::structured::lint_schema;
+
+    #[test]
+    fn lint_briefing_schema_is_portable() {
+        lint_schema(&briefing_schema())
+            .expect("briefing_schema must be portable across providers");
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_ascii() {
+        assert_eq!(truncate_on_char_boundary("hello", 3), "hel...");
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_under_limit() {
+        assert_eq!(truncate_on_char_boundary("hi", 10), "hi");
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_multibyte() {
+        // "héllo" is 6 bytes (é is 2 bytes). Truncating at byte offset 3
+        // must not split the é codepoint — we should land at a safe boundary.
+        let out = truncate_on_char_boundary("héllo", 3);
+        assert!(out.ends_with("..."));
+        // The non-ellipsis prefix must be valid UTF-8 (implicit — it's a String),
+        // and it should contain either "h" or "hé" but never a broken é.
+        let without_ellipsis = out.trim_end_matches("...");
+        assert!(!without_ellipsis.is_empty());
+    }
+
+    #[test]
+    fn extract_citations_maps_to_initial_list() {
+        let atoms = vec![
+            mock_atom("a-1", "first", "body 1"),
+            mock_atom("a-2", "second", "body 2"),
+            mock_atom("a-3", "third", "body 3"),
+        ];
+        let content = "The first atom introduces X [1]. The third expands on it [3].";
+        let citations = extract_citations(content, &atoms);
+        assert_eq!(citations.len(), 2);
+        assert_eq!(citations[0].0, 1);
+        assert_eq!(citations[0].1, "a-1");
+        assert_eq!(citations[1].0, 3);
+        assert_eq!(citations[1].1, "a-3");
+    }
+
+    #[test]
+    fn extract_citations_dedupes_repeats() {
+        let atoms = vec![mock_atom("a-1", "only", "body")];
+        // Same atom cited twice should only appear once in the output.
+        let content = "See [1] and also [1].";
+        let citations = extract_citations(content, &atoms);
+        assert_eq!(citations.len(), 1);
+        assert_eq!(citations[0].0, 1);
+    }
+
+    #[test]
+    fn extract_citations_drops_out_of_range() {
+        // Agent hallucinated [5] when only 2 atoms exist — must be dropped
+        // without panicking.
+        let atoms = vec![
+            mock_atom("a-1", "first", "body 1"),
+            mock_atom("a-2", "second", "body 2"),
+        ];
+        let content = "Valid [1] and [2], bogus [5] and [99].";
+        let citations = extract_citations(content, &atoms);
+        assert_eq!(citations.len(), 2);
+        assert_eq!(citations[0].0, 1);
+        assert_eq!(citations[1].0, 2);
+    }
+
+    #[test]
+    fn extract_citations_handles_no_citations() {
+        let atoms = vec![mock_atom("a-1", "only", "body")];
+        let content = "A plain paragraph with no markers at all.";
+        let citations = extract_citations(content, &atoms);
+        assert!(citations.is_empty());
+    }
+
+    fn mock_atom(id: &str, title: &str, snippet: &str) -> AtomWithTags {
+        use crate::models::Atom;
+        AtomWithTags {
+            atom: Atom {
+                id: id.to_string(),
+                content: snippet.to_string(),
+                title: title.to_string(),
+                snippet: snippet.to_string(),
+                source_url: None,
+                source: None,
+                published_at: None,
+                created_at: "2026-04-11T00:00:00Z".to_string(),
+                updated_at: "2026-04-11T00:00:00Z".to_string(),
+                embedding_status: "complete".to_string(),
+                tagging_status: "complete".to_string(),
+                embedding_error: None,
+                tagging_error: None,
+            },
+            tags: vec![],
+        }
+    }
 }

--- a/crates/atomic-core/src/briefing/agentic.rs
+++ b/crates/atomic-core/src/briefing/agentic.rs
@@ -1,0 +1,607 @@
+//! Agentic daily-briefing generation.
+//!
+//! Mirrors `wiki::agentic`: an LLM is given a small tool set (read_atom,
+//! semantic_search, done), runs a short research loop, then writes the
+//! final briefing in a tool-free pass. The `[N]` citation markers in the
+//! final text are extracted into [`super::BriefingCitation`] rows indexed
+//! against the *initial* new-atoms list — references the agent pulled in
+//! via `semantic_search` are for context only and cannot be cited.
+
+use crate::models::AtomWithTags;
+use crate::providers::types::{
+    CompletionResponse, GenerationParams, Message, MessageRole, StructuredOutputSchema,
+    ToolDefinition,
+};
+use crate::providers::{get_llm_provider, LlmConfig, ProviderConfig, ProviderType};
+use crate::search::{SearchMode, SearchOptions};
+use crate::AtomicCore;
+
+use chrono::{DateTime, Utc};
+use regex::Regex;
+use serde::Deserialize;
+use std::collections::HashSet;
+
+/// Hard cap on tool-calling iterations. Smaller than wiki's 15 because a
+/// daily briefing doesn't need deep research — most runs should terminate
+/// in a handful of iterations.
+const MAX_RESEARCH_ITERATIONS: usize = 10;
+const SNIPPET_LEN: usize = 200;
+const EXCERPT_LEN: usize = 300;
+const DEFAULT_SEARCH_LIMIT: i64 = 5;
+const MAX_SEARCH_LIMIT: i64 = 10;
+
+/// Line pagination defaults for `read_atom`. Matches the MCP server's
+/// `read_atom` tool (crates/atomic-server/src/mcp/server.rs) so the agent sees
+/// the same bounded-window pattern across both entry points.
+const DEFAULT_READ_LIMIT: i64 = 500;
+const MAX_READ_LIMIT: i64 = 500;
+
+/// Temperature for the final structured-output pass. Matches wiki synthesis —
+/// low enough to be deterministic, high enough to preserve prose voice.
+const FINAL_PASS_TEMPERATURE: f32 = 0.3;
+
+/// Retries on transient errors for the final structured-output pass. Matches
+/// wiki synthesis: only retries rate-limit / network failures, never parse
+/// errors (the same prompt will produce the same unparseable output).
+const FINAL_PASS_MAX_RETRIES: usize = 2;
+
+/// Structured-output envelope for the final briefing pass. Mirrors
+/// `WikiGenerationResult` in the wiki module so both synthesis paths use the
+/// same "prose + citation list" shape.
+#[derive(Debug, Deserialize)]
+struct BriefingGenerationResult {
+    briefing_content: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    citations_used: Vec<i32>,
+}
+
+fn briefing_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "briefing_content": {
+                "type": "string",
+                "description": "The 2-3 paragraph briefing in markdown, with [N] citation markers referring to the initial new-atoms list."
+            },
+            "citations_used": {
+                "type": "array",
+                "items": { "type": "integer" },
+                "description": "List of citation numbers actually used in briefing_content."
+            }
+        },
+        "required": ["briefing_content", "citations_used"],
+        "additionalProperties": false
+    })
+}
+
+const SYSTEM_PROMPT: &str = r#"You are writing a short daily briefing of newly captured notes for a personal knowledge base.
+
+The user will provide a numbered list of atoms (notes) added since the last briefing. Your job is to synthesize these new atoms into a 2-3 paragraph briefing that highlights what's noteworthy, what themes emerge, and where these new notes connect to existing knowledge.
+
+You have two tools:
+
+- **read_atom(atom_id, limit?, offset?)**: Read a window of lines from an atom's markdown content. Use this when the title and snippet aren't enough to summarize. Returns up to `limit` lines starting at `offset` (default: first 500 lines). For long atoms, page through with offset — do not try to read everything.
+- **semantic_search(query, limit)**: Search the full knowledge base (new + existing atoms) to find related material. Use this sparingly — typically only when a new atom references something that sounds like it should connect to older notes.
+- **done()**: Signal that you have enough material and will now write the briefing.
+
+Guidelines:
+- Keep the briefing to 2-3 short paragraphs. Do not write a long digest.
+- Use [N] inline citation markers to cite specific new atoms. The N should correspond to the numbered position of the atom in the initial list (1-indexed). Every citation must map to an atom from that list.
+- You may only cite atoms from the initial new-atoms list, not atoms returned by semantic_search. Search is for context only.
+- After you have gathered enough context, call done() and write the final briefing in your next message.
+- Skip atoms that aren't noteworthy. You are not required to cite every atom.
+- Write in the user's voice: concise, direct, mildly analytical, no filler.
+
+Do NOT write the briefing until you have called done() at least once."#;
+
+// ==================== Tool Definitions ====================
+
+fn briefing_tools() -> Vec<ToolDefinition> {
+    vec![
+        ToolDefinition::new(
+            "read_atom",
+            "Read a window of lines from an atom's markdown content. Use when the title and snippet aren't enough. For large atoms, page through with offset.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "atom_id": {
+                        "type": "string",
+                        "description": "UUID of the atom to read"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max number of lines to return (default 500, max 500)",
+                        "default": 500
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": "Line offset for pagination, 0-indexed (default 0)",
+                        "default": 0
+                    }
+                },
+                "required": ["atom_id"],
+                "additionalProperties": false
+            }),
+        ),
+        ToolDefinition::new(
+            "semantic_search",
+            "Search the full knowledge base for related material. Returns atom titles and snippets for context only — you cannot cite these atoms.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural-language query"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results (default 5, max 10)",
+                        "default": 5
+                    }
+                },
+                "required": ["query"],
+                "additionalProperties": false
+            }),
+        ),
+        ToolDefinition::new(
+            "done",
+            "Signal that research is complete. Call this before writing the final briefing.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        ),
+    ]
+}
+
+// ==================== Prompt construction ====================
+
+fn truncate_on_char_boundary(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let boundary = s
+        .char_indices()
+        .take_while(|(i, _)| *i < max)
+        .last()
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(0);
+    let mut out = s[..boundary].to_string();
+    out.push_str("...");
+    out
+}
+
+fn snippet_for(atom: &AtomWithTags) -> String {
+    // Prefer the stored snippet if present; fall back to truncated content.
+    let src = if !atom.atom.snippet.is_empty() {
+        atom.atom.snippet.as_str()
+    } else {
+        atom.atom.content.as_str()
+    };
+    let cleaned: String = src.chars().map(|c| if c == '\n' { ' ' } else { c }).collect();
+    truncate_on_char_boundary(cleaned.trim(), SNIPPET_LEN)
+}
+
+fn build_user_prompt(
+    since: &DateTime<Utc>,
+    new_atoms: &[AtomWithTags],
+    total_new: i32,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "The following {} atoms were added since {}. Summarize them in a 2-3 paragraph briefing.\n\n",
+        new_atoms.len(),
+        since.to_rfc3339()
+    ));
+    if (total_new as usize) > new_atoms.len() {
+        out.push_str(&format!(
+            "NOTE: {} atoms were added in this period. You are only seeing the {} most recent.\n\n",
+            total_new,
+            new_atoms.len()
+        ));
+    }
+    out.push_str("NEW ATOMS:\n");
+    for (i, atom) in new_atoms.iter().enumerate() {
+        let title = if atom.atom.title.is_empty() {
+            "(untitled)".to_string()
+        } else {
+            atom.atom.title.clone()
+        };
+        out.push_str(&format!(
+            "[{}] {}\n    {}\n    (atom id: {})\n\n",
+            i + 1,
+            title,
+            snippet_for(atom),
+            atom.atom.id,
+        ));
+    }
+    out
+}
+
+// ==================== Tool handlers ====================
+
+async fn handle_read_atom(core: &AtomicCore, args: &serde_json::Value) -> String {
+    let Some(atom_id) = args.get("atom_id").and_then(|v| v.as_str()) else {
+        return "Error: atom_id is required".to_string();
+    };
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(DEFAULT_READ_LIMIT)
+        .clamp(1, MAX_READ_LIMIT) as usize;
+    let offset = args
+        .get("offset")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0)
+        .max(0) as usize;
+
+    let atom = match core.get_atom(atom_id) {
+        Ok(Some(a)) => a,
+        Ok(None) => return format!("Error: no atom found with id {}", atom_id),
+        Err(e) => return format!("Error fetching atom {}: {}", atom_id, e),
+    };
+
+    let title = if atom.atom.title.is_empty() {
+        "(untitled)"
+    } else {
+        atom.atom.title.as_str()
+    };
+
+    let lines: Vec<&str> = atom.atom.content.lines().collect();
+    let total_lines = lines.len();
+    let start = offset.min(total_lines);
+    let end = (start + limit).min(total_lines);
+    let returned = end - start;
+    let has_more = end < total_lines;
+
+    let mut out = format!(
+        "# {}\n(lines {}-{} of {})\n\n",
+        title,
+        start + 1,
+        end,
+        total_lines
+    );
+    out.push_str(&lines[start..end].join("\n"));
+    if has_more {
+        out.push_str(&format!(
+            "\n\n(Atom content continues. Call read_atom again with offset={} to read more.)",
+            end
+        ));
+    }
+    let _ = returned; // surfaced via the "lines X-Y of Z" header
+    out
+}
+
+async fn handle_semantic_search(core: &AtomicCore, args: &serde_json::Value) -> String {
+    let query = args
+        .get("query")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if query.is_empty() {
+        return "Error: query is required".to_string();
+    }
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(DEFAULT_SEARCH_LIMIT)
+        .clamp(1, MAX_SEARCH_LIMIT) as i32;
+
+    let options = SearchOptions::new(query.clone(), SearchMode::Semantic, limit);
+    let results = match core.search(options).await {
+        Ok(r) => r,
+        Err(e) => return format!("Search error: {}", e),
+    };
+
+    if results.is_empty() {
+        return "No results.".to_string();
+    }
+
+    let mut out = String::new();
+    for (i, r) in results.iter().enumerate() {
+        let title = if r.atom.atom.title.is_empty() {
+            "(untitled)"
+        } else {
+            r.atom.atom.title.as_str()
+        };
+        let snippet = truncate_on_char_boundary(
+            &r.matching_chunk_content
+                .chars()
+                .map(|c| if c == '\n' { ' ' } else { c })
+                .collect::<String>(),
+            SNIPPET_LEN,
+        );
+        out.push_str(&format!(
+            "{}. {}\n   (atom id: {}, score: {:.2})\n   {}\n\n",
+            i + 1,
+            title,
+            r.atom.atom.id,
+            r.similarity_score,
+            snippet,
+        ));
+    }
+    out
+}
+
+// ==================== Research loop ====================
+
+struct AgentState {
+    messages: Vec<Message>,
+    done_called: bool,
+}
+
+fn resolve_model(core: &AtomicCore) -> Result<(ProviderConfig, String), String> {
+    let settings = core
+        .get_settings()
+        .map_err(|e| format!("Failed to load settings: {}", e))?;
+    let config = ProviderConfig::from_settings(&settings);
+    // Mirror build_wiki_strategy_context: local providers use their own llm_model,
+    // OpenRouter uses the wiki_model setting (the briefing shares it — intentional).
+    let model = match config.provider_type {
+        ProviderType::Ollama => config.llm_model().to_string(),
+        ProviderType::OpenAICompat => config.llm_model().to_string(),
+        ProviderType::OpenRouter => settings
+            .get("wiki_model")
+            .cloned()
+            .unwrap_or_else(|| "anthropic/claude-sonnet-4.6".to_string()),
+    };
+    Ok((config, model))
+}
+
+async fn run_research(
+    core: &AtomicCore,
+    state: &mut AgentState,
+    provider_config: &ProviderConfig,
+    model: &str,
+) -> Result<(), String> {
+    let tools = briefing_tools();
+    let llm_config = LlmConfig::new(model);
+    let provider = get_llm_provider(provider_config).map_err(|e| e.to_string())?;
+
+    for iteration in 0..MAX_RESEARCH_ITERATIONS {
+        tracing::debug!(
+            iteration = iteration + 1,
+            max = MAX_RESEARCH_ITERATIONS,
+            "[briefing/agentic] Research iteration"
+        );
+
+        let response: CompletionResponse = provider
+            .complete_with_tools(&state.messages, &tools, &llm_config)
+            .await
+            .map_err(|e| format!("Briefing research LLM call failed: {}", e))?;
+
+        let tool_calls = match response.tool_calls {
+            Some(ref tcs) if !tcs.is_empty() => tcs.clone(),
+            _ => {
+                if !response.content.is_empty() {
+                    tracing::debug!(
+                        "[briefing/agentic] Agent produced text without tools, ending research"
+                    );
+                }
+                break;
+            }
+        };
+
+        state.messages.push(Message {
+            role: MessageRole::Assistant,
+            content: if response.content.is_empty() {
+                None
+            } else {
+                Some(response.content.clone())
+            },
+            tool_calls: Some(tool_calls.clone()),
+            tool_call_id: None,
+            name: None,
+        });
+
+        let mut done_this_round = false;
+        for tc in &tool_calls {
+            let name = tc.get_name().unwrap_or("");
+            let args: serde_json::Value = tc
+                .get_arguments()
+                .and_then(|a| serde_json::from_str(a).ok())
+                .unwrap_or(serde_json::json!({}));
+
+            let result = match name {
+                "read_atom" => handle_read_atom(core, &args).await,
+                "semantic_search" => handle_semantic_search(core, &args).await,
+                "done" => {
+                    done_this_round = true;
+                    state.done_called = true;
+                    "Acknowledged. Write the briefing in your next message.".to_string()
+                }
+                _ => format!("Unknown tool: {}", name),
+            };
+
+            state
+                .messages
+                .push(Message::tool_result(tc.id.clone(), result));
+        }
+
+        if done_this_round {
+            tracing::debug!("[briefing/agentic] done() called, exiting research loop");
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+/// Final pass: call the LLM with the accumulated research conversation, no
+/// tools, and a structured-output schema so the response is guaranteed-parsable
+/// JSON with a `briefing_content` field. Retries transient errors with
+/// exponential backoff, mirroring `call_llm_for_wiki_typed`.
+async fn final_briefing_call(
+    provider_config: &ProviderConfig,
+    model: &str,
+    messages: &[Message],
+) -> Result<String, String> {
+    let provider = get_llm_provider(provider_config).map_err(|e| e.to_string())?;
+
+    let llm_config = LlmConfig::new(model).with_params(
+        GenerationParams::new()
+            .with_temperature(FINAL_PASS_TEMPERATURE)
+            .with_structured_output(StructuredOutputSchema::new(
+                "briefing_generation_result",
+                briefing_schema(),
+            )),
+    );
+
+    let mut last_error = String::new();
+    for attempt in 0..=FINAL_PASS_MAX_RETRIES {
+        if attempt > 0 {
+            let delay = 1u64 << attempt;
+            tracing::warn!(
+                attempt,
+                max_retries = FINAL_PASS_MAX_RETRIES,
+                delay_secs = delay,
+                last_error = %last_error,
+                "[briefing] Retrying final pass"
+            );
+            tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+        }
+
+        match provider.complete(messages, &llm_config).await {
+            Ok(response) => {
+                if response.content.is_empty() {
+                    return Err("Briefing LLM returned empty content".to_string());
+                }
+                match serde_json::from_str::<BriefingGenerationResult>(&response.content) {
+                    Ok(result) => return Ok(result.briefing_content),
+                    Err(parse_err) => {
+                        // Don't retry on parse errors — the same prompt would produce
+                        // the same unparseable output. Log a preview for debugging.
+                        let preview: String = response.content.chars().take(500).collect();
+                        tracing::error!(
+                            error = %parse_err,
+                            preview = %preview,
+                            "[briefing] Failed to parse structured briefing output"
+                        );
+                        return Err(format!("Failed to parse briefing result: {}", parse_err));
+                    }
+                }
+            }
+            Err(e) => {
+                last_error = e.to_string();
+                if e.is_retryable() && attempt < FINAL_PASS_MAX_RETRIES {
+                    continue;
+                }
+                if !e.is_retryable() {
+                    tracing::error!("[briefing] Non-retryable error on final pass");
+                } else {
+                    tracing::error!("[briefing] Max retries exhausted on final pass");
+                }
+                return Err(format!("Briefing final LLM call failed: {}", e));
+            }
+        }
+    }
+
+    Err(last_error)
+}
+
+// ==================== Citation extraction ====================
+
+/// Extract `[N]` markers from the briefing and map each to an atom in the
+/// initial new-atoms list (1-indexed). Citations that don't map are dropped
+/// with a warning — this is the spec'd behavior for "agent cites something
+/// it doesn't have."
+fn extract_citations(
+    content: &str,
+    new_atoms: &[AtomWithTags],
+) -> Vec<(i32, String, String)> {
+    let re = match Regex::new(r"\[(\d+)\]") {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(error = %e, "[briefing] Failed to compile citation regex");
+            return vec![];
+        }
+    };
+
+    let mut out: Vec<(i32, String, String)> = Vec::new();
+    let mut seen: HashSet<i32> = HashSet::new();
+
+    for cap in re.captures_iter(content) {
+        let Some(m) = cap.get(1) else { continue };
+        let Ok(idx) = m.as_str().parse::<i32>() else {
+            continue;
+        };
+        if !seen.insert(idx) {
+            continue;
+        }
+        let pos = (idx - 1) as usize;
+        let Some(atom) = new_atoms.get(pos) else {
+            tracing::warn!(
+                citation_index = idx,
+                atom_count = new_atoms.len(),
+                "[briefing] Agent produced citation out of range; dropping"
+            );
+            continue;
+        };
+        let source = if !atom.atom.snippet.is_empty() {
+            atom.atom.snippet.as_str()
+        } else {
+            atom.atom.content.as_str()
+        };
+        let excerpt = truncate_on_char_boundary(source.trim(), EXCERPT_LEN);
+        out.push((idx, atom.atom.id.clone(), excerpt));
+    }
+
+    out.sort_by_key(|(idx, _, _)| *idx);
+    out
+}
+
+// ==================== Public entry ====================
+
+/// Run the briefing agent and return `(content, citations)`. Citations are
+/// `(index, atom_id, excerpt)` tuples ready to be persisted.
+pub(crate) async fn generate(
+    core: &AtomicCore,
+    since: &DateTime<Utc>,
+    new_atoms: &[AtomWithTags],
+    total_new: i32,
+) -> Result<(String, Vec<(i32, String, String)>), String> {
+    let (provider_config, model) = resolve_model(core)?;
+    tracing::info!(model = %model, atoms = new_atoms.len(), "[briefing/agentic] Running agent");
+
+    let user_prompt = build_user_prompt(since, new_atoms, total_new);
+
+    let mut state = AgentState {
+        messages: vec![
+            Message::system(SYSTEM_PROMPT.to_string()),
+            Message::user(user_prompt),
+        ],
+        done_called: false,
+    };
+
+    run_research(core, &mut state, &provider_config, &model).await?;
+
+    if !state.done_called {
+        tracing::debug!(
+            "[briefing/agentic] Agent ended research without calling done(); proceeding to final pass anyway"
+        );
+    }
+
+    // Nudge the model to produce the final briefing. The final call passes a
+    // structured-output schema so the response is a JSON object with a
+    // `briefing_content` field — the model needs to know this, otherwise it
+    // will write raw markdown and the parse will fail.
+    state.messages.push(Message::user(
+        "Now write the final briefing. Respond with a JSON object matching the \
+         briefing_generation_result schema: set `briefing_content` to 2-3 short \
+         paragraphs of markdown with [N] citation markers, and set `citations_used` \
+         to the list of citation numbers you referenced. Do not call any tools."
+            .to_string(),
+    ));
+
+    let content = final_briefing_call(&provider_config, &model, &state.messages).await?;
+
+    let citations = extract_citations(&content, new_atoms);
+    tracing::info!(
+        citations = citations.len(),
+        "[briefing/agentic] Briefing generated"
+    );
+
+    Ok((content, citations))
+}

--- a/crates/atomic-core/src/briefing/mod.rs
+++ b/crates/atomic-core/src/briefing/mod.rs
@@ -1,0 +1,159 @@
+//! Daily briefing generation.
+//!
+//! Produces a short 2-3 paragraph summary of atoms added to the knowledge
+//! base since the last briefing run. The heavy lifting is in [`agentic`],
+//! which mirrors the wiki agentic strategy — an LLM with a tiny tool set
+//! curates context, then writes the final briefing in a tool-free pass.
+//!
+//! Public entry point is [`run_briefing`]. Storage lives in new `briefings`
+//! and `briefing_citations` tables (migration v12). See also
+//! [`crate::scheduler`] for the task that invokes this on a timer.
+
+pub mod agentic;
+pub mod task;
+
+pub use task::DailyBriefingTask;
+
+use crate::error::AtomicCoreError;
+use crate::AtomicCore;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A generated daily briefing. Mirrors the shape of `WikiArticle`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct Briefing {
+    pub id: String,
+    pub content: String,
+    pub created_at: String,
+    /// Number of atoms that were visible to the agent for this run. May be
+    /// less than the total number of atoms added in the period if the run
+    /// hit the 100-atom cap.
+    pub atom_count: i32,
+    /// Timestamp of the previous briefing run (or the seeded "7 days ago"
+    /// on the first run). Used by clients to show "N new atoms since X".
+    pub last_run_at: String,
+}
+
+/// A single citation attached to a briefing. The `source_url` field is
+/// populated by a JOIN on read and is not stored on the row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct BriefingCitation {
+    pub id: String,
+    pub briefing_id: String,
+    pub citation_index: i32,
+    pub atom_id: String,
+    pub excerpt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+}
+
+/// A briefing joined with its citations — the primary read shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct BriefingWithCitations {
+    pub briefing: Briefing,
+    pub citations: Vec<BriefingCitation>,
+}
+
+/// Bounded number of new atoms sent to the LLM on a single run. Prevents
+/// long context explosions while still giving the agent substantial material
+/// on busy days.
+const MAX_NEW_ATOMS: usize = 100;
+
+/// Hardcoded briefing content returned when no new atoms exist.
+fn empty_briefing_content(since: &DateTime<Utc>) -> String {
+    format!("Nothing new since {}.", since.to_rfc3339())
+}
+
+/// Generate a daily briefing for all atoms created after `since`.
+///
+/// Flow:
+/// 1. Fetch up to [`MAX_NEW_ATOMS`] atoms with `created_at > since`,
+///    ordered by `created_at DESC`.
+/// 2. If zero atoms: insert a placeholder briefing ("Nothing new since ...")
+///    and return it without invoking the LLM.
+/// 3. Otherwise: run the agentic loop over the new atoms, synthesize the
+///    briefing, extract `[N]` citations, and persist.
+pub async fn run_briefing(
+    core: &AtomicCore,
+    since: DateTime<Utc>,
+) -> Result<BriefingWithCitations, AtomicCoreError> {
+    let since_str = since.to_rfc3339();
+    tracing::info!(since = %since_str, "[briefing] Starting daily briefing run");
+
+    let new_atoms = core
+        .storage()
+        .list_new_atoms_since_sync(&since_str, MAX_NEW_ATOMS as i32)?;
+    let total_new = core
+        .storage()
+        .count_new_atoms_since_sync(&since_str)?;
+
+    tracing::info!(
+        visible = new_atoms.len(),
+        total = total_new,
+        "[briefing] Fetched new atoms"
+    );
+
+    // Zero-atom fast path: no LLM call.
+    if new_atoms.is_empty() {
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = Utc::now().to_rfc3339();
+        let briefing = Briefing {
+            id: id.clone(),
+            content: empty_briefing_content(&since),
+            created_at: now.clone(),
+            atom_count: 0,
+            last_run_at: since_str.clone(),
+        };
+        let saved = core
+            .storage()
+            .insert_briefing_sync(&briefing, &[])?;
+        tracing::info!(briefing_id = %saved.briefing.id, "[briefing] Saved empty briefing (no new atoms)");
+        return Ok(saved);
+    }
+
+    // Run the agent loop.
+    let (content, citations) = agentic::generate(
+        core,
+        &since,
+        &new_atoms,
+        total_new,
+    )
+    .await
+    .map_err(AtomicCoreError::Wiki)?;
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let now = Utc::now().to_rfc3339();
+    let briefing = Briefing {
+        id: id.clone(),
+        content,
+        created_at: now.clone(),
+        atom_count: new_atoms.len() as i32,
+        last_run_at: since_str.clone(),
+    };
+
+    // Materialize citations with the briefing_id.
+    let citations: Vec<BriefingCitation> = citations
+        .into_iter()
+        .map(|(index, atom_id, excerpt)| BriefingCitation {
+            id: uuid::Uuid::new_v4().to_string(),
+            briefing_id: id.clone(),
+            citation_index: index,
+            atom_id,
+            excerpt,
+            source_url: None,
+        })
+        .collect();
+
+    let saved = core
+        .storage()
+        .insert_briefing_sync(&briefing, &citations)?;
+    tracing::info!(
+        briefing_id = %saved.briefing.id,
+        citations = saved.citations.len(),
+        "[briefing] Saved briefing"
+    );
+    Ok(saved)
+}

--- a/crates/atomic-core/src/briefing/task.rs
+++ b/crates/atomic-core/src/briefing/task.rs
@@ -8,7 +8,6 @@
 use crate::scheduler::{state as task_state, ScheduledTask, TaskContext, TaskError, TaskEvent};
 use crate::AtomicCore;
 use async_trait::async_trait;
-use chrono::Utc;
 use std::time::Duration;
 
 /// The daily briefing task.
@@ -17,10 +16,6 @@ pub struct DailyBriefingTask;
 const TASK_ID: &str = "daily_briefing";
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const DEFAULT_ENABLED: bool = true;
-
-/// When the task has never run, seed `since` with this lookback so the
-/// first briefing has real material to summarize.
-const FIRST_RUN_LOOKBACK_DAYS: i64 = 7;
 
 #[async_trait]
 impl ScheduledTask for DailyBriefingTask {
@@ -54,25 +49,17 @@ impl ScheduledTask for DailyBriefingTask {
             .map(|s| s.to_string())
             .unwrap_or_else(|| "default".to_string());
 
-        let since = task_state::get_last_run(core, TASK_ID)?
-            .unwrap_or_else(|| Utc::now() - chrono::Duration::days(FIRST_RUN_LOOKBACK_DAYS));
-
         (ctx.event_cb)(TaskEvent::Started {
             task_id: TASK_ID.to_string(),
             db_id: db_id.clone(),
         });
 
-        match super::run_briefing(core, since).await {
+        // Delegate to `run_daily_briefing` so the scheduler tick contends for
+        // the same single-flight lock as the HTTP route. `run_daily_briefing`
+        // also computes `since` from the persisted `last_run` (same 7-day
+        // first-run lookback) and persists a fresh `last_run` on success.
+        match core.run_daily_briefing().await {
             Ok(result) => {
-                // Persist last_run so subsequent ticks correctly skip until
-                // the next interval elapses.
-                if let Err(e) = task_state::set_last_run(core, TASK_ID, Utc::now()) {
-                    tracing::warn!(
-                        task_id = TASK_ID,
-                        error = %e,
-                        "[scheduler] Failed to persist task last_run"
-                    );
-                }
                 (ctx.event_cb)(TaskEvent::Completed {
                     task_id: TASK_ID.to_string(),
                     db_id,

--- a/crates/atomic-core/src/briefing/task.rs
+++ b/crates/atomic-core/src/briefing/task.rs
@@ -1,0 +1,94 @@
+//! Daily briefing scheduled task.
+//!
+//! Wraps [`super::run_briefing`] in the [`ScheduledTask`] trait so the
+//! scheduler loop can drive it on a timer. State (`last_run`, `enabled`,
+//! `interval_hours`) lives in the per-database settings table keyed under
+//! `task.daily_briefing.*`.
+
+use crate::scheduler::{state as task_state, ScheduledTask, TaskContext, TaskError, TaskEvent};
+use crate::AtomicCore;
+use async_trait::async_trait;
+use chrono::Utc;
+use std::time::Duration;
+
+/// The daily briefing task.
+pub struct DailyBriefingTask;
+
+const TASK_ID: &str = "daily_briefing";
+const DEFAULT_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+const DEFAULT_ENABLED: bool = true;
+
+/// When the task has never run, seed `since` with this lookback so the
+/// first briefing has real material to summarize.
+const FIRST_RUN_LOOKBACK_DAYS: i64 = 7;
+
+#[async_trait]
+impl ScheduledTask for DailyBriefingTask {
+    fn id(&self) -> &'static str {
+        TASK_ID
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Daily briefing"
+    }
+
+    fn default_interval(&self) -> Duration {
+        DEFAULT_INTERVAL
+    }
+
+    async fn run(&self, core: &AtomicCore, ctx: &TaskContext) -> Result<(), TaskError> {
+        if !task_state::is_enabled(core, TASK_ID, DEFAULT_ENABLED) {
+            return Err(TaskError::Disabled);
+        }
+        if !task_state::is_due(core, TASK_ID, DEFAULT_INTERVAL, DEFAULT_ENABLED) {
+            return Err(TaskError::NotDue);
+        }
+
+        // Resolve the db_id for event reporting. For SQLite we use the file
+        // stem; Postgres is not supported for briefings but the task ID is
+        // still meaningful.
+        let db_id = core
+            .db_path()
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "default".to_string());
+
+        let since = task_state::get_last_run(core, TASK_ID)?
+            .unwrap_or_else(|| Utc::now() - chrono::Duration::days(FIRST_RUN_LOOKBACK_DAYS));
+
+        (ctx.event_cb)(TaskEvent::Started {
+            task_id: TASK_ID.to_string(),
+            db_id: db_id.clone(),
+        });
+
+        match super::run_briefing(core, since).await {
+            Ok(result) => {
+                // Persist last_run so subsequent ticks correctly skip until
+                // the next interval elapses.
+                if let Err(e) = task_state::set_last_run(core, TASK_ID, Utc::now()) {
+                    tracing::warn!(
+                        task_id = TASK_ID,
+                        error = %e,
+                        "[scheduler] Failed to persist task last_run"
+                    );
+                }
+                (ctx.event_cb)(TaskEvent::Completed {
+                    task_id: TASK_ID.to_string(),
+                    db_id,
+                    result_id: Some(result.briefing.id.clone()),
+                });
+                Ok(())
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                (ctx.event_cb)(TaskEvent::Failed {
+                    task_id: TASK_ID.to_string(),
+                    db_id,
+                    error: msg.clone(),
+                });
+                Err(TaskError::Other(msg))
+            }
+        }
+    }
+}

--- a/crates/atomic-core/src/compaction.rs
+++ b/crates/atomic-core/src/compaction.rs
@@ -2,9 +2,9 @@
 //!
 //! This module handles LLM-assisted tag merging and categorization.
 
-use crate::providers::traits::LlmConfig;
-use crate::providers::types::{GenerationParams, Message, StructuredOutputSchema};
-use crate::providers::{get_llm_provider, ProviderConfig};
+use crate::providers::structured::{call_structured, StructuredCall};
+use crate::providers::types::{GenerationParams, Message};
+use crate::providers::ProviderConfig;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -53,7 +53,7 @@ EXAMPLES of BAD merges (don't do these):
 
 Return an empty merges array if no clear merges are warranted."#;
 
-fn merge_schema() -> serde_json::Value {
+pub(crate) fn merge_schema() -> serde_json::Value {
     serde_json::json!({
         "type": "object",
         "properties": {
@@ -189,51 +189,28 @@ async fn get_merge_suggestions(
 
     let mut params = GenerationParams::new()
         .with_temperature(0.1)
-        .with_structured_output(StructuredOutputSchema::new("merge_result", merge_schema()))
         .with_minimize_reasoning(true);
-
     if let Some(supported) = supported_params {
         params = params.with_supported_parameters(supported);
     }
 
-    let llm_config = LlmConfig::new(model).with_params(params);
-    let provider = get_llm_provider(provider_config).map_err(|e| e.to_string())?;
+    let call = StructuredCall::<MergeResult>::new(
+        provider_config,
+        model,
+        &messages,
+        "merge_result",
+        merge_schema(),
+    )
+    .with_params(params)
+    .with_max_retries(3);
 
-    let mut last_error = String::new();
-    for attempt in 0..3 {
-        if attempt > 0 {
-            tokio::time::sleep(std::time::Duration::from_secs(1 << attempt)).await;
-        }
-
-        match provider.complete(&messages, &llm_config).await {
-            Ok(response) => {
-                let content = &response.content;
-                if !content.is_empty() {
-                    tracing::debug!(output = %content, "MERGE LLM OUTPUT");
-
-                    let result: MergeResult = serde_json::from_str(content).map_err(|e| {
-                        format!("Failed to parse merge result: {} - Content: {}", e, content)
-                    })?;
-                    return Ok(result);
-                }
-                return Err("No content in response".to_string());
-            }
-            Err(e) => {
-                let err_str = e.to_string();
-                if e.is_retryable() {
-                    tracing::warn!(attempt = attempt + 1, max_attempts = 3, model = %model, error = %err_str, "Tag merge LLM call failed (retryable)");
-                    last_error = err_str;
-                    continue;
-                } else {
-                    tracing::error!(model = %model, error = %err_str, "Tag merge LLM call failed (non-retryable)");
-                    last_error = err_str;
-                    break;
-                }
-            }
+    match call_structured::<MergeResult>(call).await {
+        Ok(result) => Ok(result),
+        Err(e) => {
+            tracing::error!(model = %model, error = %e, "Tag merge call failed");
+            Err(e.to_compact_string())
         }
     }
-
-    Err(last_error)
 }
 
 fn execute_tag_merge(conn: &Connection, merge: &TagMerge) -> Result<(bool, i32), String> {
@@ -378,12 +355,21 @@ pub async fn fetch_merge_suggestions(
 mod tests {
     use super::*;
     use crate::db::Database;
+    use crate::providers::structured::lint_schema;
     use tempfile::NamedTempFile;
 
     fn create_test_db() -> (Database, NamedTempFile) {
         let temp_file = NamedTempFile::new().unwrap();
         let db = Database::open_or_create(temp_file.path()).unwrap();
         (db, temp_file)
+    }
+
+    // ==================== Schema lint regression test ====================
+
+    #[test]
+    fn lint_merge_schema_is_portable() {
+        lint_schema(&merge_schema())
+            .expect("merge_schema must be portable across providers");
     }
 
     fn insert_tag(conn: &Connection, id: &str, name: &str, parent_id: Option<&str>) {

--- a/crates/atomic-core/src/db.rs
+++ b/crates/atomic-core/src/db.rs
@@ -199,7 +199,7 @@ impl Database {
     ///   1. Add a new `if version < N` block at the end (before the virtual-table section)
     ///   2. End the block with `PRAGMA user_version = N;`
     ///   3. Bump LATEST_VERSION
-    const LATEST_VERSION: i32 = 11;
+    const LATEST_VERSION: i32 = 12;
 
     pub fn run_migrations(conn: &Connection) -> Result<(), AtomicCoreError> {
         let version: i32 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
@@ -642,6 +642,35 @@ impl Database {
                    WHERE parent_id IS NULL
                      AND name IN ('Topics', 'People', 'Locations', 'Organizations', 'Events');
                  PRAGMA user_version = 11;",
+            )?;
+        }
+
+        // --- V11 → V12: Daily briefings + briefing citations ---
+        if version < 12 {
+            conn.execute_batch(
+                r#"
+                CREATE TABLE IF NOT EXISTS briefings (
+                    id TEXT PRIMARY KEY,
+                    content TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    atom_count INTEGER NOT NULL,
+                    last_run_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS briefing_citations (
+                    id TEXT PRIMARY KEY,
+                    briefing_id TEXT NOT NULL REFERENCES briefings(id) ON DELETE CASCADE,
+                    citation_index INTEGER NOT NULL,
+                    atom_id TEXT NOT NULL REFERENCES atoms(id) ON DELETE CASCADE,
+                    excerpt TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_briefings_created ON briefings(created_at DESC);
+                CREATE INDEX IF NOT EXISTS idx_briefing_citations_briefing
+                    ON briefing_citations(briefing_id);
+
+                PRAGMA user_version = 12;
+                "#,
             )?;
         }
 

--- a/crates/atomic-core/src/error.rs
+++ b/crates/atomic-core/src/error.rs
@@ -37,6 +37,10 @@ pub enum AtomicCoreError {
     #[error("Lock error: {0}")]
     Lock(String),
 
+    /// Conflict with existing in-flight operation (e.g., a concurrent request).
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
     /// Embedding generation error
     #[error("Embedding error: {0}")]
     Embedding(String),

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -2,18 +2,32 @@
 //!
 //! This module handles automatic tag extraction from atom content.
 
-use crate::providers::traits::LlmConfig;
-use crate::providers::types::{GenerationParams, Message, StructuredOutputSchema};
-use crate::providers::{get_llm_provider, ProviderConfig};
+use crate::providers::structured::{call_structured, StructuredCall};
+use crate::providers::types::{GenerationParams, Message};
+use crate::providers::ProviderConfig;
 use rusqlite::Connection;
 use serde::Deserialize;
 use std::sync::{LazyLock, Mutex};
 
-// Extraction result types — ExtractionResult is the schema-enforced format (OpenRouter);
-// some providers (Ollama) may return a bare array instead, handled by parse_tag_extractions().
+/// Tag extraction response shape. Accepts both the schema-enforced wrapped
+/// form `{"tags": [...]}` and a bare array `[...]` — some local/OSS providers
+/// routed via OpenRouter (or Ollama directly) return the bare form even when
+/// given an object schema. Serde's `untagged` attribute tries each variant
+/// in order so either shape deserializes into the same value.
 #[derive(Debug, Clone, Deserialize)]
-struct ExtractionResult {
-    tags: Vec<TagApplication>,
+#[serde(untagged)]
+enum ExtractionResult {
+    Wrapped { tags: Vec<TagApplication> },
+    Bare(Vec<TagApplication>),
+}
+
+impl ExtractionResult {
+    fn into_tags(self) -> Vec<TagApplication> {
+        match self {
+            ExtractionResult::Wrapped { tags } => tags,
+            ExtractionResult::Bare(tags) => tags,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -129,42 +143,86 @@ Guidelines:
 - Every tag must have a valid parent_name from the top-level categories listed below
 - If none of the categories below feel like a natural fit for the content, return an empty tag list rather than forcing a poor match"#;
 
-/// Parse tag extractions from LLM output, handling both:
-/// - `{"tags": [...]}` (schema-enforced, OpenRouter/OpenAI)
-/// - `[...]` (bare array, common from Ollama/local models)
-fn parse_tag_extractions(json: &str, raw_content: &str) -> Result<Vec<TagApplication>, String> {
-    if let Ok(result) = serde_json::from_str::<ExtractionResult>(json) {
-        return Ok(result.tags);
-    }
-    if let Ok(tags) = serde_json::from_str::<Vec<TagApplication>>(json) {
-        return Ok(tags);
-    }
-    match serde_json::from_str::<serde_json::Value>(json) {
-        Ok(val) => Err(format!(
-            "Unexpected JSON shape for tag extraction: {} - Content: {}",
-            val, raw_content
-        )),
-        Err(err) => Err(format!(
-            "Failed to parse extraction result: {} - Content: {}",
-            err, raw_content
-        )),
-    }
+/// JSON schema for tag extraction calls. Shared by `extract_tags_from_content`
+/// and `extract_tags_from_chunk`. Kept portable: all properties required,
+/// `additionalProperties: false`, no unions. See `providers::structured::lint_schema`
+/// for the full portability rule set.
+pub(crate) fn extraction_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "tags": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the tag to apply"
+                        },
+                        "parent_name": {
+                            "type": "string",
+                            "description": "Name of parent tag, or empty string for top-level categories"
+                        }
+                    },
+                    "required": ["name", "parent_name"],
+                    "additionalProperties": false
+                },
+                "description": "Tags to apply to this text"
+            }
+        },
+        "required": ["tags"],
+        "additionalProperties": false
+    })
 }
 
-/// Strip markdown code fences from LLM output before parsing as JSON.
-/// Some models wrap structured output in ```json ... ``` fences.
-fn strip_markdown_fences(content: &str) -> String {
-    let trimmed = content.trim();
-    if trimmed.starts_with("```") {
-        trimmed
-            .lines()
-            .skip(1)
-            .take_while(|l| !l.starts_with("```"))
-            .collect::<Vec<_>>()
-            .join("\n")
-    } else {
-        trimmed.to_string()
+/// JSON schema for tag consolidation calls.
+pub(crate) fn consolidation_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "tags_to_remove": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Names of tags to remove"
+            },
+            "tags_to_add": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the tag to add"
+                        },
+                        "parent_name": {
+                            "type": "string",
+                            "description": "Name of parent tag, or empty string for top-level categories"
+                        }
+                    },
+                    "required": ["name", "parent_name"],
+                    "additionalProperties": false
+                },
+                "description": "New broader tags to create and add"
+            }
+        },
+        "required": ["tags_to_remove", "tags_to_add"],
+        "additionalProperties": false
+    })
+}
+
+/// Build the shared generation params for extraction calls. Temperature 0.1
+/// (tag-picking is nearly deterministic), reasoning minimized, optional
+/// `supported_params` threaded through so we don't send fields the router's
+/// downstream provider doesn't accept.
+fn extraction_params(supported_params: Option<Vec<String>>) -> GenerationParams {
+    let mut params = GenerationParams::new()
+        .with_temperature(0.1)
+        .with_minimize_reasoning(true);
+    if let Some(supported) = supported_params {
+        params = params.with_supported_parameters(supported);
     }
+    params
 }
 
 /// Default maximum characters to send for tagging (~30K tokens ≈ 120K chars)
@@ -220,83 +278,25 @@ pub async fn extract_tags_from_content(
         tag_tree_json, text
     );
 
-    let schema = serde_json::json!({
-        "type": "object",
-        "properties": {
-            "tags": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Name of the tag to apply"
-                        },
-                        "parent_name": {
-                            "type": "string",
-                            "description": "Name of parent tag, or empty string for top-level categories"
-                        }
-                    },
-                    "required": ["name", "parent_name"],
-                    "additionalProperties": false
-                },
-                "description": "Tags to apply to this text"
-            }
-        },
-        "required": ["tags"],
-        "additionalProperties": false
-    });
-
     let messages = vec![Message::system(SYSTEM_PROMPT), Message::user(user_content)];
 
-    let mut params = GenerationParams::new()
-        .with_temperature(0.1)
-        .with_structured_output(StructuredOutputSchema::new("extraction_result", schema))
-        .with_minimize_reasoning(true);
+    let call = StructuredCall::<ExtractionResult>::new(
+        provider_config,
+        model,
+        &messages,
+        "extraction_result",
+        extraction_schema(),
+    )
+    .with_params(extraction_params(supported_params))
+    .with_max_retries(3);
 
-    if let Some(supported) = supported_params {
-        params = params.with_supported_parameters(supported);
-    }
-
-    let llm_config = LlmConfig::new(model).with_params(params);
-
-    let provider = get_llm_provider(provider_config).map_err(|e| e.to_string())?;
-
-    // Retry logic with exponential backoff
-    let mut last_error = String::new();
-    for attempt in 0..3 {
-        if attempt > 0 {
-            tokio::time::sleep(std::time::Duration::from_secs(1 << attempt)).await;
-        }
-
-        match provider.complete(&messages, &llm_config).await {
-            Ok(response) => {
-                let response_content = &response.content;
-                if !response_content.is_empty() {
-                    tracing::debug!(output = %response_content, "TAG EXTRACTION LLM OUTPUT");
-
-                    let cleaned = strip_markdown_fences(response_content);
-                    let tags = parse_tag_extractions(&cleaned, response_content)?;
-                    return Ok(tags);
-                }
-                return Err("No content in response".to_string());
-            }
-            Err(e) => {
-                let err_str = e.to_string();
-                if e.is_retryable() {
-                    tracing::warn!(attempt = attempt + 1, max_attempts = 3, model = %model, error = %err_str, "Tag extraction LLM call failed (retryable)");
-                    last_error = err_str;
-                    continue;
-                } else {
-                    tracing::error!(model = %model, error = %err_str, "Tag extraction LLM call failed (non-retryable)");
-                    last_error = err_str;
-                    break;
-                }
-            }
+    match call_structured::<ExtractionResult>(call).await {
+        Ok(result) => Ok(result.into_tags()),
+        Err(e) => {
+            tracing::error!(model = %model, error = %e, "Tag extraction failed");
+            Err(e.to_compact_string())
         }
     }
-
-    Err(last_error)
 }
 
 /// Extract tags from a single chunk using LLM provider
@@ -312,86 +312,25 @@ pub async fn extract_tags_from_chunk(
         tag_tree_json, chunk_content
     );
 
-    let schema = serde_json::json!({
-        "type": "object",
-        "properties": {
-            "tags": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Name of the tag to apply"
-                        },
-                        "parent_name": {
-                            "type": "string",
-                            "description": "Name of parent tag, or empty string for top-level categories"
-                        }
-                    },
-                    "required": ["name", "parent_name"],
-                    "additionalProperties": false
-                },
-                "description": "Tags to apply to this text"
-            }
-        },
-        "required": ["tags"],
-        "additionalProperties": false
-    });
-
     let messages = vec![Message::system(SYSTEM_PROMPT), Message::user(user_content)];
 
-    let mut params = GenerationParams::new()
-        .with_temperature(0.1)
-        .with_structured_output(StructuredOutputSchema::new("extraction_result", schema))
-        .with_minimize_reasoning(true); // Speed up reasoning models for simple tag extraction
+    let call = StructuredCall::<ExtractionResult>::new(
+        provider_config,
+        model,
+        &messages,
+        "extraction_result",
+        extraction_schema(),
+    )
+    .with_params(extraction_params(supported_params))
+    .with_max_retries(3);
 
-    if let Some(supported) = supported_params {
-        params = params.with_supported_parameters(supported);
-    }
-
-    let llm_config = LlmConfig::new(model).with_params(params);
-
-    let provider = get_llm_provider(provider_config).map_err(|e| e.to_string())?;
-
-    // Retry logic with exponential backoff
-    let mut last_error = String::new();
-    for attempt in 0..3 {
-        if attempt > 0 {
-            // Exponential backoff: 1s, 2s, 4s
-            tokio::time::sleep(std::time::Duration::from_secs(1 << attempt)).await;
-        }
-
-        match provider.complete(&messages, &llm_config).await {
-            Ok(response) => {
-                let content = &response.content;
-                if !content.is_empty() {
-                    tracing::debug!(output = %content, "TAG EXTRACTION LLM OUTPUT");
-
-                    // Parse the extraction result from the content
-                    let cleaned = strip_markdown_fences(content);
-                    let tags = parse_tag_extractions(&cleaned, content)?;
-                    return Ok(tags);
-                }
-                return Err("No content in response".to_string());
-            }
-            Err(e) => {
-                let err_str = e.to_string();
-                if e.is_retryable() {
-                    tracing::warn!(attempt = attempt + 1, max_attempts = 3, model = %model, error = %err_str, "Tag extraction (chunk) LLM call failed (retryable)");
-                    last_error = err_str;
-                    continue;
-                } else {
-                    tracing::error!(model = %model, error = %err_str, "Tag extraction (chunk) LLM call failed (non-retryable)");
-                    // Don't retry on non-retryable errors
-                    last_error = err_str;
-                    break;
-                }
-            }
+    match call_structured::<ExtractionResult>(call).await {
+        Ok(result) => Ok(result.into_tags()),
+        Err(e) => {
+            tracing::error!(model = %model, error = %e, "Tag extraction (chunk) failed");
+            Err(e.to_compact_string())
         }
     }
-
-    Err(last_error)
 }
 
 /// Get simplified tag tree for LLM (tree format like `tree` CLI)
@@ -670,111 +609,95 @@ pub async fn consolidate_atom_tags(
         tag_info
     );
 
-    let schema = serde_json::json!({
-        "type": "object",
-        "properties": {
-            "tags_to_remove": {
-                "type": "array",
-                "items": { "type": "string" },
-                "description": "Names of tags to remove"
-            },
-            "tags_to_add": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Name of the tag to add"
-                        },
-                        "parent_name": {
-                            "type": "string",
-                            "description": "Name of parent tag, or empty string for top-level categories"
-                        }
-                    },
-                    "required": ["name", "parent_name"],
-                    "additionalProperties": false
-                },
-                "description": "New broader tags to create and add"
-            }
-        },
-        "required": ["tags_to_remove", "tags_to_add"],
-        "additionalProperties": false
-    });
-
     let messages = vec![
         Message::system(TAG_CONSOLIDATION_PROMPT),
         Message::user(user_content),
     ];
 
-    let mut params = GenerationParams::new()
-        .with_temperature(0.1)
-        .with_structured_output(StructuredOutputSchema::new("consolidation_result", schema))
-        .with_minimize_reasoning(true); // Speed up reasoning models for simple consolidation
+    let call = StructuredCall::<TagConsolidationResult>::new(
+        provider_config,
+        model,
+        &messages,
+        "consolidation_result",
+        consolidation_schema(),
+    )
+    .with_params(extraction_params(supported_params))
+    .with_max_retries(3);
 
-    if let Some(supported) = supported_params {
-        params = params.with_supported_parameters(supported);
-    }
-
-    let llm_config = LlmConfig::new(model).with_params(params);
-
-    let provider = get_llm_provider(provider_config).map_err(|e| e.to_string())?;
-
-    // Retry logic with exponential backoff
-    let mut last_error = String::new();
-    for attempt in 0..3 {
-        if attempt > 0 {
-            // Exponential backoff: 1s, 2s, 4s
-            tokio::time::sleep(std::time::Duration::from_secs(1 << attempt)).await;
-        }
-
-        match provider.complete(&messages, &llm_config).await {
-            Ok(response) => {
-                let content = &response.content;
-                if !content.is_empty() {
-                    tracing::debug!(output = %content, "TAG CONSOLIDATION LLM OUTPUT");
-
-                    // Parse the consolidation result from the content
-                    let result: TagConsolidationResult =
-                        serde_json::from_str(content).map_err(|e| {
-                            format!(
-                                "Failed to parse consolidation result: {} - Content: {}",
-                                e, content
-                            )
-                        })?;
-                    return Ok(result);
-                }
-                return Err("No content in response".to_string());
-            }
-            Err(e) => {
-                let err_str = e.to_string();
-                if e.is_retryable() {
-                    tracing::warn!(attempt = attempt + 1, max_attempts = 3, model = %model, error = %err_str, "Tag consolidation LLM call failed (retryable)");
-                    last_error = err_str;
-                    continue;
-                } else {
-                    tracing::error!(model = %model, error = %err_str, "Tag consolidation LLM call failed (non-retryable)");
-                    // Don't retry on non-retryable errors
-                    last_error = err_str;
-                    break;
-                }
-            }
+    match call_structured::<TagConsolidationResult>(call).await {
+        Ok(result) => Ok(result),
+        Err(e) => {
+            tracing::error!(model = %model, error = %e, "Tag consolidation failed");
+            Err(e.to_compact_string())
         }
     }
-
-    Err(last_error)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::db::Database;
+    use crate::providers::structured::lint_schema;
     use tempfile::NamedTempFile;
 
     fn create_test_db() -> (Database, NamedTempFile) {
         let temp_file = NamedTempFile::new().unwrap();
         let db = Database::open_or_create(temp_file.path()).unwrap();
         (db, temp_file)
+    }
+
+    // ==================== Schema lint regression tests ====================
+
+    #[test]
+    fn lint_extraction_schema_is_portable() {
+        lint_schema(&extraction_schema())
+            .expect("extraction_schema must be portable across providers");
+    }
+
+    #[test]
+    fn lint_consolidation_schema_is_portable() {
+        lint_schema(&consolidation_schema())
+            .expect("consolidation_schema must be portable across providers");
+    }
+
+    // ==================== ExtractionResult shape tolerance ====================
+    //
+    // Some providers return the schema-enforced wrapped form `{"tags": [...]}`
+    // while others (notably Ollama-hosted and some OpenRouter-routed OSS
+    // models) return a bare array `[...]`. The untagged serde enum should
+    // accept both, and `into_tags()` should flatten either into the same
+    // `Vec<TagApplication>`.
+
+    #[test]
+    fn extraction_result_accepts_wrapped_form() {
+        let json = r#"{"tags":[{"name":"AI","parent_name":"Topics"}]}"#;
+        let result: ExtractionResult = serde_json::from_str(json).unwrap();
+        let tags = result.into_tags();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "AI");
+    }
+
+    #[test]
+    fn extraction_result_accepts_bare_array_form() {
+        let json = r#"[{"name":"AI","parent_name":"Topics"}]"#;
+        let result: ExtractionResult = serde_json::from_str(json).unwrap();
+        let tags = result.into_tags();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "AI");
+    }
+
+    #[test]
+    fn extraction_result_accepts_empty_wrapped() {
+        let json = r#"{"tags":[]}"#;
+        let result: ExtractionResult = serde_json::from_str(json).unwrap();
+        assert!(result.into_tags().is_empty());
+    }
+
+    #[test]
+    fn extraction_result_accepts_empty_bare() {
+        let json = "[]";
+        let result: ExtractionResult = serde_json::from_str(json).unwrap();
+        assert!(result.into_tags().is_empty());
     }
 
     // ==================== Tag Tree Generation Tests ====================

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -1374,6 +1374,12 @@ impl AtomicCore {
         self.storage.get_latest_briefing_sync()
     }
 
+    /// Get a specific briefing by id, joined with citations. Returns `None`
+    /// if no briefing with that id exists.
+    pub fn get_briefing(&self, id: &str) -> Result<Option<briefing::BriefingWithCitations>, AtomicCoreError> {
+        self.storage.get_briefing_sync(id)
+    }
+
     /// List recent briefings (without citations) for a lightweight history view.
     pub fn list_briefings(&self, limit: i32) -> Result<Vec<briefing::Briefing>, AtomicCoreError> {
         self.storage.list_briefings_sync(limit)

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -28,6 +28,7 @@
 //! ```
 
 pub mod agent;
+pub mod briefing;
 pub mod canvas_level;
 pub mod chunking;
 pub mod chat;
@@ -45,6 +46,7 @@ pub mod models;
 pub mod projection;
 pub mod providers;
 pub mod registry;
+pub mod scheduler;
 pub mod search;
 pub mod storage;
 pub mod settings;
@@ -53,6 +55,7 @@ pub mod wiki;
 
 // Re-exports for convenience
 pub use agent::{ChatEvent, CanvasContext, CanvasClusterSummary};
+pub use briefing::{Briefing, BriefingCitation, BriefingWithCitations};
 pub use db::Database;
 pub use embedding::EmbeddingEvent;
 pub use error::AtomicCoreError;
@@ -463,6 +466,13 @@ impl AtomicCore {
     /// Returns None for Postgres backend.
     pub fn database(&self) -> Option<Arc<Database>> {
         self.storage.as_sqlite().map(|s| Arc::clone(&s.db))
+    }
+
+    /// Get a reference to the underlying storage backend. Used by sibling
+    /// modules (briefing, scheduler helpers) that need to issue storage
+    /// calls directly without going through the full facade surface.
+    pub(crate) fn storage(&self) -> &storage::StorageBackend {
+        &self.storage
     }
 
     // ==================== Settings ====================
@@ -1324,6 +1334,37 @@ impl AtomicCore {
     /// Get a specific wiki article version
     pub fn get_wiki_version(&self, version_id: &str) -> Result<Option<WikiArticleVersion>, AtomicCoreError> {
         self.storage.get_wiki_version_sync(version_id)
+    }
+
+    // ==================== Daily Briefing ====================
+
+    /// Run the daily briefing pipeline immediately. Used by the scheduled
+    /// task and the `/briefings/run` route. Computes `since` from the
+    /// persisted `task.daily_briefing.last_run` (or a 7-day lookback on the
+    /// first run), invokes the agentic loop, and persists the result.
+    ///
+    /// Updates `task.daily_briefing.last_run` on success so the next
+    /// scheduled tick correctly waits for the full interval. On failure the
+    /// error bubbles up and `last_run` is left unchanged — the scheduler
+    /// will retry on the next tick.
+    pub async fn run_daily_briefing(&self) -> Result<briefing::BriefingWithCitations, AtomicCoreError> {
+        let since = scheduler::state::get_last_run(self, "daily_briefing")?
+            .unwrap_or_else(|| chrono::Utc::now() - chrono::Duration::days(7));
+        let result = briefing::run_briefing(self, since).await?;
+        if let Err(e) = scheduler::state::set_last_run(self, "daily_briefing", chrono::Utc::now()) {
+            tracing::warn!(error = %e, "[briefing] Failed to persist daily_briefing last_run");
+        }
+        Ok(result)
+    }
+
+    /// Get the most recent briefing joined with citations.
+    pub fn get_latest_briefing(&self) -> Result<Option<briefing::BriefingWithCitations>, AtomicCoreError> {
+        self.storage.get_latest_briefing_sync()
+    }
+
+    /// List recent briefings (without citations) for a lightweight history view.
+    pub fn list_briefings(&self, limit: i32) -> Result<Vec<briefing::Briefing>, AtomicCoreError> {
+        self.storage.list_briefings_sync(limit)
     }
 
     // ==================== Embedding Management ====================

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -239,6 +239,11 @@ pub struct AtomicCore {
     /// created lazily and persist for the lifetime of the process — the
     /// working set is bounded by the number of wiki articles touched.
     wiki_tag_locks: Arc<std::sync::Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// Single-flight guard for `run_daily_briefing`. Both the scheduler tick
+    /// loop and the `POST /api/briefings/run` route contend for this lock —
+    /// `try_lock` rejects the loser with `Conflict` so we never fire two
+    /// overlapping LLM calls for the same coverage window.
+    briefing_lock: Arc<tokio::sync::Mutex<()>>,
     /// In-memory cache for `compute_and_get_canvas_data`. Shared across clones
     /// so every handle sees the same cached payload.
     canvas_cache: CanvasCache,
@@ -253,6 +258,7 @@ impl AtomicCore {
             storage,
             registry: None,
             wiki_tag_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            briefing_lock: Arc::new(tokio::sync::Mutex::new(())),
             canvas_cache: CanvasCache::new(),
         };
         core.register_canvas_rebuilder();
@@ -323,6 +329,7 @@ impl AtomicCore {
             storage,
             registry,
             wiki_tag_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            briefing_lock: Arc::new(tokio::sync::Mutex::new(())),
             canvas_cache: CanvasCache::new(),
         };
         core.register_canvas_rebuilder();
@@ -336,6 +343,7 @@ impl AtomicCore {
             storage: storage::StorageBackend::Postgres(pg),
             registry: None,
             wiki_tag_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            briefing_lock: Arc::new(tokio::sync::Mutex::new(())),
             canvas_cache: CanvasCache::new(),
         };
         core.register_canvas_rebuilder();
@@ -445,6 +453,7 @@ impl AtomicCore {
             storage,
             registry,
             wiki_tag_locks: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            briefing_lock: Arc::new(tokio::sync::Mutex::new(())),
             canvas_cache: CanvasCache::new(),
         };
         core.register_canvas_rebuilder();
@@ -1348,6 +1357,9 @@ impl AtomicCore {
     /// error bubbles up and `last_run` is left unchanged — the scheduler
     /// will retry on the next tick.
     pub async fn run_daily_briefing(&self) -> Result<briefing::BriefingWithCitations, AtomicCoreError> {
+        let _guard = self.briefing_lock.try_lock().map_err(|_| {
+            AtomicCoreError::Conflict("A daily briefing is already running".to_string())
+        })?;
         let since = scheduler::state::get_last_run(self, "daily_briefing")?
             .unwrap_or_else(|| chrono::Utc::now() - chrono::Duration::days(7));
         let result = briefing::run_briefing(self, since).await?;
@@ -3725,6 +3737,25 @@ mod tests {
         let topics_tag = all_tags.iter().find(|t| t.tag.name == "Topics").unwrap();
 
         assert_eq!(topics_tag.atom_count, 3);
+    }
+
+    #[tokio::test]
+    async fn run_daily_briefing_rejects_concurrent_call_with_conflict() {
+        let (db, _temp) = create_test_db();
+
+        // Simulate an in-flight briefing by holding the single-flight lock.
+        // The lock is acquired as the very first step of `run_daily_briefing`
+        // (before any DB or LLM work), so we don't need a working provider to
+        // exercise the contention path.
+        let _held = db.briefing_lock.clone().lock_owned().await;
+
+        let result = db.run_daily_briefing().await;
+        match result {
+            Err(AtomicCoreError::Conflict(msg)) => {
+                assert!(msg.contains("already running"), "unexpected message: {msg}");
+            }
+            other => panic!("expected Conflict, got {:?}", other.err()),
+        }
     }
 
     #[test]

--- a/crates/atomic-core/src/providers/mod.rs
+++ b/crates/atomic-core/src/providers/mod.rs
@@ -6,6 +6,7 @@ pub mod models;
 pub mod ollama;
 pub mod openai_compat;
 pub mod openrouter;
+pub mod structured;
 pub mod traits;
 pub mod types;
 
@@ -17,6 +18,7 @@ pub use models::{fetch_and_return_capabilities, get_cached_capabilities_sync, sa
 pub use ollama::OllamaProvider;
 pub use openai_compat::OpenAICompatProvider;
 pub use openrouter::OpenRouterProvider;
+pub use structured::{call_structured, lint_schema, parse_tolerant, StructuredCall, StructuredCallError};
 pub use traits::{EmbeddingConfig, EmbeddingProvider, LlmConfig, LlmProvider, StreamingLlmProvider};
 
 /// Provider type enum

--- a/crates/atomic-core/src/providers/structured.rs
+++ b/crates/atomic-core/src/providers/structured.rs
@@ -1,0 +1,1225 @@
+//! Unified entry point for structured-output LLM calls.
+//!
+//! Every call site that wants typed JSON output (wiki synthesis, briefing
+//! final pass, tag extraction, tag consolidation, ...) should go through
+//! [`call_structured`] instead of threading its own retry/parse/fallback
+//! loop. The function applies a portable-schema lint, drives the primary
+//! structured call with retry, tolerantly parses the response (handling
+//! markdown code fences and surrounding prose), and falls back to a
+//! schema-in-prompt call if the first attempt produces unparseable text.
+//!
+//! # Portability constraints
+//!
+//! Schemas passed to this module must follow the "lowest common denominator"
+//! rules enforced by [`lint_schema`]:
+//!
+//! - No `oneOf` / `anyOf` — some providers (notably OpenRouter-routed local
+//!   models) don't handle union types reliably.
+//! - No nullable unions (`"type": ["string", "null"]`). Use empty-string
+//!   sentinels for optional fields instead.
+//! - Object nodes must set `additionalProperties: false`.
+//! - Every declared property must appear in `required` (OpenAI strict mode).
+//!
+//! These are caught at call time and surface as [`StructuredCallError::SchemaLint`].
+//!
+//! # What this doesn't do
+//!
+//! - **Streaming**. Structured output and streaming are mutually exclusive in
+//!   every provider backend we ship. Callers that need streaming should use
+//!   `complete_streaming_with_tools` directly and do their own parsing.
+//! - **Model-capability gating**. The capabilities cache in
+//!   [`super::models::ModelCapabilitiesCache`] knows which OpenRouter models
+//!   advertise `structured_outputs`, but we don't gate here — the fallback
+//!   path covers models that silently ignore `response_format`, and a hard
+//!   gate would break local/OpenAI-compat setups where capabilities aren't
+//!   reported at all.
+
+use crate::providers::error::ProviderError;
+use crate::providers::traits::{LlmConfig, LlmProvider};
+use crate::providers::types::{GenerationParams, Message, StructuredOutputSchema};
+use crate::providers::{get_llm_provider, ProviderConfig};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+// ==================== Public API ====================
+
+/// A single structured-output LLM call. Construct with [`StructuredCall::new`],
+/// optionally adjust via the `with_*` methods, then pass to [`call_structured`].
+pub struct StructuredCall<'a, T> {
+    pub provider_config: &'a ProviderConfig,
+    pub model: &'a str,
+    pub messages: &'a [Message],
+    pub schema_name: &'static str,
+    pub schema: Value,
+    pub params: GenerationParams,
+    pub max_retries: usize,
+    /// Whether to request OpenAI-style strict schema enforcement. Default: `true`.
+    /// Strict mode guarantees the response adheres to the schema via
+    /// constrained decoding, but narrows the routable provider pool on
+    /// OpenRouter (since `provider.require_parameters` is also set). Opt out
+    /// with [`StructuredCall::with_strict`] when calling a model that's
+    /// known to reject strict mode (typically smaller OSS models routed via
+    /// OpenRouter or non-OpenAI backends). The linter rules + prompt-based
+    /// fallback still cover correctness when strict is off.
+    pub strict: bool,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<'a, T> StructuredCall<'a, T> {
+    /// Create a new call with sensible defaults (temperature 0.3, 2 retries,
+    /// strict schema enforcement on).
+    pub fn new(
+        provider_config: &'a ProviderConfig,
+        model: &'a str,
+        messages: &'a [Message],
+        schema_name: &'static str,
+        schema: Value,
+    ) -> Self {
+        Self {
+            provider_config,
+            model,
+            messages,
+            schema_name,
+            schema,
+            params: GenerationParams::new().with_temperature(0.3),
+            max_retries: 2,
+            strict: true,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Override the generation params (temperature, max_tokens, etc.). The
+    /// `structured_output` field is always set by [`call_structured`] —
+    /// anything you set here is overwritten.
+    pub fn with_params(mut self, params: GenerationParams) -> Self {
+        self.params = params;
+        self
+    }
+
+    /// Override the retry count on transient provider errors. Default: 2.
+    pub fn with_max_retries(mut self, max_retries: usize) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    /// Override the strict-mode flag. Default: `true`.
+    ///
+    /// Set to `false` when the target model or provider route is known to
+    /// reject OpenAI strict schemas (e.g. OpenRouter routing to a smaller
+    /// OSS model via vLLM). The primary call still passes the schema via
+    /// `response_format`, just without the constrained-decoding guarantee —
+    /// parse failures then fall through to the prompt-based fallback path.
+    pub fn with_strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+}
+
+/// Errors returned by [`call_structured`]. Callers should match on the variant
+/// so they can log / surface it sensibly — `ParseFailed` in particular carries
+/// a preview of the unparseable response for debugging.
+#[derive(Debug, thiserror::Error)]
+pub enum StructuredCallError {
+    #[error("schema lint failed: {0}")]
+    SchemaLint(String),
+
+    #[error("provider error: {0}")]
+    Provider(#[from] ProviderError),
+
+    #[error("failed to parse structured output after {attempts} attempt(s): {parse_error}")]
+    ParseFailed {
+        parse_error: String,
+        preview: String,
+        attempts: usize,
+    },
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl StructuredCallError {
+    /// Short, single-line representation suitable for propagating up as a
+    /// `String` error (most of our call sites return `Result<T, String>`).
+    pub fn to_compact_string(&self) -> String {
+        match self {
+            StructuredCallError::ParseFailed { parse_error, preview, attempts } => {
+                format!(
+                    "parse failed after {} attempt(s): {} (preview: {})",
+                    attempts,
+                    parse_error,
+                    preview.chars().take(200).collect::<String>(),
+                )
+            }
+            other => other.to_string(),
+        }
+    }
+}
+
+/// Run a structured-output call against the configured provider. See the
+/// module-level docs for the full semantics.
+///
+/// Lifecycle:
+///
+/// 1. Lint the schema for portability violations. Errors return immediately.
+/// 2. Build an `LlmConfig` with `structured_output` wired into the caller's
+///    `GenerationParams`.
+/// 3. Call `provider.complete()`. On `is_retryable()` errors, back off and
+///    retry up to `max_retries` times.
+/// 4. Tolerantly parse the response (raw → strip code fences → locate first
+///    `{…}` substring).
+/// 5. If parsing fails, fire a single prompt-based fallback call *without*
+///    `structured_output`, appending an explicit "reply with ONLY valid JSON
+///    matching this schema" nudge. Parse tolerantly again.
+/// 6. Return the typed value or a [`StructuredCallError::ParseFailed`] with
+///    the preview of the last unparseable response.
+pub async fn call_structured<T: DeserializeOwned>(
+    call: StructuredCall<'_, T>,
+) -> Result<T, StructuredCallError> {
+    let provider = get_llm_provider(call.provider_config)?;
+    call_structured_with_provider(call, provider).await
+}
+
+/// Test-facing variant of [`call_structured`] that accepts an explicit
+/// provider implementation. Production code should use [`call_structured`]
+/// (which resolves the provider from `ProviderConfig`). This form exists so
+/// unit tests can inject a mock and drive the full retry / parse / fallback
+/// pipeline deterministically without a real LLM.
+///
+/// Keeping both entry points means production callers don't pay a plumbing
+/// cost and the test surface stays fully isolated from real providers.
+pub async fn call_structured_with_provider<T: DeserializeOwned>(
+    call: StructuredCall<'_, T>,
+    provider: Arc<dyn LlmProvider>,
+) -> Result<T, StructuredCallError> {
+    lint_schema(&call.schema)?;
+
+    let StructuredCall {
+        model,
+        messages,
+        schema_name,
+        schema,
+        params,
+        max_retries,
+        strict,
+        ..
+    } = call;
+
+    // Primary attempt: with structured output enabled. Strict defaults to
+    // true but callers can opt out via `StructuredCall::with_strict(false)`
+    // for models that reject OpenAI strict mode.
+    let schema_wrapper = StructuredOutputSchema {
+        name: schema_name.to_string(),
+        schema: schema.clone(),
+        strict,
+    };
+    let structured_params = params.clone().with_structured_output(schema_wrapper);
+    let primary_config = LlmConfig::new(model.to_string()).with_params(structured_params);
+
+    let mut last_preview = String::new();
+    let mut last_parse_err = String::new();
+
+    for attempt in 0..=max_retries {
+        if attempt > 0 {
+            let delay = 1u64 << attempt;
+            tracing::warn!(
+                attempt,
+                max_retries,
+                delay_secs = delay,
+                last_error = %last_parse_err,
+                schema_name,
+                "[structured] Retrying transient provider error"
+            );
+            tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+        }
+
+        match provider.complete(messages, &primary_config).await {
+            Ok(response) => {
+                if response.content.is_empty() {
+                    return Err(StructuredCallError::Other(
+                        "LLM returned empty content".to_string(),
+                    ));
+                }
+                match parse_tolerant::<T>(&response.content) {
+                    Ok(value) => return Ok(value),
+                    Err(parse_err) => {
+                        last_preview = preview_of(&response.content);
+                        last_parse_err = parse_err.to_string();
+                        tracing::warn!(
+                            schema_name,
+                            parse_error = %last_parse_err,
+                            preview = %last_preview,
+                            "[structured] Primary parse failed, will try prompt-based fallback"
+                        );
+                        // Parse errors don't retry on the same call shape — break out
+                        // of the retry loop and try the fallback instead.
+                        break;
+                    }
+                }
+            }
+            Err(e) => {
+                last_parse_err = e.to_string();
+                if e.is_retryable() && attempt < max_retries {
+                    continue;
+                }
+                return Err(StructuredCallError::Provider(e));
+            }
+        }
+    }
+
+    // Prompt-based fallback: no schema, explicit user nudge. This handles the
+    // case where the provider silently ignored `response_format` (some weaker
+    // OpenRouter-routed models, some Ollama models) and returned prose or
+    // fenced JSON that the primary attempt couldn't cleanly parse.
+    let schema_str = serde_json::to_string_pretty(&schema)
+        .unwrap_or_else(|_| schema.to_string());
+    let nudge = format!(
+        "Your previous response could not be parsed. Reply with ONLY a single JSON \
+         object matching this schema. No markdown, no prose, no code fences, no \
+         surrounding text.\n\nSchema:\n{}",
+        schema_str
+    );
+
+    let mut fallback_messages = messages.to_vec();
+    fallback_messages.push(Message::user(nudge));
+    let fallback_config = LlmConfig::new(model.to_string()).with_params(params);
+
+    match provider.complete(&fallback_messages, &fallback_config).await {
+        Ok(response) => {
+            match parse_tolerant::<T>(&response.content) {
+                Ok(value) => {
+                    tracing::info!(schema_name, "[structured] Fallback parse succeeded");
+                    Ok(value)
+                }
+                Err(parse_err) => Err(StructuredCallError::ParseFailed {
+                    parse_error: parse_err.to_string(),
+                    preview: preview_of(&response.content),
+                    attempts: 2,
+                }),
+            }
+        }
+        Err(e) => {
+            // Fallback couldn't even reach the provider. Surface the ORIGINAL
+            // parse failure as the primary diagnostic (it's the more actionable
+            // signal) but mention the fallback failure in the error text.
+            Err(StructuredCallError::ParseFailed {
+                parse_error: format!(
+                    "{} (fallback provider call also failed: {})",
+                    last_parse_err, e
+                ),
+                preview: last_preview,
+                attempts: 2,
+            })
+        }
+    }
+}
+
+// ==================== Schema linting ====================
+
+/// Validate that a JSON schema follows the portable subset we ship. Returns
+/// an error describing every violation at once so authors can fix them in
+/// a single pass rather than playing whack-a-mole.
+pub fn lint_schema(schema: &Value) -> Result<(), StructuredCallError> {
+    let errors = collect_lint_errors(schema, "");
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(StructuredCallError::SchemaLint(errors.join("; ")))
+    }
+}
+
+fn collect_lint_errors(node: &Value, path: &str) -> Vec<String> {
+    let mut errors = Vec::new();
+    let Some(obj) = node.as_object() else {
+        if let Some(arr) = node.as_array() {
+            for (i, v) in arr.iter().enumerate() {
+                let child = format!("{}[{}]", path, i);
+                errors.extend(collect_lint_errors(v, &child));
+            }
+        }
+        return errors;
+    };
+
+    let here = if path.is_empty() { "<root>" } else { path };
+
+    if obj.contains_key("oneOf") {
+        errors.push(format!("{}: oneOf is not portable — use a flat schema with a discriminator field", here));
+    }
+    if obj.contains_key("anyOf") {
+        errors.push(format!("{}: anyOf is not portable — use a flat schema with a discriminator field", here));
+    }
+
+    if let Some(type_val) = obj.get("type") {
+        if let Some(type_arr) = type_val.as_array() {
+            let has_null = type_arr.iter().any(|v| v.as_str() == Some("null"));
+            if has_null {
+                errors.push(format!(
+                    "{}: nullable union types are not portable — use an empty-string sentinel instead",
+                    here
+                ));
+            }
+        }
+    }
+
+    if obj.get("type").and_then(|v| v.as_str()) == Some("object") {
+        if obj.get("additionalProperties").and_then(|v| v.as_bool()) != Some(false) {
+            errors.push(format!(
+                "{}: object must set \"additionalProperties\": false (OpenAI strict mode)",
+                here
+            ));
+        }
+        let properties = obj.get("properties").and_then(|v| v.as_object());
+        let required: Vec<&str> = obj
+            .get("required")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+        if let Some(props) = properties {
+            for prop in props.keys() {
+                if !required.iter().any(|r| r == prop) {
+                    errors.push(format!(
+                        "{}: property '{}' must appear in \"required\" (use empty-string sentinels for optional fields)",
+                        here, prop
+                    ));
+                }
+            }
+        }
+    }
+
+    for (key, value) in obj {
+        // Skip re-linting the required/type arrays themselves — they're metadata,
+        // not nested schemas.
+        if key == "required" || key == "type" || key == "enum" {
+            continue;
+        }
+        let child = if path.is_empty() {
+            key.clone()
+        } else {
+            format!("{}.{}", path, key)
+        };
+        errors.extend(collect_lint_errors(value, &child));
+    }
+
+    errors
+}
+
+// ==================== Tolerant parsing ====================
+
+/// Try hard to parse `content` as a `T`. In order:
+///
+/// 1. Raw `serde_json::from_str`.
+/// 2. Strip surrounding markdown code fences (``` ```json ... ``` ```) and retry.
+/// 3. Locate the first `{` and last `}` and parse that substring, stripping
+///    any leading apology or trailing "I hope that helps!" prose.
+///
+/// Returns the parse error from step 3 if all attempts fail.
+pub fn parse_tolerant<T: DeserializeOwned>(content: &str) -> Result<T, serde_json::Error> {
+    // Attempt 1: raw parse.
+    if let Ok(v) = serde_json::from_str::<T>(content) {
+        return Ok(v);
+    }
+
+    // Attempt 2: strip code fences if present.
+    let stripped = strip_code_fences(content);
+    if stripped != content {
+        if let Ok(v) = serde_json::from_str::<T>(&stripped) {
+            return Ok(v);
+        }
+    }
+
+    // Attempt 3: find the outermost JSON object substring.
+    let located = locate_json_object(&stripped);
+    serde_json::from_str::<T>(&located)
+}
+
+fn strip_code_fences(content: &str) -> String {
+    let trimmed = content.trim();
+    // Match ```<optional lang>\n ... \n```  or  ```<lang>\n ... ```  or  ``` ... ```
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        // Skip the language hint up to the first newline (if any).
+        let after_lang = match rest.find('\n') {
+            Some(nl) => &rest[nl + 1..],
+            None => rest,
+        };
+        if let Some(without_trailing) = after_lang.strip_suffix("```") {
+            return without_trailing.trim().to_string();
+        }
+        // No trailing fence — return what we have after the opening fence.
+        return after_lang.trim().to_string();
+    }
+    trimmed.to_string()
+}
+
+fn locate_json_object(content: &str) -> String {
+    let Some(start) = content.find('{') else {
+        return content.to_string();
+    };
+    let Some(end) = content.rfind('}') else {
+        return content.to_string();
+    };
+    if start >= end {
+        return content.to_string();
+    }
+    content[start..=end].to_string()
+}
+
+// ==================== Utilities ====================
+
+fn preview_of(content: &str) -> String {
+    let mut out: String = content.chars().take(500).collect();
+    if content.chars().count() > 500 {
+        out.push_str("...[truncated]");
+    }
+    out
+}
+
+// ==================== Tests ====================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::types::CompletionResponse;
+    use async_trait::async_trait;
+    use serde::Deserialize;
+    use serde_json::json;
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Sample {
+        value: String,
+        count: i32,
+    }
+
+    // ==================== Mock provider ====================
+    //
+    // Programmable LlmProvider implementation for integration-level tests.
+    // Tests enqueue a sequence of responses (successes or errors) and assert
+    // on the sequence of calls + captured messages after driving the full
+    // `call_structured_with_provider` pipeline.
+
+    enum MockResponse {
+        Ok(String),
+        Err(ProviderError),
+    }
+
+    struct MockLlmProvider {
+        responses: Mutex<VecDeque<MockResponse>>,
+        call_count: AtomicUsize,
+        captured_messages: Mutex<Vec<Vec<Message>>>,
+        /// Captured `structured_output` field from each incoming config, so
+        /// tests can assert on schema/strict/name propagation without cloning
+        /// the full LlmConfig (which is borrow-heavy).
+        captured_schemas: Mutex<Vec<Option<StructuredOutputSchema>>>,
+    }
+
+    impl MockLlmProvider {
+        fn new() -> Self {
+            Self {
+                responses: Mutex::new(VecDeque::new()),
+                call_count: AtomicUsize::new(0),
+                captured_messages: Mutex::new(Vec::new()),
+                captured_schemas: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn queue_response(&self, content: impl Into<String>) -> &Self {
+            self.responses
+                .lock()
+                .unwrap()
+                .push_back(MockResponse::Ok(content.into()));
+            self
+        }
+
+        fn queue_error(&self, error: ProviderError) -> &Self {
+            self.responses
+                .lock()
+                .unwrap()
+                .push_back(MockResponse::Err(error));
+            self
+        }
+
+        fn call_count(&self) -> usize {
+            self.call_count.load(Ordering::SeqCst)
+        }
+
+        fn captured_messages(&self) -> Vec<Vec<Message>> {
+            self.captured_messages.lock().unwrap().clone()
+        }
+
+        fn captured_schemas(&self) -> Vec<Option<StructuredOutputSchema>> {
+            self.captured_schemas
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|s| s.as_ref().map(|schema| StructuredOutputSchema {
+                    name: schema.name.clone(),
+                    schema: schema.schema.clone(),
+                    strict: schema.strict,
+                }))
+                .collect()
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for MockLlmProvider {
+        async fn complete(
+            &self,
+            messages: &[Message],
+            config: &LlmConfig,
+        ) -> Result<CompletionResponse, ProviderError> {
+            self.captured_messages.lock().unwrap().push(messages.to_vec());
+            self.captured_schemas
+                .lock()
+                .unwrap()
+                .push(config.params.structured_output.as_ref().map(|s| {
+                    StructuredOutputSchema {
+                        name: s.name.clone(),
+                        schema: s.schema.clone(),
+                        strict: s.strict,
+                    }
+                }));
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            match self.responses.lock().unwrap().pop_front() {
+                Some(MockResponse::Ok(content)) => Ok(CompletionResponse {
+                    content,
+                    tool_calls: None,
+                }),
+                Some(MockResponse::Err(e)) => Err(e),
+                None => Err(ProviderError::Configuration(
+                    "mock response queue exhausted".to_string(),
+                )),
+            }
+        }
+    }
+
+    fn sample_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": "string" },
+                "count": { "type": "integer" }
+            },
+            "required": ["value", "count"],
+            "additionalProperties": false
+        })
+    }
+
+    /// Minimal provider config for tests. None of the real provider lookups
+    /// are hit because we bypass `get_llm_provider` via
+    /// `call_structured_with_provider`.
+    fn test_provider_config() -> ProviderConfig {
+        ProviderConfig::from_settings(&std::collections::HashMap::new())
+    }
+
+    async fn run_sample(
+        provider: Arc<MockLlmProvider>,
+        messages: Vec<Message>,
+    ) -> Result<Sample, StructuredCallError> {
+        let config = test_provider_config();
+        let call = StructuredCall::<Sample>::new(
+            &config,
+            "test-model",
+            &messages,
+            "sample_result",
+            sample_schema(),
+        )
+        .with_max_retries(2);
+        call_structured_with_provider::<Sample>(call, provider).await
+    }
+
+    // Minimal valid response matching `Sample`.
+    const OK_JSON: &str = r#"{"value":"hello","count":7}"#;
+
+    // ==================== Pipeline integration tests ====================
+    //
+    // These exercise the full call_structured_with_provider loop:
+    // primary → parse → (retry | fallback) → parse → Ok | Err. Each test
+    // programs a sequence of mock responses and then asserts on both the
+    // returned value AND the number/shape of provider calls, so they catch
+    // regressions in the orchestration logic that parse/lint unit tests
+    // can't see.
+
+    #[tokio::test]
+    async fn pipeline_primary_success_no_fallback() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response(OK_JSON);
+
+        let messages = vec![Message::system("s"), Message::user("u")];
+        let result = run_sample(provider.clone(), messages).await.unwrap();
+
+        assert_eq!(result, Sample { value: "hello".into(), count: 7 });
+        assert_eq!(provider.call_count(), 1, "should not have fired fallback");
+    }
+
+    #[tokio::test]
+    async fn pipeline_fenced_json_parses_without_fallback() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response("```json\n{\"value\":\"hi\",\"count\":1}\n```");
+
+        let messages = vec![Message::system("s"), Message::user("u")];
+        let result = run_sample(provider.clone(), messages).await.unwrap();
+
+        assert_eq!(result.count, 1);
+        // Tolerant parse handled the fence — no fallback call needed.
+        assert_eq!(provider.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn pipeline_prose_wrapped_json_parses_without_fallback() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response("Sure, here's the data: {\"value\":\"hi\",\"count\":2}\n\nLet me know if you need more.");
+
+        let messages = vec![Message::system("s"), Message::user("u")];
+        let result = run_sample(provider.clone(), messages).await.unwrap();
+
+        assert_eq!(result.count, 2);
+        assert_eq!(provider.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn pipeline_prose_response_triggers_fallback() {
+        let provider = Arc::new(MockLlmProvider::new());
+        // Primary: completely unparseable prose
+        provider.queue_response("I'm unable to provide that in JSON format.");
+        // Fallback: properly formatted JSON
+        provider.queue_response(OK_JSON);
+
+        let messages = vec![Message::system("s"), Message::user("u")];
+        let result = run_sample(provider.clone(), messages).await.unwrap();
+
+        assert_eq!(result.count, 7);
+        assert_eq!(provider.call_count(), 2, "fallback should have fired");
+
+        // Verify the fallback call included the schema nudge as a user message
+        let captured = provider.captured_messages();
+        assert_eq!(captured.len(), 2);
+        let fallback_msgs = &captured[1];
+        // Fallback message count = original messages + nudge
+        assert_eq!(fallback_msgs.len(), 3);
+        let last = &fallback_msgs[fallback_msgs.len() - 1];
+        assert!(matches!(last.role, crate::providers::types::MessageRole::User));
+        let nudge = last.content.as_deref().unwrap_or("");
+        assert!(
+            nudge.contains("could not be parsed") && nudge.contains("Schema:"),
+            "nudge should describe the parse failure and include the schema"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_both_paths_fail_returns_parse_failed() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response("prose prose prose");
+        provider.queue_response("still prose after the nudge");
+
+        let messages = vec![Message::system("s"), Message::user("u")];
+        let err = run_sample(provider.clone(), messages).await.unwrap_err();
+
+        assert_eq!(provider.call_count(), 2);
+        match err {
+            StructuredCallError::ParseFailed { attempts, preview, .. } => {
+                assert_eq!(attempts, 2);
+                assert!(preview.contains("still prose"), "preview should be the fallback response");
+            }
+            other => panic!("expected ParseFailed, got {:?}", other),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pipeline_transient_error_retries_then_succeeds() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_error(ProviderError::RateLimited { retry_after_secs: None });
+        provider.queue_response(OK_JSON);
+
+        let messages = vec![Message::system("s"), Message::user("u")];
+        let result = run_sample(provider.clone(), messages).await.unwrap();
+
+        assert_eq!(result.count, 7);
+        assert_eq!(provider.call_count(), 2, "retry consumed 1 extra call");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pipeline_retry_exhausted_returns_provider_error() {
+        let provider = Arc::new(MockLlmProvider::new());
+        // max_retries = 2 → 1 primary + 2 retries = 3 failing calls before
+        // the loop gives up. All transient so the loop keeps trying.
+        provider.queue_error(ProviderError::Network("t1".into()));
+        provider.queue_error(ProviderError::Network("t2".into()));
+        provider.queue_error(ProviderError::Network("t3".into()));
+
+        let messages = vec![Message::system("s"), Message::user("u")];
+        let err = run_sample(provider.clone(), messages).await.unwrap_err();
+
+        assert_eq!(provider.call_count(), 3);
+        assert!(matches!(err, StructuredCallError::Provider(ProviderError::Network(_))));
+    }
+
+    #[tokio::test]
+    async fn pipeline_non_retryable_error_bails_immediately() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_error(ProviderError::Api {
+            status: 400,
+            message: "bad request".into(),
+        });
+
+        let messages = vec![Message::system("s"), Message::user("u")];
+        let err = run_sample(provider.clone(), messages).await.unwrap_err();
+
+        // 400 is non-retryable (see ProviderError::is_retryable), so we bail
+        // on the first call without consuming retries.
+        assert_eq!(provider.call_count(), 1);
+        assert!(matches!(
+            err,
+            StructuredCallError::Provider(ProviderError::Api { status: 400, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn pipeline_fallback_provider_call_also_fails() {
+        let provider = Arc::new(MockLlmProvider::new());
+        // Primary: unparseable prose
+        provider.queue_response("nope, not doing JSON today");
+        // Fallback: provider itself errors out
+        provider.queue_error(ProviderError::Api {
+            status: 500,
+            message: "upstream exploded".into(),
+        });
+
+        let messages = vec![Message::system("s"), Message::user("u")];
+        let err = run_sample(provider.clone(), messages).await.unwrap_err();
+
+        assert_eq!(provider.call_count(), 2);
+        match err {
+            StructuredCallError::ParseFailed { parse_error, .. } => {
+                // Primary parse failure is the primary diagnostic, but the
+                // error text should mention the fallback also failed.
+                assert!(
+                    parse_error.contains("fallback"),
+                    "error should surface the fallback failure: {}",
+                    parse_error
+                );
+            }
+            other => panic!("expected ParseFailed, got {:?}", other),
+        }
+    }
+
+    // ==================== Strict-mode escape hatch ====================
+
+    #[test]
+    fn structured_call_default_strict_is_true() {
+        let config = test_provider_config();
+        let messages: Vec<Message> = vec![];
+        let call = StructuredCall::<Sample>::new(
+            &config,
+            "m",
+            &messages,
+            "sample_result",
+            sample_schema(),
+        );
+        assert!(call.strict, "default strict must be true");
+    }
+
+    #[test]
+    fn with_strict_false_sets_field() {
+        let config = test_provider_config();
+        let messages: Vec<Message> = vec![];
+        let call = StructuredCall::<Sample>::new(
+            &config,
+            "m",
+            &messages,
+            "sample_result",
+            sample_schema(),
+        )
+        .with_strict(false);
+        assert!(!call.strict);
+    }
+
+    #[tokio::test]
+    async fn pipeline_primary_call_sends_strict_true_by_default() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response(OK_JSON);
+
+        let messages = vec![Message::user("u")];
+        run_sample(provider.clone(), messages).await.unwrap();
+
+        let schemas = provider.captured_schemas();
+        assert_eq!(schemas.len(), 1, "only primary call, no fallback");
+        let primary = schemas[0].as_ref().expect("primary must carry a schema");
+        assert_eq!(primary.name, "sample_result");
+        assert!(primary.strict, "primary call must default to strict=true");
+    }
+
+    #[tokio::test]
+    async fn pipeline_primary_call_sends_strict_false_when_opted_out() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response(OK_JSON);
+
+        let config = test_provider_config();
+        let messages = vec![Message::user("u")];
+        let call = StructuredCall::<Sample>::new(
+            &config,
+            "weak-model",
+            &messages,
+            "sample_result",
+            sample_schema(),
+        )
+        .with_strict(false);
+        call_structured_with_provider::<Sample>(call, provider.clone())
+            .await
+            .unwrap();
+
+        let schemas = provider.captured_schemas();
+        assert_eq!(schemas.len(), 1);
+        let primary = schemas[0].as_ref().expect("primary must carry a schema");
+        assert!(
+            !primary.strict,
+            "with_strict(false) must propagate to the outbound request"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_fallback_call_never_sends_schema() {
+        // When the primary response can't be parsed we fire a fallback call.
+        // That call should NOT carry `structured_output` — the nudge prompt
+        // is our only mechanism on the fallback path, and some providers
+        // reject repeated schema attempts after an initial refusal.
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response("prose, no json here");
+        provider.queue_response(OK_JSON);
+
+        let messages = vec![Message::user("u")];
+        run_sample(provider.clone(), messages).await.unwrap();
+
+        let schemas = provider.captured_schemas();
+        assert_eq!(schemas.len(), 2, "primary + fallback");
+        assert!(schemas[0].is_some(), "primary must carry the schema");
+        assert!(
+            schemas[1].is_none(),
+            "fallback call must NOT carry structured_output"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_schema_lint_fails_before_any_call() {
+        // Schema with oneOf — lint rejects, we never reach the provider.
+        let bad_schema = json!({
+            "type": "object",
+            "properties": {
+                "value": { "oneOf": [{"type": "string"}] }
+            },
+            "required": ["value"],
+            "additionalProperties": false
+        });
+
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response(OK_JSON);
+
+        let config = test_provider_config();
+        let messages = vec![Message::user("u")];
+        let call = StructuredCall::<Sample>::new(
+            &config,
+            "test-model",
+            &messages,
+            "sample_result",
+            bad_schema,
+        );
+
+        let err = call_structured_with_provider::<Sample>(call, provider.clone())
+            .await
+            .unwrap_err();
+
+        assert_eq!(provider.call_count(), 0, "should not call provider on lint failure");
+        assert!(matches!(err, StructuredCallError::SchemaLint(_)));
+    }
+
+    // ==================== Schema snapshot ====================
+    //
+    // Golden file of every live schema passed to `call_structured`. The
+    // snapshot catches semantic drift that the lint tests can't see — e.g.
+    // someone renaming `article_content` to `content`, or flipping an
+    // integer field to a string. The lint tests still pass but real LLM
+    // calls start returning data that deserializes into the wrong shape.
+    //
+    // Regenerate with:
+    //   UPDATE_SNAPSHOTS=1 cargo test -p atomic-core schema_snapshot
+    //
+    // The test collects schemas from every module that uses structured
+    // output. If you add a new `call_structured` call site, add its schema
+    // here and rerun with UPDATE_SNAPSHOTS=1 to bake it into the snapshot.
+
+    fn collect_live_schemas() -> std::collections::BTreeMap<&'static str, Value> {
+        let mut out = std::collections::BTreeMap::new();
+        out.insert(
+            "wiki_generation_result",
+            crate::wiki::wiki_generation_schema(),
+        );
+        out.insert(
+            "wiki_update_section_ops",
+            crate::wiki::section_ops_schema(),
+        );
+        out.insert(
+            "briefing_generation_result",
+            crate::briefing::agentic::briefing_schema(),
+        );
+        out.insert("extraction_result", crate::extraction::extraction_schema());
+        out.insert(
+            "consolidation_result",
+            crate::extraction::consolidation_schema(),
+        );
+        out.insert("merge_result", crate::compaction::merge_schema());
+        out
+    }
+
+    fn snapshot_path() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src/providers/testdata/schemas.snap.json")
+    }
+
+    #[test]
+    fn schema_snapshot_matches_live_schemas() {
+        let live = collect_live_schemas();
+        // serde_json::Map is BTreeMap-backed by default, so serialized keys
+        // are deterministically sorted — no canonicalization needed.
+        let current = serde_json::to_string_pretty(&live)
+            .expect("schema snapshot should serialize");
+
+        let path = snapshot_path();
+
+        if std::env::var("UPDATE_SNAPSHOTS").is_ok() {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, format!("{}\n", current))
+                .expect("failed to write snapshot");
+            eprintln!("[snapshot] wrote {}", path.display());
+            return;
+        }
+
+        let expected = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            panic!(
+                "Snapshot file missing at {}: {}\n\n\
+                 Run: UPDATE_SNAPSHOTS=1 cargo test -p atomic-core schema_snapshot",
+                path.display(),
+                e
+            )
+        });
+
+        let expected_trimmed = expected.trim_end();
+        let current_trimmed = current.trim_end();
+
+        if expected_trimmed != current_trimmed {
+            // Compute which top-level schema names drifted so the error
+            // points at the offending caller quickly.
+            let expected_parsed: serde_json::Map<String, Value> =
+                serde_json::from_str(expected_trimmed)
+                    .expect("existing snapshot should be valid JSON");
+            let current_parsed: serde_json::Map<String, Value> =
+                serde_json::from_str(current_trimmed).unwrap();
+
+            let mut drifted: Vec<String> = Vec::new();
+            for (k, v) in &current_parsed {
+                match expected_parsed.get(k) {
+                    Some(existing) if existing == v => {}
+                    Some(_) => drifted.push(format!("{} (changed)", k)),
+                    None => drifted.push(format!("{} (added)", k)),
+                }
+            }
+            for k in expected_parsed.keys() {
+                if !current_parsed.contains_key(k) {
+                    drifted.push(format!("{} (removed)", k));
+                }
+            }
+
+            panic!(
+                "Schema snapshot mismatch in: {}\n\n\
+                 To regenerate the snapshot:\n\
+                     UPDATE_SNAPSHOTS=1 cargo test -p atomic-core schema_snapshot\n",
+                drifted.join(", ")
+            );
+        }
+    }
+
+    #[test]
+    fn every_live_schema_is_lint_clean() {
+        // Belt-and-suspenders: the per-module lint tests already cover each
+        // schema individually, but this iterates the full registry so a
+        // newly-added schema is automatically included the moment the
+        // author registers it in `collect_live_schemas`.
+        for (name, schema) in collect_live_schemas() {
+            lint_schema(&schema).unwrap_or_else(|e| {
+                panic!("schema '{}' failed lint: {}", name, e)
+            });
+        }
+    }
+
+    // ---------- parse_tolerant ----------
+
+    #[test]
+    fn parse_raw_json() {
+        let input = r#"{"value":"hello","count":3}"#;
+        let parsed: Sample = parse_tolerant(input).unwrap();
+        assert_eq!(parsed, Sample { value: "hello".into(), count: 3 });
+    }
+
+    #[test]
+    fn parse_fenced_json_block() {
+        let input = "```json\n{\"value\":\"hi\",\"count\":1}\n```";
+        let parsed: Sample = parse_tolerant(input).unwrap();
+        assert_eq!(parsed, Sample { value: "hi".into(), count: 1 });
+    }
+
+    #[test]
+    fn parse_fenced_generic_block() {
+        let input = "```\n{\"value\":\"hi\",\"count\":2}\n```";
+        let parsed: Sample = parse_tolerant(input).unwrap();
+        assert_eq!(parsed, Sample { value: "hi".into(), count: 2 });
+    }
+
+    #[test]
+    fn parse_json_with_prose_prefix() {
+        let input = "Sure! Here is the JSON you asked for: {\"value\":\"ok\",\"count\":7}";
+        let parsed: Sample = parse_tolerant(input).unwrap();
+        assert_eq!(parsed, Sample { value: "ok".into(), count: 7 });
+    }
+
+    #[test]
+    fn parse_json_with_trailing_prose() {
+        let input = "{\"value\":\"x\",\"count\":0}\n\nLet me know if you need anything else!";
+        let parsed: Sample = parse_tolerant(input).unwrap();
+        assert_eq!(parsed, Sample { value: "x".into(), count: 0 });
+    }
+
+    #[test]
+    fn parse_garbage_fails() {
+        let input = "not json at all";
+        let result: Result<Sample, _> = parse_tolerant(input);
+        assert!(result.is_err());
+    }
+
+    // ---------- lint_schema ----------
+
+    fn portable_sample_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": "string" },
+                "count": { "type": "integer" }
+            },
+            "required": ["value", "count"],
+            "additionalProperties": false
+        })
+    }
+
+    #[test]
+    fn lint_accepts_portable_schema() {
+        assert!(lint_schema(&portable_sample_schema()).is_ok());
+    }
+
+    #[test]
+    fn lint_rejects_one_of() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "op": {
+                    "oneOf": [
+                        { "type": "object", "properties": { "kind": { "type": "string" } }, "required": ["kind"], "additionalProperties": false }
+                    ]
+                }
+            },
+            "required": ["op"],
+            "additionalProperties": false
+        });
+        let err = lint_schema(&schema).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("oneOf"), "expected oneOf violation, got: {}", msg);
+    }
+
+    #[test]
+    fn lint_rejects_nullable_union() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": ["string", "null"] }
+            },
+            "required": ["value"],
+            "additionalProperties": false
+        });
+        let err = lint_schema(&schema).unwrap_err();
+        assert!(err.to_string().contains("nullable"));
+    }
+
+    #[test]
+    fn lint_rejects_missing_additional_properties_false() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": "string" }
+            },
+            "required": ["value"]
+        });
+        let err = lint_schema(&schema).unwrap_err();
+        assert!(err.to_string().contains("additionalProperties"));
+    }
+
+    #[test]
+    fn lint_rejects_optional_property() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": "string" },
+                "count": { "type": "integer" }
+            },
+            "required": ["value"],
+            "additionalProperties": false
+        });
+        let err = lint_schema(&schema).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("count") && msg.contains("required"),
+            "expected missing-required violation for 'count', got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn lint_accepts_nested_portable_schema() {
+        // Mirrors the shape wiki section_ops_schema uses.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "operations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "op": { "type": "string", "enum": ["NoChange", "Append"] },
+                            "content": { "type": "string" }
+                        },
+                        "required": ["op", "content"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "required": ["operations"],
+            "additionalProperties": false
+        });
+        assert!(lint_schema(&schema).is_ok());
+    }
+
+    // ---------- strip_code_fences ----------
+
+    #[test]
+    fn strip_fences_json_lang() {
+        assert_eq!(strip_code_fences("```json\n{\"a\":1}\n```"), "{\"a\":1}");
+    }
+
+    #[test]
+    fn strip_fences_no_lang() {
+        assert_eq!(strip_code_fences("```\n{\"a\":1}\n```"), "{\"a\":1}");
+    }
+
+    #[test]
+    fn strip_fences_noop() {
+        assert_eq!(strip_code_fences("{\"a\":1}"), "{\"a\":1}");
+    }
+}

--- a/crates/atomic-core/src/providers/testdata/schemas.snap.json
+++ b/crates/atomic-core/src/providers/testdata/schemas.snap.json
@@ -1,0 +1,205 @@
+{
+  "briefing_generation_result": {
+    "additionalProperties": false,
+    "properties": {
+      "briefing_content": {
+        "description": "The 2-3 paragraph briefing in markdown, with [N] citation markers referring to the initial new-atoms list.",
+        "type": "string"
+      },
+      "citations_used": {
+        "description": "List of citation numbers actually used in briefing_content.",
+        "items": {
+          "type": "integer"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "briefing_content",
+      "citations_used"
+    ],
+    "type": "object"
+  },
+  "consolidation_result": {
+    "additionalProperties": false,
+    "properties": {
+      "tags_to_add": {
+        "description": "New broader tags to create and add",
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "description": "Name of the tag to add",
+              "type": "string"
+            },
+            "parent_name": {
+              "description": "Name of parent tag, or empty string for top-level categories",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "parent_name"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "tags_to_remove": {
+        "description": "Names of tags to remove",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "tags_to_remove",
+      "tags_to_add"
+    ],
+    "type": "object"
+  },
+  "extraction_result": {
+    "additionalProperties": false,
+    "properties": {
+      "tags": {
+        "description": "Tags to apply to this text",
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "description": "Name of the tag to apply",
+              "type": "string"
+            },
+            "parent_name": {
+              "description": "Name of parent tag, or empty string for top-level categories",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "parent_name"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "tags"
+    ],
+    "type": "object"
+  },
+  "merge_result": {
+    "additionalProperties": false,
+    "properties": {
+      "merges": {
+        "description": "List of tag pairs to merge",
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "loser_name": {
+              "description": "Name of the tag to merge into the winner and delete",
+              "type": "string"
+            },
+            "reason": {
+              "description": "Brief explanation for why these tags should be merged",
+              "type": "string"
+            },
+            "winner_name": {
+              "description": "Name of the tag that should survive (canonical name)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "winner_name",
+            "loser_name",
+            "reason"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "merges"
+    ],
+    "type": "object"
+  },
+  "wiki_generation_result": {
+    "additionalProperties": false,
+    "properties": {
+      "article_content": {
+        "description": "The full wiki article in markdown format with [N] citations",
+        "type": "string"
+      },
+      "citations_used": {
+        "description": "List of citation numbers actually used in the article",
+        "items": {
+          "type": "integer"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "article_content",
+      "citations_used"
+    ],
+    "type": "object"
+  },
+  "wiki_update_section_ops": {
+    "additionalProperties": false,
+    "properties": {
+      "citations_used": {
+        "description": "List of citation numbers referenced across the operations.",
+        "items": {
+          "type": "integer"
+        },
+        "type": "array"
+      },
+      "operations": {
+        "description": "List of section operations to apply to the article, in order. Return a single operation with op=\"NoChange\" if nothing needs to change.",
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "after_heading": {
+              "description": "For InsertSection only: exact existing heading to insert AFTER, or empty string to append at end of article. For all other ops: empty string.",
+              "type": "string"
+            },
+            "content": {
+              "description": "New markdown content for the operation. For NoChange: empty string.",
+              "type": "string"
+            },
+            "heading": {
+              "description": "For AppendToSection/ReplaceSection: exact existing heading to target. For InsertSection: the new section's heading. For NoChange: empty string.",
+              "type": "string"
+            },
+            "op": {
+              "description": "Operation type.",
+              "enum": [
+                "NoChange",
+                "AppendToSection",
+                "ReplaceSection",
+                "InsertSection"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "op",
+            "heading",
+            "after_heading",
+            "content"
+          ],
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "operations",
+      "citations_used"
+    ],
+    "type": "object"
+  }
+}

--- a/crates/atomic-core/src/scheduler/mod.rs
+++ b/crates/atomic-core/src/scheduler/mod.rs
@@ -1,0 +1,148 @@
+//! Scheduled-task framework for atomic-core.
+//!
+//! This module defines a minimal scheduling primitive that any transport
+//! (atomic-server, Tauri sidecar, etc.) can drive from its own runtime. The
+//! registry lives here so task implementations ship with core, while the
+//! ticking loop itself is owned by the caller.
+//!
+//! Tasks are responsible for their own enablement / due-ness checks, state
+//! persistence, and event reporting — see [`ScheduledTask::run`].
+
+pub mod state;
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::Mutex as AsyncMutex;
+
+/// A unit of work that runs on a schedule.
+///
+/// Implementations are registered in a [`TaskRegistry`] and invoked by the
+/// host runtime (typically one tick per minute). Each `run` call is
+/// responsible for:
+///
+/// 1. Checking enablement via [`state::is_enabled`]
+/// 2. Checking due-ness via [`state::is_due`]
+/// 3. Performing the work
+/// 4. Persisting `last_run` via [`state::set_last_run`] on success
+/// 5. Emitting a [`TaskEvent`] through `ctx.event_cb`
+#[async_trait]
+pub trait ScheduledTask: Send + Sync {
+    /// Stable identifier used as the key for per-task state in the settings table.
+    fn id(&self) -> &'static str;
+
+    /// Human-readable name for logs and future UI.
+    fn display_name(&self) -> &'static str;
+
+    /// Default interval between runs when the per-task setting is absent.
+    fn default_interval(&self) -> Duration;
+
+    /// Execute the task. The task is responsible for checking enablement,
+    /// reading its own state, and updating `last_run` on success.
+    async fn run(
+        &self,
+        core: &crate::AtomicCore,
+        ctx: &TaskContext,
+    ) -> Result<(), TaskError>;
+}
+
+/// Context passed to each task run. Currently just a callback sink so tasks
+/// can emit events without knowing about the host transport.
+pub struct TaskContext {
+    pub event_cb: Arc<dyn Fn(TaskEvent) + Send + Sync>,
+}
+
+/// Events emitted by scheduled tasks. The host runtime adapts these into its
+/// own event channel (see `atomic-server::event_bridge::task_event_callback`).
+#[derive(Debug, Clone)]
+pub enum TaskEvent {
+    Started {
+        task_id: String,
+        db_id: String,
+    },
+    Completed {
+        task_id: String,
+        db_id: String,
+        /// Identifier of the resource produced by the run, if any (e.g. a
+        /// briefing id). Lets downstream UIs deep-link to the result.
+        result_id: Option<String>,
+    },
+    Failed {
+        task_id: String,
+        db_id: String,
+        error: String,
+    },
+}
+
+/// Errors returned by [`ScheduledTask::run`]. Non-failure outcomes use the
+/// `Disabled` / `NotDue` / `AlreadyRunning` variants so the host loop can
+/// silently skip them without logging at warn level.
+#[derive(Debug, thiserror::Error)]
+pub enum TaskError {
+    #[error("task disabled")]
+    Disabled,
+    #[error("task not due")]
+    NotDue,
+    #[error("task already running")]
+    AlreadyRunning,
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<crate::AtomicCoreError> for TaskError {
+    fn from(e: crate::AtomicCoreError) -> Self {
+        TaskError::Other(e.to_string())
+    }
+}
+
+/// Registry of scheduled tasks. Owns the task trait objects and the
+/// per-(task, database) lock map that prevents re-entry across ticks.
+pub struct TaskRegistry {
+    tasks: Vec<Arc<dyn ScheduledTask>>,
+    /// Per-task-per-database locks. A task that's still running when the next
+    /// tick arrives must be skipped, not queued.
+    locks: Mutex<HashMap<(String, String), Arc<AsyncMutex<()>>>>,
+}
+
+impl Default for TaskRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TaskRegistry {
+    pub fn new() -> Self {
+        Self {
+            tasks: Vec::new(),
+            locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn register(&mut self, task: Arc<dyn ScheduledTask>) {
+        self.tasks.push(task);
+    }
+
+    pub fn tasks(&self) -> &[Arc<dyn ScheduledTask>] {
+        &self.tasks
+    }
+
+    /// Try to acquire the per-(task, db) lock. Returns `None` if the lock is
+    /// already held (task still running from a previous tick).
+    pub fn try_lock(
+        &self,
+        task_id: &str,
+        db_id: &str,
+    ) -> Option<tokio::sync::OwnedMutexGuard<()>> {
+        let lock = {
+            let mut map = self
+                .locks
+                .lock()
+                .expect("scheduler locks mutex poisoned");
+            map.entry((task_id.to_string(), db_id.to_string()))
+                .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+                .clone()
+        };
+        lock.try_lock_owned().ok()
+    }
+}

--- a/crates/atomic-core/src/scheduler/state.rs
+++ b/crates/atomic-core/src/scheduler/state.rs
@@ -1,0 +1,107 @@
+//! Per-task state helpers.
+//!
+//! Scheduled task state is stored in the per-database `settings` table under
+//! keys of the form `task.{task_id}.{field}`. Using the settings table means
+//! we get the existing registry/data-db routing for free — no new tables, no
+//! new migrations, no new query paths.
+//!
+//! Storage layout per task:
+//!
+//! - `task.{task_id}.last_run`      RFC3339 timestamp of the last successful run
+//! - `task.{task_id}.enabled`       `"true"` / `"false"`
+//! - `task.{task_id}.interval_hours`  integer hour count (stored as string)
+
+use crate::AtomicCore;
+use crate::error::AtomicCoreError;
+use chrono::{DateTime, Utc};
+use std::time::Duration;
+
+fn key(task_id: &str, field: &str) -> String {
+    format!("task.{}.{}", task_id, field)
+}
+
+/// Read the last successful run timestamp for a task. Returns `None` if the
+/// task has never run or the stored value is not a valid RFC3339 timestamp.
+pub fn get_last_run(
+    core: &AtomicCore,
+    task_id: &str,
+) -> Result<Option<DateTime<Utc>>, AtomicCoreError> {
+    let settings = core.get_settings()?;
+    let Some(raw) = settings.get(&key(task_id, "last_run")) else {
+        return Ok(None);
+    };
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    match DateTime::parse_from_rfc3339(raw) {
+        Ok(dt) => Ok(Some(dt.with_timezone(&Utc))),
+        Err(e) => {
+            tracing::warn!(
+                task_id,
+                value = %raw,
+                error = %e,
+                "[scheduler] Ignoring unparseable task last_run timestamp"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Persist the last successful run timestamp for a task.
+pub fn set_last_run(
+    core: &AtomicCore,
+    task_id: &str,
+    when: DateTime<Utc>,
+) -> Result<(), AtomicCoreError> {
+    core.set_setting(&key(task_id, "last_run"), &when.to_rfc3339())
+}
+
+/// Check whether a task is enabled. Defaults to `default` when the setting
+/// is missing; treats any non-`"false"` value as enabled to tolerate casing
+/// differences.
+pub fn is_enabled(core: &AtomicCore, task_id: &str, default: bool) -> bool {
+    match core.get_settings() {
+        Ok(settings) => match settings.get(&key(task_id, "enabled")) {
+            Some(v) => !matches!(v.to_ascii_lowercase().as_str(), "false" | "0" | "no" | "off"),
+            None => default,
+        },
+        Err(_) => default,
+    }
+}
+
+/// Read the configured interval for a task. Falls back to `default` when the
+/// setting is missing or unparseable.
+pub fn get_interval(core: &AtomicCore, task_id: &str, default: Duration) -> Duration {
+    let settings = match core.get_settings() {
+        Ok(s) => s,
+        Err(_) => return default,
+    };
+    let Some(raw) = settings.get(&key(task_id, "interval_hours")) else {
+        return default;
+    };
+    match raw.parse::<u64>() {
+        Ok(hours) if hours > 0 => Duration::from_secs(hours * 3600),
+        _ => default,
+    }
+}
+
+/// Composite check used by the scheduling loop: returns `true` when the task
+/// is enabled AND (has never run OR the configured interval has elapsed).
+pub fn is_due(
+    core: &AtomicCore,
+    task_id: &str,
+    default_interval: Duration,
+    default_enabled: bool,
+) -> bool {
+    if !is_enabled(core, task_id, default_enabled) {
+        return false;
+    }
+    let interval = get_interval(core, task_id, default_interval);
+    match get_last_run(core, task_id) {
+        Ok(Some(last)) => {
+            let elapsed = Utc::now().signed_duration_since(last);
+            elapsed.num_seconds().max(0) as u64 >= interval.as_secs()
+        }
+        _ => true,
+    }
+}

--- a/crates/atomic-core/src/settings.rs
+++ b/crates/atomic-core/src/settings.rs
@@ -32,6 +32,9 @@ pub const DEFAULT_SETTINGS: &[(&str, &str)] = &[
     ("openai_compat_timeout_secs", "300"), // 5 minutes default for OpenAI-compatible servers
     ("wiki_generation_prompt", ""),
     ("wiki_update_prompt", ""),
+    // Scheduled tasks — see crate::scheduler::state for key format
+    ("task.daily_briefing.enabled", "true"),
+    ("task.daily_briefing.interval_hours", "24"),
 ];
 
 /// Migrate settings - add any missing default settings

--- a/crates/atomic-core/src/storage/mod.rs
+++ b/crates/atomic-core/src/storage/mod.rs
@@ -414,6 +414,8 @@ dispatch! {
         => sqlite: insert_briefing_sync, pg_trait: BriefingStore, pg_method: insert_briefing;
     fn get_latest_briefing_sync(&self) -> Result<Option<crate::briefing::BriefingWithCitations>, AtomicCoreError>
         => sqlite: get_latest_briefing_sync, pg_trait: BriefingStore, pg_method: get_latest_briefing;
+    fn get_briefing_sync(&self, id: &str) -> Result<Option<crate::briefing::BriefingWithCitations>, AtomicCoreError>
+        => sqlite: get_briefing_sync, pg_trait: BriefingStore, pg_method: get_briefing;
     fn list_briefings_sync(&self, limit: i32) -> Result<Vec<crate::briefing::Briefing>, AtomicCoreError>
         => sqlite: list_briefings_sync, pg_trait: BriefingStore, pg_method: list_briefings;
     fn delete_briefing_sync(&self, id: &str) -> Result<(), AtomicCoreError>

--- a/crates/atomic-core/src/storage/mod.rs
+++ b/crates/atomic-core/src/storage/mod.rs
@@ -405,6 +405,20 @@ dispatch! {
     fn delete_wiki_proposal_sync(&self, tag_id: &str) -> Result<(), AtomicCoreError>
         => sqlite: delete_wiki_proposal_sync, pg_trait: WikiStore, pg_method: delete_wiki_proposal;
 
+    // ---- BriefingStore ----
+    fn list_new_atoms_since_sync(&self, since: &str, limit: i32) -> Result<Vec<AtomWithTags>, AtomicCoreError>
+        => sqlite: list_new_atoms_since_sync, pg_trait: BriefingStore, pg_method: list_new_atoms_since;
+    fn count_new_atoms_since_sync(&self, since: &str) -> Result<i32, AtomicCoreError>
+        => sqlite: count_new_atoms_since_sync, pg_trait: BriefingStore, pg_method: count_new_atoms_since;
+    fn insert_briefing_sync(&self, briefing: &crate::briefing::Briefing, citations: &[crate::briefing::BriefingCitation]) -> Result<crate::briefing::BriefingWithCitations, AtomicCoreError>
+        => sqlite: insert_briefing_sync, pg_trait: BriefingStore, pg_method: insert_briefing;
+    fn get_latest_briefing_sync(&self) -> Result<Option<crate::briefing::BriefingWithCitations>, AtomicCoreError>
+        => sqlite: get_latest_briefing_sync, pg_trait: BriefingStore, pg_method: get_latest_briefing;
+    fn list_briefings_sync(&self, limit: i32) -> Result<Vec<crate::briefing::Briefing>, AtomicCoreError>
+        => sqlite: list_briefings_sync, pg_trait: BriefingStore, pg_method: list_briefings;
+    fn delete_briefing_sync(&self, id: &str) -> Result<(), AtomicCoreError>
+        => sqlite: delete_briefing_sync, pg_trait: BriefingStore, pg_method: delete_briefing;
+
     // ---- FeedStore ----
     fn list_feeds_sync(&self) -> Result<Vec<Feed>, AtomicCoreError>
         => sqlite: list_feeds_sync, pg_trait: FeedStore, pg_method: list_feeds;

--- a/crates/atomic-core/src/storage/postgres/briefings.rs
+++ b/crates/atomic-core/src/storage/postgres/briefings.rs
@@ -43,6 +43,10 @@ impl BriefingStore for PostgresStorage {
         unsupported()
     }
 
+    async fn get_briefing(&self, _id: &str) -> StorageResult<Option<BriefingWithCitations>> {
+        unsupported()
+    }
+
     async fn list_briefings(&self, _limit: i32) -> StorageResult<Vec<Briefing>> {
         unsupported()
     }

--- a/crates/atomic-core/src/storage/postgres/briefings.rs
+++ b/crates/atomic-core/src/storage/postgres/briefings.rs
@@ -1,0 +1,53 @@
+//! Postgres stub for briefings.
+//!
+//! Briefings are SQLite-only in v1. The Postgres backend returns a
+//! Configuration error for every call so the scheduler loop can skip the
+//! task cleanly without touching the runtime.
+
+use super::PostgresStorage;
+use crate::briefing::{Briefing, BriefingCitation, BriefingWithCitations};
+use crate::error::AtomicCoreError;
+use crate::models::AtomWithTags;
+use crate::storage::traits::{BriefingStore, StorageResult};
+use async_trait::async_trait;
+
+fn unsupported<T>() -> StorageResult<T> {
+    Err(AtomicCoreError::Configuration(
+        "briefings not yet supported on Postgres".to_string(),
+    ))
+}
+
+#[async_trait]
+impl BriefingStore for PostgresStorage {
+    async fn list_new_atoms_since(
+        &self,
+        _since: &str,
+        _limit: i32,
+    ) -> StorageResult<Vec<AtomWithTags>> {
+        unsupported()
+    }
+
+    async fn count_new_atoms_since(&self, _since: &str) -> StorageResult<i32> {
+        unsupported()
+    }
+
+    async fn insert_briefing(
+        &self,
+        _briefing: &Briefing,
+        _citations: &[BriefingCitation],
+    ) -> StorageResult<BriefingWithCitations> {
+        unsupported()
+    }
+
+    async fn get_latest_briefing(&self) -> StorageResult<Option<BriefingWithCitations>> {
+        unsupported()
+    }
+
+    async fn list_briefings(&self, _limit: i32) -> StorageResult<Vec<Briefing>> {
+        unsupported()
+    }
+
+    async fn delete_briefing(&self, _id: &str) -> StorageResult<()> {
+        unsupported()
+    }
+}

--- a/crates/atomic-core/src/storage/postgres/mod.rs
+++ b/crates/atomic-core/src/storage/postgres/mod.rs
@@ -17,6 +17,8 @@ mod chat;
 #[cfg(feature = "postgres")]
 mod wiki;
 #[cfg(feature = "postgres")]
+mod briefings;
+#[cfg(feature = "postgres")]
 mod feeds;
 #[cfg(feature = "postgres")]
 mod clusters;

--- a/crates/atomic-core/src/storage/sqlite/briefings.rs
+++ b/crates/atomic-core/src/storage/sqlite/briefings.rs
@@ -317,6 +317,14 @@ impl BriefingStore for SqliteStorage {
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
     }
 
+    async fn get_briefing(&self, id: &str) -> StorageResult<Option<BriefingWithCitations>> {
+        let storage = self.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(move || storage.get_briefing_sync(&id))
+            .await
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
+    }
+
     async fn list_briefings(&self, limit: i32) -> StorageResult<Vec<Briefing>> {
         let storage = self.clone();
         tokio::task::spawn_blocking(move || storage.list_briefings_sync(limit))

--- a/crates/atomic-core/src/storage/sqlite/briefings.rs
+++ b/crates/atomic-core/src/storage/sqlite/briefings.rs
@@ -1,0 +1,334 @@
+//! SQLite storage for daily briefings and briefing citations.
+//!
+//! Mirrors the wiki storage layout: a briefing row plus a set of citation
+//! rows, with source_url joined in from the atoms table on read so clients
+//! can render citations consistently.
+
+use super::SqliteStorage;
+use crate::briefing::{Briefing, BriefingCitation, BriefingWithCitations};
+use crate::error::AtomicCoreError;
+use crate::models::AtomWithTags;
+use crate::storage::traits::{BriefingStore, StorageResult};
+use async_trait::async_trait;
+
+impl SqliteStorage {
+    // ==================== Atom fetch helpers for briefing ====================
+
+    /// Fetch up to `limit` atoms with `created_at > since`, newest first.
+    /// Returns full `AtomWithTags` rows so the agent prompt can include tags.
+    pub(crate) fn list_new_atoms_since_sync(
+        &self,
+        since: &str,
+        limit: i32,
+    ) -> StorageResult<Vec<AtomWithTags>> {
+        use crate::models::{Atom, Tag};
+        let conn = self.db.read_conn()?;
+
+        let mut stmt = conn.prepare(
+            "SELECT id, content, title, snippet, source_url, source, published_at,
+                    created_at, updated_at, embedding_status, tagging_status,
+                    embedding_error, tagging_error
+             FROM atoms
+             WHERE created_at > ?1
+             ORDER BY created_at DESC
+             LIMIT ?2",
+        )?;
+
+        let atoms: Vec<Atom> = stmt
+            .query_map(rusqlite::params![since, limit], |row| {
+                Ok(Atom {
+                    id: row.get(0)?,
+                    content: row.get(1)?,
+                    title: row.get(2)?,
+                    snippet: row.get(3)?,
+                    source_url: row.get(4)?,
+                    source: row.get(5)?,
+                    published_at: row.get(6)?,
+                    created_at: row.get(7)?,
+                    updated_at: row.get(8)?,
+                    embedding_status: row.get(9)?,
+                    tagging_status: row.get(10)?,
+                    embedding_error: row.get(11)?,
+                    tagging_error: row.get(12)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if atoms.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Batch fetch tags for all atoms
+        let atom_ids: Vec<&str> = atoms.iter().map(|a| a.id.as_str()).collect();
+        let placeholders = atom_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let mut tag_map: std::collections::HashMap<String, Vec<Tag>> =
+            std::collections::HashMap::new();
+        let tag_sql = format!(
+            "SELECT at.atom_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target
+             FROM atom_tags at
+             INNER JOIN tags t ON t.id = at.tag_id
+             WHERE at.atom_id IN ({})",
+            placeholders
+        );
+        let mut tag_stmt = conn.prepare(&tag_sql)?;
+        let rows = tag_stmt
+            .query_map(rusqlite::params_from_iter(atom_ids.iter()), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    Tag {
+                        id: row.get(1)?,
+                        name: row.get(2)?,
+                        parent_id: row.get(3)?,
+                        created_at: row.get(4)?,
+                        is_autotag_target: row.get::<_, i64>(5).unwrap_or(0) != 0,
+                    },
+                ))
+            })?;
+        for row in rows {
+            let (atom_id, tag) = row?;
+            tag_map.entry(atom_id).or_default().push(tag);
+        }
+
+        Ok(atoms
+            .into_iter()
+            .map(|a| {
+                let tags = tag_map.remove(&a.id).unwrap_or_default();
+                AtomWithTags { atom: a, tags }
+            })
+            .collect())
+    }
+
+    /// Count atoms with `created_at > since`. Reported to the agent so it
+    /// knows whether it's seeing all the new material or a truncated slice.
+    pub(crate) fn count_new_atoms_since_sync(&self, since: &str) -> StorageResult<i32> {
+        let conn = self.db.read_conn()?;
+        let count: i32 = conn.query_row(
+            "SELECT COUNT(*) FROM atoms WHERE created_at > ?1",
+            rusqlite::params![since],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
+    // ==================== Briefing CRUD ====================
+
+    pub(crate) fn insert_briefing_sync(
+        &self,
+        briefing: &Briefing,
+        citations: &[BriefingCitation],
+    ) -> StorageResult<BriefingWithCitations> {
+        let mut conn = self
+            .db
+            .conn
+            .lock()
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
+
+        let tx = conn.transaction()?;
+
+        tx.execute(
+            "INSERT INTO briefings (id, content, created_at, atom_count, last_run_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![
+                briefing.id,
+                briefing.content,
+                briefing.created_at,
+                briefing.atom_count,
+                briefing.last_run_at,
+            ],
+        )?;
+
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO briefing_citations (id, briefing_id, citation_index, atom_id, excerpt)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+            )?;
+            for c in citations {
+                stmt.execute(rusqlite::params![
+                    c.id,
+                    briefing.id,
+                    c.citation_index,
+                    c.atom_id,
+                    c.excerpt,
+                ])?;
+            }
+        }
+
+        tx.commit()?;
+        drop(conn);
+
+        // Read back with JOINed source_url
+        self.get_briefing_sync(&briefing.id)?.ok_or_else(|| {
+            AtomicCoreError::DatabaseOperation(format!(
+                "Briefing {} vanished after insert",
+                briefing.id
+            ))
+        })
+    }
+
+    /// Fetch a single briefing by id, joining citations with source_url.
+    pub(crate) fn get_briefing_sync(
+        &self,
+        id: &str,
+    ) -> StorageResult<Option<BriefingWithCitations>> {
+        let conn = self.db.read_conn()?;
+
+        let briefing = conn
+            .query_row(
+                "SELECT id, content, created_at, atom_count, last_run_at
+                 FROM briefings WHERE id = ?1",
+                rusqlite::params![id],
+                |row| {
+                    Ok(Briefing {
+                        id: row.get(0)?,
+                        content: row.get(1)?,
+                        created_at: row.get(2)?,
+                        atom_count: row.get(3)?,
+                        last_run_at: row.get(4)?,
+                    })
+                },
+            )
+            .ok();
+
+        let Some(briefing) = briefing else {
+            return Ok(None);
+        };
+
+        let mut stmt = conn.prepare(
+            "SELECT bc.id, bc.briefing_id, bc.citation_index, bc.atom_id, bc.excerpt, a.source_url
+             FROM briefing_citations bc
+             LEFT JOIN atoms a ON a.id = bc.atom_id
+             WHERE bc.briefing_id = ?1
+             ORDER BY bc.citation_index",
+        )?;
+        let citations: Vec<BriefingCitation> = stmt
+            .query_map(rusqlite::params![id], |row| {
+                Ok(BriefingCitation {
+                    id: row.get(0)?,
+                    briefing_id: row.get(1)?,
+                    citation_index: row.get(2)?,
+                    atom_id: row.get(3)?,
+                    excerpt: row.get(4)?,
+                    source_url: row.get(5)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Some(BriefingWithCitations { briefing, citations }))
+    }
+
+    /// Fetch the most recent briefing (by `created_at`), joined with citations.
+    pub(crate) fn get_latest_briefing_sync(
+        &self,
+    ) -> StorageResult<Option<BriefingWithCitations>> {
+        let conn = self.db.read_conn()?;
+
+        let id: Option<String> = conn
+            .query_row(
+                "SELECT id FROM briefings ORDER BY created_at DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .ok();
+        drop(conn);
+
+        let Some(id) = id else {
+            return Ok(None);
+        };
+        self.get_briefing_sync(&id)
+    }
+
+    /// List recent briefings (without citations) for a lightweight history view.
+    pub(crate) fn list_briefings_sync(&self, limit: i32) -> StorageResult<Vec<Briefing>> {
+        let conn = self.db.read_conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, content, created_at, atom_count, last_run_at
+             FROM briefings
+             ORDER BY created_at DESC
+             LIMIT ?1",
+        )?;
+        let rows = stmt
+            .query_map(rusqlite::params![limit], |row| {
+                Ok(Briefing {
+                    id: row.get(0)?,
+                    content: row.get(1)?,
+                    created_at: row.get(2)?,
+                    atom_count: row.get(3)?,
+                    last_run_at: row.get(4)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Delete a briefing and its citations (FK cascade handles the citations).
+    pub(crate) fn delete_briefing_sync(&self, id: &str) -> StorageResult<()> {
+        let conn = self
+            .db
+            .conn
+            .lock()
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
+        conn.execute(
+            "DELETE FROM briefings WHERE id = ?1",
+            rusqlite::params![id],
+        )?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl BriefingStore for SqliteStorage {
+    async fn list_new_atoms_since(
+        &self,
+        since: &str,
+        limit: i32,
+    ) -> StorageResult<Vec<AtomWithTags>> {
+        let storage = self.clone();
+        let since = since.to_string();
+        tokio::task::spawn_blocking(move || storage.list_new_atoms_since_sync(&since, limit))
+            .await
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
+    }
+
+    async fn count_new_atoms_since(&self, since: &str) -> StorageResult<i32> {
+        let storage = self.clone();
+        let since = since.to_string();
+        tokio::task::spawn_blocking(move || storage.count_new_atoms_since_sync(&since))
+            .await
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
+    }
+
+    async fn insert_briefing(
+        &self,
+        briefing: &Briefing,
+        citations: &[BriefingCitation],
+    ) -> StorageResult<BriefingWithCitations> {
+        let storage = self.clone();
+        let briefing = briefing.clone();
+        let citations = citations.to_vec();
+        tokio::task::spawn_blocking(move || storage.insert_briefing_sync(&briefing, &citations))
+            .await
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
+    }
+
+    async fn get_latest_briefing(&self) -> StorageResult<Option<BriefingWithCitations>> {
+        let storage = self.clone();
+        tokio::task::spawn_blocking(move || storage.get_latest_briefing_sync())
+            .await
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
+    }
+
+    async fn list_briefings(&self, limit: i32) -> StorageResult<Vec<Briefing>> {
+        let storage = self.clone();
+        tokio::task::spawn_blocking(move || storage.list_briefings_sync(limit))
+            .await
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
+    }
+
+    async fn delete_briefing(&self, id: &str) -> StorageResult<()> {
+        let storage = self.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(move || storage.delete_briefing_sync(&id))
+            .await
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
+    }
+}

--- a/crates/atomic-core/src/storage/sqlite/mod.rs
+++ b/crates/atomic-core/src/storage/sqlite/mod.rs
@@ -10,6 +10,7 @@ mod chunks;
 mod search;
 mod chat;
 mod wiki;
+mod briefings;
 mod feeds;
 mod clusters;
 mod settings;

--- a/crates/atomic-core/src/storage/traits.rs
+++ b/crates/atomic-core/src/storage/traits.rs
@@ -704,6 +704,12 @@ pub trait BriefingStore: Send + Sync {
         &self,
     ) -> StorageResult<Option<crate::briefing::BriefingWithCitations>>;
 
+    /// Fetch a specific briefing by id (joined with citations).
+    async fn get_briefing(
+        &self,
+        id: &str,
+    ) -> StorageResult<Option<crate::briefing::BriefingWithCitations>>;
+
     /// List recent briefings (without citations) for a lightweight history view.
     async fn list_briefings(
         &self,

--- a/crates/atomic-core/src/storage/traits.rs
+++ b/crates/atomic-core/src/storage/traits.rs
@@ -676,6 +676,44 @@ pub trait WikiStore: Send + Sync {
     async fn delete_wiki_proposal(&self, tag_id: &str) -> StorageResult<()>;
 }
 
+// ==================== Briefing Storage ====================
+
+/// Storage operations for daily briefings (the scheduled-task briefing feature).
+#[async_trait]
+pub trait BriefingStore: Send + Sync {
+    /// Fetch up to `limit` atoms with `created_at > since`, newest first.
+    async fn list_new_atoms_since(
+        &self,
+        since: &str,
+        limit: i32,
+    ) -> StorageResult<Vec<AtomWithTags>>;
+
+    /// Count atoms with `created_at > since`.
+    async fn count_new_atoms_since(&self, since: &str) -> StorageResult<i32>;
+
+    /// Insert a new briefing plus its citations. Returns the briefing joined
+    /// with citations (citations have `source_url` populated via JOIN).
+    async fn insert_briefing(
+        &self,
+        briefing: &crate::briefing::Briefing,
+        citations: &[crate::briefing::BriefingCitation],
+    ) -> StorageResult<crate::briefing::BriefingWithCitations>;
+
+    /// Fetch the most recent briefing (joined with citations).
+    async fn get_latest_briefing(
+        &self,
+    ) -> StorageResult<Option<crate::briefing::BriefingWithCitations>>;
+
+    /// List recent briefings (without citations) for a lightweight history view.
+    async fn list_briefings(
+        &self,
+        limit: i32,
+    ) -> StorageResult<Vec<crate::briefing::Briefing>>;
+
+    /// Delete a briefing by id. Briefing citations cascade.
+    async fn delete_briefing(&self, id: &str) -> StorageResult<()>;
+}
+
 // ==================== Feed Storage ====================
 
 /// Storage operations for RSS/Atom feed subscriptions.
@@ -875,6 +913,7 @@ pub trait Storage:
     + SearchStore
     + ChatStore
     + WikiStore
+    + BriefingStore
     + FeedStore
     + ClusterStore
     + SettingsStore

--- a/crates/atomic-core/src/wiki/mod.rs
+++ b/crates/atomic-core/src/wiki/mod.rs
@@ -15,9 +15,9 @@ use crate::models::{
     WikiArticleStatus, WikiArticleVersion, WikiArticleWithCitations, WikiCitation,
     WikiLink, WikiVersionSummary,
 };
-use crate::providers::traits::LlmConfig;
-use crate::providers::types::{GenerationParams, Message, StructuredOutputSchema};
-use crate::providers::{get_llm_provider, ProviderConfig};
+use crate::providers::structured::{call_structured, StructuredCall};
+use crate::providers::types::Message;
+use crate::providers::ProviderConfig;
 use crate::storage::StorageBackend;
 
 use chrono::Utc;
@@ -222,7 +222,7 @@ pub(crate) struct WikiUpdateOpsResult {
 ///
 /// The LLM emits the flat shape; `WikiSectionOpWire::into_op()` validates
 /// and converts to the strict `WikiSectionOp` enum.
-fn section_ops_schema() -> serde_json::Value {
+pub(crate) fn section_ops_schema() -> serde_json::Value {
     serde_json::json!({
         "type": "object",
         "properties": {
@@ -568,15 +568,10 @@ pub(crate) struct WikiGenerationResult {
     pub citations_used: Vec<i32>,
 }
 
-/// Call LLM provider for wiki generation (full-article rewrite schema).
-/// Thin wrapper over `call_llm_for_wiki_typed`.
-pub(crate) async fn call_llm_for_wiki(
-    provider_config: &ProviderConfig,
-    system_prompt: &str,
-    user_content: &str,
-    model: &str,
-) -> Result<WikiGenerationResult, String> {
-    let schema = serde_json::json!({
+/// JSON schema for wiki full-article generation. Extracted as a function so
+/// it's callable from the lint regression tests.
+pub(crate) fn wiki_generation_schema() -> serde_json::Value {
+    serde_json::json!({
         "type": "object",
         "properties": {
             "article_content": {
@@ -591,107 +586,71 @@ pub(crate) async fn call_llm_for_wiki(
         },
         "required": ["article_content", "citations_used"],
         "additionalProperties": false
-    });
+    })
+}
 
+/// Call LLM provider for wiki generation (full-article rewrite schema).
+/// Thin wrapper over [`call_llm_for_wiki_typed`].
+pub(crate) async fn call_llm_for_wiki(
+    provider_config: &ProviderConfig,
+    system_prompt: &str,
+    user_content: &str,
+    model: &str,
+) -> Result<WikiGenerationResult, String> {
     call_llm_for_wiki_typed::<WikiGenerationResult>(
         provider_config,
         system_prompt,
         user_content,
         model,
         "wiki_generation_result",
-        schema,
+        wiki_generation_schema(),
     )
     .await
 }
 
-/// Generic LLM call for wiki operations. Callers provide the JSON schema and
-/// the result type; retry/parse/error handling is shared.
+/// Generic LLM call for wiki operations. Thin wrapper over the shared
+/// [`call_structured`] helper that adds wiki-specific tracing context so
+/// the logs still say `[wiki]` for anyone watching them. The retry / parse
+/// / prompt-based-fallback loop lives in the shared helper now.
 pub(crate) async fn call_llm_for_wiki_typed<T: DeserializeOwned>(
     provider_config: &ProviderConfig,
     system_prompt: &str,
     user_content: &str,
     model: &str,
-    schema_name: &str,
+    schema_name: &'static str,
     schema: serde_json::Value,
 ) -> Result<T, String> {
-    let input_chars = user_content.len();
-    tracing::info!(model, input_chars, schema = %schema_name, "[wiki] Starting generation");
+    tracing::info!(
+        model,
+        input_chars = user_content.len(),
+        schema = %schema_name,
+        "[wiki] Starting generation"
+    );
 
     let messages = vec![Message::system(system_prompt), Message::user(user_content)];
 
-    let llm_config = LlmConfig::new(model).with_params(
-        GenerationParams::new()
-            .with_temperature(0.3)
-            .with_structured_output(StructuredOutputSchema::new(schema_name, schema)),
+    let call = StructuredCall::<T>::new(
+        provider_config,
+        model,
+        &messages,
+        schema_name,
+        schema,
     );
 
-    let provider = get_llm_provider(provider_config).map_err(|e| e.to_string())?;
-
-    // Only retry on transient errors (rate limits, network). Never retry on
-    // content/parse errors — those waste tokens on calls doomed to fail the same way.
-    let max_retries = 2;
-    let mut last_error = String::new();
-    for attempt in 0..=max_retries {
-        if attempt > 0 {
-            let delay = 1u64 << attempt;
-            tracing::warn!(attempt, max_retries, delay_secs = delay, last_error = %last_error, "[wiki] Retrying");
-            tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+    let started = std::time::Instant::now();
+    match call_structured::<T>(call).await {
+        Ok(result) => {
+            tracing::info!(
+                elapsed_secs = format_args!("{:.1}", started.elapsed().as_secs_f64()),
+                "[wiki] Structured generation complete"
+            );
+            Ok(result)
         }
-
-        let start = std::time::Instant::now();
-        match provider.complete(&messages, &llm_config).await {
-            Ok(response) => {
-                let elapsed = start.elapsed();
-                let content = &response.content;
-                tracing::info!(elapsed_secs = format_args!("{:.1}", elapsed.as_secs_f64()), output_chars = content.len(), "[wiki] LLM responded");
-
-                if content.is_empty() {
-                    tracing::error!("[wiki] LLM returned empty content");
-                    return Err("LLM returned empty content".to_string());
-                }
-
-                // Parse the structured JSON response
-                match serde_json::from_str::<T>(content) {
-                    Ok(result) => {
-                        return Ok(result);
-                    }
-                    Err(parse_err) => {
-                        // Log the parse failure with enough context to debug, but don't retry —
-                        // the same prompt will produce the same unparseable output.
-                        let preview = {
-                            let mut iter = content.chars();
-                            let head: String = iter.by_ref().take(500).collect();
-                            if iter.next().is_some() {
-                                format!("{}...[truncated]", head)
-                            } else {
-                                head
-                            }
-                        };
-                        tracing::error!(error = %parse_err, preview = %preview, "[wiki] Failed to parse LLM response as JSON");
-                        return Err(format!("Failed to parse wiki result: {}", parse_err));
-                    }
-                }
-            }
-            Err(e) => {
-                let elapsed = start.elapsed();
-                tracing::error!(elapsed_secs = format_args!("{:.1}", elapsed.as_secs_f64()), error = %e, "[wiki] LLM call failed");
-
-                if e.is_retryable() && attempt < max_retries {
-                    last_error = e.to_string();
-                    continue;
-                } else {
-                    if !e.is_retryable() {
-                        tracing::error!("[wiki] Non-retryable error, giving up immediately");
-                    } else {
-                        tracing::error!("[wiki] Max retries exhausted");
-                    }
-                    return Err(e.to_string());
-                }
-            }
+        Err(e) => {
+            tracing::error!(error = %e, "[wiki] Structured generation failed");
+            Err(e.to_compact_string())
         }
     }
-
-    Err(last_error)
 }
 
 // ==================== Shared Utilities ====================
@@ -1667,12 +1626,32 @@ pub fn get_suggested_wiki_articles(
 mod tests {
     use super::*;
     use crate::db::Database as CoreDatabase;
+    use crate::providers::structured::lint_schema;
     use tempfile::NamedTempFile;
 
     fn create_test_db() -> (CoreDatabase, NamedTempFile) {
         let temp_file = NamedTempFile::new().unwrap();
         let db = CoreDatabase::open_or_create(temp_file.path()).unwrap();
         (db, temp_file)
+    }
+
+    // ==================== Schema lint regression tests ====================
+    //
+    // These guard against someone editing a schema in a way that would cause
+    // silent cross-provider divergence (wiki has been bitten by this before —
+    // see the long comment on `section_ops_schema`). The linter lives in
+    // `providers::structured::lint_schema`.
+
+    #[test]
+    fn lint_wiki_generation_schema() {
+        lint_schema(&wiki_generation_schema())
+            .expect("wiki_generation_schema must be portable across providers");
+    }
+
+    #[test]
+    fn lint_wiki_section_ops_schema() {
+        lint_schema(&section_ops_schema())
+            .expect("section_ops_schema must be portable across providers");
     }
 
     fn insert_tag(conn: &Connection, id: &str, name: &str) {

--- a/crates/atomic-server/src/error.rs
+++ b/crates/atomic-server/src/error.rs
@@ -27,6 +27,11 @@ pub fn error_response(e: atomic_core::AtomicCoreError) -> HttpResponse {
                 error: e.to_string(),
             })
         }
+        atomic_core::AtomicCoreError::Conflict(_) => {
+            HttpResponse::Conflict().json(ApiErrorResponse {
+                error: e.to_string(),
+            })
+        }
         _ => HttpResponse::InternalServerError().json(ApiErrorResponse {
             error: e.to_string(),
         }),
@@ -66,6 +71,7 @@ pub fn status_code_for(e: &atomic_core::AtomicCoreError) -> actix_web::http::Sta
         atomic_core::AtomicCoreError::NotFound(_) => StatusCode::NOT_FOUND,
         atomic_core::AtomicCoreError::Validation(_) => StatusCode::BAD_REQUEST,
         atomic_core::AtomicCoreError::Configuration(_) => StatusCode::BAD_REQUEST,
+        atomic_core::AtomicCoreError::Conflict(_) => StatusCode::CONFLICT,
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }

--- a/crates/atomic-server/src/event_bridge.rs
+++ b/crates/atomic-server/src/event_bridge.rs
@@ -5,6 +5,7 @@
 //! as ServerEvent variants.
 
 use crate::state::ServerEvent;
+use std::sync::Arc;
 use tokio::sync::broadcast;
 
 /// Create an EmbeddingEvent callback that broadcasts to WebSocket clients
@@ -32,4 +33,39 @@ pub fn chat_event_callback(
     move |event: atomic_core::ChatEvent| {
         let _ = tx.send(ServerEvent::from(event));
     }
+}
+
+/// Create a TaskEvent callback for the scheduler. Only the daily briefing
+/// task produces a broadcast-visible event right now (BriefingReady). Other
+/// task events are logged at debug level and ignored.
+pub fn task_event_callback(
+    tx: broadcast::Sender<ServerEvent>,
+) -> Arc<dyn Fn(atomic_core::scheduler::TaskEvent) + Send + Sync> {
+    Arc::new(move |event: atomic_core::scheduler::TaskEvent| {
+        use atomic_core::scheduler::TaskEvent;
+        match event {
+            TaskEvent::Completed {
+                task_id,
+                db_id,
+                result_id,
+            } if task_id == "daily_briefing" => {
+                if let Some(briefing_id) = result_id {
+                    let _ = tx.send(ServerEvent::BriefingReady { db_id, briefing_id });
+                }
+            }
+            TaskEvent::Started { task_id, db_id } => {
+                tracing::debug!(task_id, db_id, "[scheduler] task started");
+            }
+            TaskEvent::Completed { task_id, db_id, .. } => {
+                tracing::debug!(task_id, db_id, "[scheduler] task completed");
+            }
+            TaskEvent::Failed {
+                task_id,
+                db_id,
+                error,
+            } => {
+                tracing::debug!(task_id, db_id, error = %error, "[scheduler] task failed");
+            }
+        }
+    })
 }

--- a/crates/atomic-server/src/main.rs
+++ b/crates/atomic-server/src/main.rs
@@ -349,6 +349,59 @@ async fn run_server(
         });
     }
 
+    // Spawn scheduled-tasks runner (ticks every 60 seconds across all databases).
+    // Each registered task checks its own due-ness and state; we just hand it
+    // a core + context. A per-(task, db) lock in the registry prevents the
+    // next tick from re-entering a still-running task.
+    {
+        let task_manager = Arc::clone(&manager);
+        let task_tx = event_tx.clone();
+        tokio::spawn(async move {
+            let mut registry = atomic_core::scheduler::TaskRegistry::new();
+            registry.register(Arc::new(atomic_core::briefing::DailyBriefingTask));
+            let registry = Arc::new(registry);
+
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let databases = match task_manager.list_databases() {
+                    Ok((dbs, _)) => dbs,
+                    Err(_) => continue,
+                };
+                for db_info in &databases {
+                    let db_core = match task_manager.get_core(&db_info.id) {
+                        Ok(c) => c,
+                        Err(_) => continue,
+                    };
+                    for task in registry.tasks() {
+                        let Some(guard) = registry.try_lock(task.id(), &db_info.id) else {
+                            continue;
+                        };
+                        let task_clone = Arc::clone(task);
+                        let db_core_clone = db_core.clone();
+                        let tx = task_tx.clone();
+                        let db_id = db_info.id.clone();
+                        tokio::spawn(async move {
+                            let ctx = atomic_core::scheduler::TaskContext {
+                                event_cb: event_bridge::task_event_callback(tx),
+                            };
+                            if let Err(e) = task_clone.run(&db_core_clone, &ctx).await {
+                                tracing::debug!(
+                                    task = task_clone.id(),
+                                    db = %db_id,
+                                    error = %e,
+                                    "task run ended"
+                                );
+                            }
+                            drop(guard);
+                        });
+                    }
+                }
+            }
+        });
+    }
+
     let bind_owned = bind.to_string();
     let shutdown_manager = Arc::clone(&manager);
 

--- a/crates/atomic-server/src/routes/briefings.rs
+++ b/crates/atomic-server/src/routes/briefings.rs
@@ -51,6 +51,28 @@ pub async fn list_briefings(db: Db, query: web::Query<ListBriefingsQuery>) -> Ht
 }
 
 #[utoipa::path(
+    get,
+    path = "/api/briefings/{id}",
+    responses(
+        (status = 200, description = "Briefing with citations", body = atomic_core::BriefingWithCitations),
+        (status = 404, description = "Briefing not found", body = ApiErrorResponse)
+    ),
+    tag = "briefings"
+)]
+pub async fn get_briefing(db: Db, path: web::Path<String>) -> HttpResponse {
+    let core = db.0;
+    let id = path.into_inner();
+    match web::block(move || core.get_briefing(&id)).await {
+        Ok(Ok(Some(b))) => HttpResponse::Ok().json(b),
+        Ok(Ok(None)) => HttpResponse::NotFound()
+            .json(serde_json::json!({"error": "Briefing not found"})),
+        Ok(Err(e)) => error_response(e),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": format!("Thread pool error: {}", e)})),
+    }
+}
+
+#[utoipa::path(
     post,
     path = "/api/briefings/run",
     responses(

--- a/crates/atomic-server/src/routes/briefings.rs
+++ b/crates/atomic-server/src/routes/briefings.rs
@@ -1,0 +1,90 @@
+//! Daily briefing routes.
+
+use crate::db_extractor::Db;
+use crate::error::{blocking_ok, error_response, ApiErrorResponse};
+use crate::state::{AppState, ServerEvent};
+use actix_web::{web, HttpRequest, HttpResponse};
+use serde::Deserialize;
+use utoipa::{IntoParams, ToSchema};
+
+#[utoipa::path(
+    get,
+    path = "/api/briefings/latest",
+    responses(
+        (status = 200, description = "Most recent briefing with citations", body = atomic_core::BriefingWithCitations),
+        (status = 404, description = "No briefings yet", body = ApiErrorResponse)
+    ),
+    tag = "briefings"
+)]
+pub async fn get_latest_briefing(db: Db) -> HttpResponse {
+    let core = db.0;
+    match core.get_latest_briefing() {
+        Ok(Some(b)) => HttpResponse::Ok().json(b),
+        Ok(None) => HttpResponse::NotFound()
+            .json(serde_json::json!({"error": "No briefings yet"})),
+        Err(e) => error_response(e),
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
+#[into_params(parameter_in = Query)]
+pub struct ListBriefingsQuery {
+    /// Max briefings to return (default 20)
+    pub limit: Option<i32>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/briefings",
+    params(ListBriefingsQuery),
+    responses(
+        (status = 200, description = "Recent briefings (without citations)", body = Vec<atomic_core::Briefing>)
+    ),
+    tag = "briefings"
+)]
+pub async fn list_briefings(db: Db, query: web::Query<ListBriefingsQuery>) -> HttpResponse {
+    let limit = query.limit.unwrap_or(20).clamp(1, 100);
+    let core = db.0;
+    blocking_ok(move || core.list_briefings(limit)).await
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/briefings/run",
+    responses(
+        (status = 200, description = "Briefing generated", body = atomic_core::BriefingWithCitations),
+        (status = 400, description = "Error", body = ApiErrorResponse)
+    ),
+    tag = "briefings"
+)]
+pub async fn run_briefing_now(
+    state: web::Data<AppState>,
+    req: HttpRequest,
+) -> HttpResponse {
+    // Resolve the target core before we start (same logic as Db extractor).
+    let core = match state.resolve_core(&req) {
+        Ok(c) => c,
+        Err(e) => return error_response(e),
+    };
+
+    // Capture db_id for the broadcast event. We use the file stem of the
+    // SQLite path; for Postgres this call returns a Configuration error
+    // from run_daily_briefing anyway.
+    let db_id = core
+        .db_path()
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "default".to_string());
+
+    match core.run_daily_briefing().await {
+        Ok(result) => {
+            let _ = state.event_tx.send(ServerEvent::BriefingReady {
+                db_id,
+                briefing_id: result.briefing.id.clone(),
+            });
+            HttpResponse::Ok().json(result)
+        }
+        Err(e) => error_response(e),
+    }
+}

--- a/crates/atomic-server/src/routes/briefings.rs
+++ b/crates/atomic-server/src/routes/briefings.rs
@@ -18,11 +18,13 @@ use utoipa::{IntoParams, ToSchema};
 )]
 pub async fn get_latest_briefing(db: Db) -> HttpResponse {
     let core = db.0;
-    match core.get_latest_briefing() {
-        Ok(Some(b)) => HttpResponse::Ok().json(b),
-        Ok(None) => HttpResponse::NotFound()
+    match web::block(move || core.get_latest_briefing()).await {
+        Ok(Ok(Some(b))) => HttpResponse::Ok().json(b),
+        Ok(Ok(None)) => HttpResponse::NotFound()
             .json(serde_json::json!({"error": "No briefings yet"})),
-        Err(e) => error_response(e),
+        Ok(Err(e)) => error_response(e),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": format!("Thread pool error: {}", e)})),
     }
 }
 

--- a/crates/atomic-server/src/routes/mod.rs
+++ b/crates/atomic-server/src/routes/mod.rs
@@ -101,6 +101,7 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.route("/briefings/latest", web::get().to(briefings::get_latest_briefing));
     cfg.route("/briefings", web::get().to(briefings::list_briefings));
     cfg.route("/briefings/run", web::post().to(briefings::run_briefing_now));
+    cfg.route("/briefings/{id}", web::get().to(briefings::get_briefing));
 
     // Settings
     cfg.route("/settings", web::get().to(settings::get_settings));

--- a/crates/atomic-server/src/routes/mod.rs
+++ b/crates/atomic-server/src/routes/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod auth;
 pub mod atoms;
+pub mod briefings;
 pub mod canvas;
 pub mod chat;
 pub mod clustering;
@@ -95,6 +96,11 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         "/wiki/recompute-tag-embeddings",
         web::post().to(wiki::recompute_all_tag_embeddings),
     );
+
+    // Briefings
+    cfg.route("/briefings/latest", web::get().to(briefings::get_latest_briefing));
+    cfg.route("/briefings", web::get().to(briefings::list_briefings));
+    cfg.route("/briefings/run", web::post().to(briefings::run_briefing_now));
 
     // Settings
     cfg.route("/settings", web::get().to(settings::get_settings));

--- a/crates/atomic-server/src/state.rs
+++ b/crates/atomic-server/src/state.rs
@@ -161,6 +161,12 @@ pub enum ServerEvent {
         conversation_id: String,
         error: String,
     },
+
+    // Scheduled task events
+    BriefingReady {
+        db_id: String,
+        briefing_id: String,
+    },
 }
 
 impl From<atomic_core::EmbeddingEvent> for ServerEvent {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "diff": "^8.0.4",
         "graphology": "^0.26.0",
         "graphology-types": "^0.24.8",
+        "lucide-react": "^1.8.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -5232,6 +5233,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "diff": "^8.0.4",
     "graphology": "^0.26.0",
     "graphology-types": "^0.24.8",
+    "lucide-react": "^1.8.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/DatabaseSwitcher.tsx
+++ b/src/components/DatabaseSwitcher.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { Database, ChevronDown, Pencil, Trash2 } from 'lucide-react';
 import { useDatabasesStore, DatabaseInfo } from '../stores/databases';
 
 export function DatabaseSwitcher() {
@@ -67,13 +68,9 @@ export function DatabaseSwitcher() {
         className="w-full flex items-center gap-1.5 px-2 py-1.5 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
         title={activeName}
       >
-        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" className="flex-shrink-0 opacity-60">
-          <path d="M8 1L1 4.5 8 8l7-3.5L8 1zM1 8l7 3.5L15 8M1 11.5l7 3.5 7-3.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"/>
-        </svg>
+        <Database className="w-3 h-3 flex-shrink-0 opacity-60" strokeWidth={2} />
         <span className="truncate">{activeName}</span>
-        <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor" className="flex-shrink-0 opacity-40">
-          <path d="M1 2.5L4 5.5L7 2.5" stroke="currentColor" strokeWidth="1.5" fill="none"/>
-        </svg>
+        <ChevronDown className="w-2 h-2 flex-shrink-0 opacity-40" strokeWidth={2} />
       </button>
 
       {isOpen && (
@@ -110,9 +107,7 @@ export function DatabaseSwitcher() {
                     className="opacity-0 group-hover:opacity-100 hover:text-[var(--color-text-primary)] text-[var(--color-text-tertiary)]"
                     title="Rename"
                   >
-                    <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
-                      <path d="M12.146.854a.5.5 0 0 1 .708 0l2.292 2.292a.5.5 0 0 1 0 .708l-9.5 9.5a.5.5 0 0 1-.168.11l-4 1.5a.5.5 0 0 1-.65-.65l1.5-4a.5.5 0 0 1 .11-.168l9.5-9.5z"/>
-                    </svg>
+                    <Pencil className="w-2.5 h-2.5" strokeWidth={2} />
                   </button>
                   {!db.is_default && (
                     <button
@@ -120,10 +115,7 @@ export function DatabaseSwitcher() {
                       className="opacity-0 group-hover:opacity-100 hover:text-red-400 text-[var(--color-text-tertiary)]"
                       title="Delete"
                     >
-                      <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
-                        <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
-                        <path fillRule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4L4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118z"/>
-                      </svg>
+                      <Trash2 className="w-2.5 h-2.5" strokeWidth={2} />
                     </button>
                   )}
                 </>

--- a/src/components/atoms/AtomCard.tsx
+++ b/src/components/atoms/AtomCard.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { DisplayAtom } from '../../stores/atoms';
 import { TagChip } from '../tags/TagChip';
 import { formatRelativeDate, formatShortRelativeDate } from '../../lib/date';
@@ -53,14 +54,7 @@ function ProcessingStatusIndicator({
         className="absolute top-2 right-2 text-red-500 hover:text-red-400 transition-colors"
         title="Embedding failed - click to retry"
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-          />
-        </svg>
+        <AlertTriangle className="w-4 h-4" strokeWidth={2} />
       </button>
     );
   }
@@ -103,14 +97,7 @@ function ProcessingStatusIndicator({
         className="absolute top-2 right-2 text-orange-500 hover:text-orange-400 transition-colors"
         title="Tag extraction failed - click to retry"
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-          />
-        </svg>
+        <RefreshCw className="w-4 h-4" strokeWidth={2} />
       </button>
     );
   }

--- a/src/components/atoms/AtomGrid.tsx
+++ b/src/components/atoms/AtomGrid.tsx
@@ -1,4 +1,5 @@
 import { memo, useRef, useEffect } from 'react';
+import { FileText } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { DisplayAtom } from '../../stores/atoms';
 import { AtomCard } from './AtomCard';
@@ -81,19 +82,7 @@ export const AtomGrid = memo(function AtomGrid({
   if (atoms.length === 0) {
     return (
       <div ref={parentRef} className="flex flex-col items-center justify-center h-full text-center p-8">
-        <svg
-          className="w-16 h-16 text-[var(--color-border)] mb-4"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-          />
-        </svg>
+        <FileText className="w-16 h-16 text-[var(--color-border)] mb-4" strokeWidth={1.5} />
         <h3 className="text-lg font-medium text-[var(--color-text-primary)] mb-2">No atoms yet</h3>
         <p className="text-sm text-[var(--color-text-secondary)] max-w-sm">
           Click the + button to create your first atom and start building your knowledge base.

--- a/src/components/atoms/AtomList.tsx
+++ b/src/components/atoms/AtomList.tsx
@@ -1,4 +1,5 @@
 import { memo, useRef, useEffect } from 'react';
+import { FileText } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { DisplayAtom } from '../../stores/atoms';
 import { AtomCard } from './AtomCard';
@@ -61,19 +62,7 @@ export const AtomList = memo(function AtomList({
   if (atoms.length === 0) {
     return (
       <div ref={parentRef} className="flex flex-col items-center justify-center h-full text-center p-8">
-        <svg
-          className="w-16 h-16 text-[var(--color-border)] mb-4"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-          />
-        </svg>
+        <FileText className="w-16 h-16 text-[var(--color-border)] mb-4" strokeWidth={1.5} />
         <h3 className="text-lg font-medium text-[var(--color-text-primary)] mb-2">No atoms yet</h3>
         <p className="text-sm text-[var(--color-text-secondary)] max-w-sm">
           Click the + button to create your first atom and start building your knowledge base.

--- a/src/components/atoms/AtomReader.tsx
+++ b/src/components/atoms/AtomReader.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, ReactNode, useRef, useMemo, memo } from 'react';
+import { ChevronDown, Loader2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
@@ -557,7 +558,7 @@ function AtomReaderContent({
                 <div className="h-8">
                   {!isFullyRendered && (
                     <div className="flex items-center gap-2 text-[var(--color-text-tertiary)]">
-                      <div className="w-4 h-4 border-2 border-[var(--color-text-tertiary)] border-t-transparent rounded-full animate-spin" />
+                      <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
                       <span className="text-sm">Loading...</span>
                     </div>
                   )}
@@ -691,9 +692,7 @@ function SidebarRelatedAtoms({ atomId, onAtomClick }: { atomId: string; onAtomCl
         className="flex items-center justify-between w-full text-xs font-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
       >
         <span>Related atoms</span>
-        <svg className={`w-3 h-3 transition-transform ${isCollapsed ? '' : 'rotate-180'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
+        <ChevronDown className={`w-3 h-3 transition-transform ${isCollapsed ? '' : 'rotate-180'}`} strokeWidth={2} />
       </button>
       {!isCollapsed && (
         <div className="mt-2 space-y-1.5">

--- a/src/components/atoms/AtomViewer.tsx
+++ b/src/components/atoms/AtomViewer.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useLayoutEffect, ReactNode, useRef, useMemo } from 'react';
+import { X, Network, Pencil, Trash2, ChevronDown, Link2, Loader2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { openExternalUrl } from '../../lib/platform';
@@ -386,36 +387,23 @@ export function AtomViewer({ atom, onClose, onEdit, highlightText }: AtomViewerP
           onClick={onClose}
           className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
         >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          <X className="w-5 h-5" strokeWidth={2} />
         </button>
         <div className="flex items-center gap-2">
           {atom.embedding_status === 'complete' && (
             <>
               <Button variant="ghost" size="sm" onClick={handleViewNeighborhood} title="View neighborhood graph">
-                <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <circle cx="12" cy="12" r="3" strokeWidth={2} />
-                  <circle cx="5" cy="8" r="2" strokeWidth={2} />
-                  <circle cx="19" cy="8" r="2" strokeWidth={2} />
-                  <circle cx="7" cy="18" r="2" strokeWidth={2} />
-                  <circle cx="17" cy="18" r="2" strokeWidth={2} />
-                  <path strokeLinecap="round" strokeWidth={2} d="M9.5 10.5L6.5 9M14.5 10.5L17.5 9M10 14L8 16.5M14 14L16 16.5" />
-                </svg>
+                <Network className="w-4 h-4 mr-1.5" strokeWidth={2} />
                 Graph
               </Button>
             </>
           )}
           <Button variant="ghost" size="sm" onClick={onEdit}>
-            <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
+            <Pencil className="w-4 h-4 mr-1.5" strokeWidth={2} />
             Edit
           </Button>
           <Button variant="ghost" size="sm" onClick={() => setShowDeleteModal(true)}>
-            <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
+            <Trash2 className="w-4 h-4 mr-1.5" strokeWidth={2} />
             Delete
           </Button>
         </div>
@@ -456,7 +444,7 @@ export function AtomViewer({ atom, onClose, onEdit, highlightText }: AtomViewerP
           <div className="h-8">
             {!isFullyRendered && (
               <div className="flex items-center gap-2 text-[var(--color-text-tertiary)]">
-                <div className="w-4 h-4 border-2 border-[var(--color-text-tertiary)] border-t-transparent rounded-full animate-spin" />
+                <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
                 <span className="text-sm">Loading...</span>
               </div>
             )}
@@ -469,9 +457,7 @@ export function AtomViewer({ atom, onClose, onEdit, highlightText }: AtomViewerP
         {/* Source URL - always visible when present */}
         {atom.source_url && (
           <div className="flex items-center gap-2 text-sm mb-3">
-            <svg className="w-3.5 h-3.5 text-[var(--color-text-tertiary)] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-            </svg>
+            <Link2 className="w-3.5 h-3.5 text-[var(--color-text-tertiary)] shrink-0" strokeWidth={2} />
             {atom.source && (
               <span className="text-xs text-[var(--color-text-tertiary)] bg-[var(--color-bg-panel)] px-1.5 py-0.5 rounded shrink-0">
                 {atom.source}
@@ -518,14 +504,10 @@ export function AtomViewer({ atom, onClose, onEdit, highlightText }: AtomViewerP
               </>
             )}
           </div>
-          <svg
+          <ChevronDown
             className={`w-4 h-4 text-[var(--color-text-secondary)] transition-transform ml-2 flex-shrink-0 ${metadataExpanded ? 'rotate-180' : ''}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-          </svg>
+            strokeWidth={2}
+          />
         </button>
 
         {/* Expanded metadata */}

--- a/src/components/atoms/FilterBar.tsx
+++ b/src/components/atoms/FilterBar.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { Filter, X, ArrowDownUp } from 'lucide-react';
 import { useAtomsStore, SourceFilterType, SortField, SortOrder } from '../../stores/atoms';
 
 const SORT_OPTIONS: { field: SortField; order: SortOrder; label: string }[] = [
@@ -77,9 +78,7 @@ export function FilterBar() {
             onClick={() => { setShowSourceDropdown(!showSourceDropdown); setShowSortDropdown(false); }}
             className="flex items-center gap-1 text-xs px-2 py-1 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
           >
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-            </svg>
+            <Filter className="w-3.5 h-3.5" strokeWidth={2} />
             Filter
           </button>
 
@@ -139,9 +138,7 @@ export function FilterBar() {
             className="flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-[var(--color-accent)]/15 text-[var(--color-accent-light)] hover:bg-[var(--color-accent)]/25 transition-colors"
           >
             {sourceFilter === 'manual' ? 'Manual' : 'External'}
-            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-3 h-3" strokeWidth={2} />
           </button>
         )}
 
@@ -151,9 +148,7 @@ export function FilterBar() {
             className="flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-[var(--color-accent)]/15 text-[var(--color-accent-light)] hover:bg-[var(--color-accent)]/25 transition-colors truncate max-w-[200px]"
           >
             {sourceValue}
-            <svg className="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-3 h-3 shrink-0" strokeWidth={2} />
           </button>
         )}
 
@@ -174,9 +169,7 @@ export function FilterBar() {
           onClick={() => { setShowSortDropdown(!showSortDropdown); setShowSourceDropdown(false); }}
           className="flex items-center gap-1 text-xs px-2 py-1 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12" />
-          </svg>
+          <ArrowDownUp className="w-3.5 h-3.5" strokeWidth={2} />
           {currentSort.label}
         </button>
 

--- a/src/components/atoms/FilterSheet.tsx
+++ b/src/components/atoms/FilterSheet.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
+import { X, Check } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import { useAtomsStore, SourceFilterType, SortField, SortOrder } from '../../stores/atoms';
-import { useUIStore, ViewMode } from '../../stores/ui';
+import { useUIStore, ViewMode, AtomsLayout } from '../../stores/ui';
 
 interface FilterSheetProps {
   isOpen: boolean;
@@ -21,15 +22,22 @@ const SORT_OPTIONS: { field: SortField; order: SortOrder; label: string }[] = [
 ];
 
 const VIEW_MODES: { id: ViewMode; label: string }[] = [
-  { id: 'grid', label: 'Grid' },
-  { id: 'list', label: 'List' },
+  { id: 'dashboard', label: 'Dashboard' },
+  { id: 'atoms', label: 'Atoms' },
   { id: 'canvas', label: 'Canvas' },
   { id: 'wiki', label: 'Wiki' },
+];
+
+const ATOM_LAYOUTS: { id: AtomsLayout; label: string }[] = [
+  { id: 'grid', label: 'Grid' },
+  { id: 'list', label: 'List' },
 ];
 
 export function FilterSheet({ isOpen, onClose, displayCount }: FilterSheetProps) {
   const viewMode = useUIStore(s => s.viewMode);
   const setViewMode = useUIStore(s => s.setViewMode);
+  const atomsLayout = useUIStore(s => s.atomsLayout);
+  const setAtomsLayout = useUIStore(s => s.setAtomsLayout);
 
   const sourceFilter = useAtomsStore(s => s.sourceFilter);
   const sourceValue = useAtomsStore(s => s.sourceValue);
@@ -98,9 +106,7 @@ export function FilterSheet({ isOpen, onClose, displayCount }: FilterSheetProps)
             className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
             aria-label="Close"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
 
@@ -111,7 +117,7 @@ export function FilterSheet({ isOpen, onClose, displayCount }: FilterSheetProps)
             <h3 className="text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)] mb-2">
               View
             </h3>
-            <div className="grid grid-cols-4 gap-2">
+            <div className="grid grid-cols-2 gap-2">
               {VIEW_MODES.map(vm => (
                 <button
                   key={vm.id}
@@ -126,6 +132,29 @@ export function FilterSheet({ isOpen, onClose, displayCount }: FilterSheetProps)
                 </button>
               ))}
             </div>
+
+            {viewMode === 'atoms' && (
+              <div className="mt-3">
+                <h4 className="text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)] mb-2">
+                  Layout
+                </h4>
+                <div className="grid grid-cols-2 gap-2">
+                  {ATOM_LAYOUTS.map(l => (
+                    <button
+                      key={l.id}
+                      onClick={() => setAtomsLayout(l.id)}
+                      className={`py-2 px-3 rounded-md text-sm transition-colors border ${
+                        atomsLayout === l.id
+                          ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent-light)] border-[var(--color-accent)]/40'
+                          : 'bg-[var(--color-bg-card)] text-[var(--color-text-primary)] border-[var(--color-border)] hover:bg-[var(--color-bg-hover)]'
+                      }`}
+                    >
+                      {l.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
           </section>
 
           {/* Source filter */}
@@ -194,9 +223,7 @@ export function FilterSheet({ isOpen, onClose, displayCount }: FilterSheetProps)
                   >
                     <span>{opt.label}</span>
                     {isActive && (
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
+                      <Check className="w-4 h-4" strokeWidth={2} />
                     )}
                   </button>
                 );

--- a/src/components/atoms/RelatedAtoms.tsx
+++ b/src/components/atoms/RelatedAtoms.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { getTransport } from '../../lib/transport';
 import { SimilarAtomResult } from '../../stores/atoms';
 import { MiniGraphPreview } from '../canvas/MiniGraphPreview';
@@ -69,14 +70,10 @@ export function RelatedAtoms({ atomId, onAtomClick, onViewGraph }: RelatedAtomsP
             </span>
           )}
         </div>
-        <svg
+        <ChevronDown
           className={`w-4 h-4 transition-transform ${isCollapsed ? '' : 'rotate-180'}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
+          strokeWidth={2}
+        />
       </button>
 
       {!isCollapsed && (

--- a/src/components/canvas/AtomPreviewPopover.tsx
+++ b/src/components/canvas/AtomPreviewPopover.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, memo } from 'react';
+import { ArrowRight, Loader2 } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -139,10 +140,7 @@ export function AtomPreviewPopover({ atomId, anchorRect, onClose, onViewAtom }: 
       {isLoading ? (
         <div className="flex items-center justify-center py-8">
           <div className="flex items-center gap-2 text-[var(--color-text-secondary)]">
-            <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-            </svg>
+            <Loader2 className="animate-spin h-4 w-4" strokeWidth={2} />
             <span className="text-sm">Loading...</span>
           </div>
         </div>
@@ -197,9 +195,7 @@ export function AtomPreviewPopover({ atomId, anchorRect, onClose, onViewAtom }: 
               className="flex items-center gap-1 text-sm text-[var(--color-accent)] hover:text-[var(--color-accent-light)] transition-colors"
             >
               Open in reader
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
-              </svg>
+              <ArrowRight className="w-4 h-4" strokeWidth={2} />
             </button>
           </div>
         </>

--- a/src/components/canvas/CanvasControls.tsx
+++ b/src/components/canvas/CanvasControls.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Network, Plus, Minus, Maximize2 } from 'lucide-react';
 import { useControls } from 'react-zoom-pan-pinch';
 import { ConnectionOptions } from './CanvasView';
 
@@ -123,11 +124,7 @@ export function CanvasControls({ connectionOptions, onConnectionOptionsChange }:
           }`}
           title="Connection options"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <circle cx="6" cy="12" r="2" strokeWidth={2} />
-            <circle cx="18" cy="12" r="2" strokeWidth={2} />
-            <path strokeLinecap="round" strokeWidth={2} d="M8 12h8" />
-          </svg>
+          <Network className="w-4 h-4" strokeWidth={2} />
         </button>
 
         <div className="h-px bg-[var(--color-bg-hover)] my-1" />
@@ -137,27 +134,21 @@ export function CanvasControls({ connectionOptions, onConnectionOptionsChange }:
           className="w-8 h-8 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors flex items-center justify-center"
           title="Zoom in"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
+          <Plus className="w-4 h-4" strokeWidth={2} />
         </button>
         <button
           onClick={() => zoomOut()}
           className="w-8 h-8 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors flex items-center justify-center"
           title="Zoom out"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-          </svg>
+          <Minus className="w-4 h-4" strokeWidth={2} />
         </button>
         <button
           onClick={() => resetTransform()}
           className="w-8 h-8 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors flex items-center justify-center"
           title="Reset view"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
-          </svg>
+          <Maximize2 className="w-4 h-4" strokeWidth={2} />
         </button>
       </div>
     </>

--- a/src/components/canvas/CanvasView.tsx
+++ b/src/components/canvas/CanvasView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { Loader2 } from 'lucide-react';
 import { TransformWrapper, TransformComponent, useControls } from 'react-zoom-pan-pinch';
 import { AtomSummary } from '../../stores/atoms';
 import { CanvasContent } from './CanvasContent';
@@ -330,21 +331,7 @@ export function CanvasView({
     return (
       <div className="flex-1 flex items-center justify-center bg-[var(--color-bg-main)]">
         <div className="flex items-center gap-3 text-[var(--color-text-secondary)]">
-          <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
+          <Loader2 className="w-5 h-5 animate-spin" strokeWidth={2} />
           Loading canvas...
         </div>
       </div>
@@ -372,21 +359,7 @@ export function CanvasView({
       {/* Simulation loading overlay */}
       {isSimulating && (
         <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-md px-4 py-2 flex items-center gap-2">
-          <svg className="w-4 h-4 animate-spin text-[var(--color-text-secondary)]" fill="none" viewBox="0 0 24 24">
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
+          <Loader2 className="w-4 h-4 animate-spin text-[var(--color-text-secondary)]" strokeWidth={2} />
           <span className="text-sm text-[var(--color-text-secondary)]">Calculating positions...</span>
         </div>
       )}

--- a/src/components/canvas/HierarchicalCanvas.tsx
+++ b/src/components/canvas/HierarchicalCanvas.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback, useRef, useState, useMemo } from 'react';
+import { Loader2, Plus, Minus, RotateCcw } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 import { useUIStore } from '../../stores/ui';
@@ -184,10 +185,7 @@ export function HierarchicalCanvas() {
         {isLoading && (
           <div className="absolute inset-0 flex items-center justify-center z-10 bg-[var(--color-bg-main)]/50">
             <div className="flex items-center gap-2 text-[var(--color-text-secondary)]">
-              <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-              </svg>
+              <Loader2 className="animate-spin h-5 w-5" strokeWidth={2} />
               <span className="text-sm">Loading...</span>
             </div>
           </div>
@@ -303,10 +301,7 @@ export function HierarchicalCanvas() {
                         className="absolute pointer-events-none"
                         style={{ left: pos.x, top: pos.y, transform: 'translate(-50%, -50%)' }}
                       >
-                        <svg className="animate-spin h-4 w-4 text-[var(--color-accent)]" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                        </svg>
+                        <Loader2 className="animate-spin h-4 w-4 text-[var(--color-accent)]" strokeWidth={2} />
                       </div>
                     );
                   })()}
@@ -351,27 +346,21 @@ export function HierarchicalCanvas() {
                     className="w-8 h-8 rounded-md bg-[var(--color-bg-card)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] flex items-center justify-center transition-colors"
                     title="Zoom in"
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                    </svg>
+                    <Plus className="w-4 h-4" strokeWidth={2} />
                   </button>
                   <button
                     onClick={() => zoomOut()}
                     className="w-8 h-8 rounded-md bg-[var(--color-bg-card)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] flex items-center justify-center transition-colors"
                     title="Zoom out"
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M20 12H4" />
-                    </svg>
+                    <Minus className="w-4 h-4" strokeWidth={2} />
                   </button>
                   <button
                     onClick={() => resetTransform()}
                     className="w-8 h-8 rounded-md bg-[var(--color-bg-card)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] flex items-center justify-center transition-colors"
                     title="Reset view"
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                    </svg>
+                    <RotateCcw className="w-4 h-4" strokeWidth={2} />
                   </button>
                 </div>
               </>

--- a/src/components/canvas/LocalGraphView.tsx
+++ b/src/components/canvas/LocalGraphView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { Undo2, BookOpen } from 'lucide-react';
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 import * as d3 from 'd3-force';
 import { getAtomNeighborhood, type NeighborhoodGraph, type NeighborhoodAtom } from '../../lib/api';
@@ -152,9 +153,7 @@ export function LocalGraphView() {
               className="p-1.5 rounded hover:bg-[var(--color-bg-hover)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
               title="Previous node"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
-              </svg>
+              <Undo2 className="w-4 h-4" strokeWidth={2} />
             </button>
           )}
           <h2 className="text-[var(--color-text-primary)] font-medium">
@@ -170,9 +169,7 @@ export function LocalGraphView() {
               className="flex items-center gap-1.5 px-2.5 py-1 rounded text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
               title="Read this atom"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-              </svg>
+              <BookOpen className="w-4 h-4" strokeWidth={2} />
               Read
             </button>
           )}

--- a/src/components/canvas/SigmaCanvas.tsx
+++ b/src/components/canvas/SigmaCanvas.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { Loader2 } from 'lucide-react';
 import { useUIStore } from '../../stores/ui';
 import { useDatabasesStore } from '../../stores/databases';
 import { getGlobalCanvas, type GlobalCanvasData } from '../../lib/api';
@@ -20,7 +21,18 @@ function truncLabel(str: string, max: number): string {
   return str.length > max ? str.substring(0, max - 1) + '\u2026' : str;
 }
 
-export function SigmaCanvas() {
+export type SigmaCanvasMode = 'main' | 'preview';
+
+interface SigmaCanvasProps {
+  /** 'main' runs the full interactive canvas; 'preview' renders a static thumbnail
+   *  with no chrome, no mount animation, no pan/zoom, and no chat controller. */
+  mode?: SigmaCanvasMode;
+  /** Click handler for preview mode — fires on any click inside the container. */
+  onPreviewClick?: () => void;
+}
+
+export function SigmaCanvas({ mode = 'main', onPreviewClick }: SigmaCanvasProps = {}) {
+  const isPreview = mode === 'preview';
   const openReader = useUIStore(s => s.openReader);
   const selectedTagId = useUIStore(s => s.selectedTagId);
   const activeDbId = useDatabasesStore(s => s.activeId);
@@ -328,32 +340,43 @@ export function SigmaCanvas() {
     }
     sigma.setCustomBBox({ x: [xMin, xMax], y: [yMin, yMax] });
 
-    // Animate nodes outward from center + fade edges in
-    edgeAnimProgress.current = 0;
-    const animStart = performance.now();
+    // Animate nodes outward from center + fade edges in.
+    // Preview mode skips the animation and snaps to final state so the thumbnail
+    // shows the real layout immediately on mount.
     let cancelledAnim = false;
-    function animateTick(now: number) {
-      if (cancelledAnim) return;
-      const elapsed = now - animStart;
-
-      // Node positions: 0 → target over 2.5s, cubic ease-out
-      const nt = Math.min(1, elapsed / 2000);
-      const ne = 1 - (1 - nt) ** 3;
+    if (isPreview) {
       for (const [id, target] of Object.entries(targetPositions)) {
         if (!graph.hasNode(id)) continue;
-        graph.setNodeAttribute(id, 'x', target.x * ne);
-        graph.setNodeAttribute(id, 'y', target.y * ne);
+        graph.setNodeAttribute(id, 'x', target.x);
+        graph.setNodeAttribute(id, 'y', target.y);
       }
+      edgeAnimProgress.current = 1;
+    } else {
+      edgeAnimProgress.current = 0;
+      const animStart = performance.now();
+      function animateTick(now: number) {
+        if (cancelledAnim) return;
+        const elapsed = now - animStart;
 
-      // Edge fade: 0 → 1 over 3s, ease-in
-      const et = Math.min(1, elapsed / 2500);
-      edgeAnimProgress.current = et * et;
+        // Node positions: 0 → target over 2.5s, cubic ease-out
+        const nt = Math.min(1, elapsed / 2000);
+        const ne = 1 - (1 - nt) ** 3;
+        for (const [id, target] of Object.entries(targetPositions)) {
+          if (!graph.hasNode(id)) continue;
+          graph.setNodeAttribute(id, 'x', target.x * ne);
+          graph.setNodeAttribute(id, 'y', target.y * ne);
+        }
 
-      if (nt < 1 || et < 1) {
-        requestAnimationFrame(animateTick);
+        // Edge fade: 0 → 1 over 3s, ease-in
+        const et = Math.min(1, elapsed / 2500);
+        edgeAnimProgress.current = et * et;
+
+        if (nt < 1 || et < 1) {
+          requestAnimationFrame(animateTick);
+        }
       }
+      requestAnimationFrame(animateTick);
     }
-    requestAnimationFrame(animateTick);
     const cancelAnim = () => { cancelledAnim = true; };
 
     // Helper to show atom preview popover at a node's screen position
@@ -374,12 +397,10 @@ export function SigmaCanvas() {
       setPreviewAtomId(atomId);
     };
 
-    sigma.on('clickNode', ({ node }) => {
-      showAtomPreview(node);
-    });
-
-    // Register canvas controller for chat tools
-    // Sigma camera uses normalized [0,1] coords; convert graph coords through the BBox
+    // Build a controller both modes use. Main mode registers it in the global
+    // `controller` slot (driven by the chat agent). Preview mode registers it
+    // in the separate `previewController` slot so dashboard widgets can drive
+    // thumbnail focus without touching the chat agent's target.
     const bboxW = xMax - xMin || 1;
     const bboxH = yMax - yMin || 1;
     const graphToCamera = (gx: number, gy: number) => ({
@@ -387,9 +408,7 @@ export function SigmaCanvas() {
       y: (gy - yMin) / bboxH,
     });
 
-    const { registerController, setCanvasData } = useCanvasStore.getState();
-    setCanvasData(data);
-    registerController({
+    const controller = {
       zoomToCluster: (clusterLabel: string) => {
         const cluster = data.clusters.find(
           (c) => c.label.toLowerCase() === clusterLabel.toLowerCase()
@@ -414,20 +433,36 @@ export function SigmaCanvas() {
         const gy = graph.getNodeAttribute(atomId, 'y') as number;
         const cam = graphToCamera(gx, gy);
         sigma.getCamera().animate({ x: cam.x, y: cam.y, ratio: 0.15 }, { duration: 600 });
-        // Show preview after camera animation settles
-        setTimeout(() => showAtomPreview(atomId), 650);
+        // Main view shows the popover after the camera settles; preview stays quiet.
+        if (!isPreview) setTimeout(() => showAtomPreview(atomId), 650);
       },
-    });
+    };
+
+    if (isPreview) {
+      useCanvasStore.getState().registerPreviewController(controller);
+    } else {
+      sigma.on('clickNode', ({ node }) => {
+        showAtomPreview(node);
+      });
+      const { registerController, setCanvasData } = useCanvasStore.getState();
+      setCanvasData(data);
+      registerController(controller);
+    }
 
     return () => {
       cancelAnim();
-      useCanvasStore.getState().unregisterController();
+      const store = useCanvasStore.getState();
+      if (isPreview) {
+        store.unregisterPreviewController();
+      } else {
+        store.unregisterController();
+      }
       sigma.kill();
       labelCanvas.remove();
       sigmaRef.current = null;
       graphRef.current = null;
     };
-  }, [data]); // intentionally exclude theme — handled below
+  }, [data, isPreview]); // intentionally exclude theme — handled below
 
   // Update colors when theme changes (without recreating graph)
   useEffect(() => {
@@ -470,8 +505,10 @@ export function SigmaCanvas() {
     return () => cancelAnimationFrame(raf);
   }, [chatSidebarOpen]);
 
-  // Subscribe to canvas action events from the chat agent
+  // Subscribe to canvas action events from the chat agent.
+  // Preview instances don't own the controller and shouldn't react to chat actions.
   useEffect(() => {
+    if (isPreview) return;
     const transport = getTransport();
     const unsub = transport.subscribe<{ conversation_id: string; action: string; params: Record<string, string> }>(
       'chat-canvas-action',
@@ -486,7 +523,7 @@ export function SigmaCanvas() {
       }
     );
     return () => unsub();
-  }, []);
+  }, [isPreview]);
 
   // Animate edge threshold changes
   const thresholdAnimRef = useRef<number | null>(null);
@@ -521,16 +558,13 @@ export function SigmaCanvas() {
     <div className="flex flex-col h-full w-full">
       <div
         className="flex-1 relative overflow-hidden"
-        style={{ backgroundColor: theme.background }}
+        style={{ backgroundColor: isPreview ? 'var(--color-bg-main)' : theme.background }}
       >
         {isLoading && (
           <div className="absolute inset-0 flex items-center justify-center z-10">
             <div className="flex items-center gap-2 text-[var(--color-text-secondary)]">
-              <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-              </svg>
-              <span className="text-sm">Computing layout...</span>
+              <Loader2 className={`animate-spin ${isPreview ? 'h-4 w-4' : 'h-5 w-5'}`} strokeWidth={2} />
+              {!isPreview && <span className="text-sm">Computing layout...</span>}
             </div>
           </div>
         )}
@@ -538,8 +572,14 @@ export function SigmaCanvas() {
         {error && (
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="text-center text-[var(--color-text-secondary)]">
-              <p className="text-lg mb-2">Error loading canvas</p>
-              <p className="text-sm">{error}</p>
+              {isPreview ? (
+                <p className="text-xs">Canvas unavailable</p>
+              ) : (
+                <>
+                  <p className="text-lg mb-2">Error loading canvas</p>
+                  <p className="text-sm">{error}</p>
+                </>
+              )}
             </div>
           </div>
         )}
@@ -547,20 +587,36 @@ export function SigmaCanvas() {
         {!isLoading && data && data.atoms.length === 0 && (
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="text-center text-[var(--color-text-secondary)]">
-              <p className="text-lg mb-2">No atoms with embeddings</p>
-              <p className="text-sm">Create some atoms and wait for embeddings to generate</p>
+              {isPreview ? (
+                <p className="text-xs">No atoms with embeddings yet</p>
+              ) : (
+                <>
+                  <p className="text-lg mb-2">No atoms with embeddings</p>
+                  <p className="text-sm">Create some atoms and wait for embeddings to generate</p>
+                </>
+              )}
             </div>
           </div>
         )}
 
         <div
           ref={containerRef}
-          className="w-full h-full"
-          style={{ minHeight: 200 }}
+          className={`w-full h-full ${isPreview ? 'pointer-events-none' : ''}`}
+          style={isPreview ? undefined : { minHeight: 200 }}
         />
 
-        {/* Theme picker + edge slider */}
-        {!isLoading && data && data.atoms.length > 0 && (
+        {/* Click-through overlay in preview mode — whole widget navigates to the main canvas */}
+        {isPreview && (
+          <button
+            type="button"
+            onClick={onPreviewClick}
+            className="absolute inset-0 z-20 cursor-pointer bg-transparent hover:bg-white/[0.03] transition-colors"
+            aria-label="Open canvas view"
+          />
+        )}
+
+        {/* Theme picker + edge slider — main view only */}
+        {!isPreview && !isLoading && data && data.atoms.length > 0 && (
           <div className="absolute bottom-4 left-4 z-20 flex flex-col gap-2">
             <div className="flex items-center gap-1.5">
               <button
@@ -608,8 +664,8 @@ export function SigmaCanvas() {
           </div>
         )}
 
-        {/* Atom preview popover */}
-        {previewAtomId && previewAnchorRect && (
+        {/* Atom preview popover — main view only */}
+        {!isPreview && previewAtomId && previewAnchorRect && (
           <AtomPreviewPopover
             atomId={previewAtomId}
             anchorRect={previewAnchorRect}

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { ChevronLeft } from 'lucide-react';
 import { ConversationWithTags, useChatStore } from '../../stores/chat';
 import { ScopeEditor } from './ScopeEditor';
 
@@ -37,9 +38,7 @@ export function ChatHeader({ conversation, onBack }: ChatHeaderProps) {
           className="p-1.5 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
           aria-label="Back to conversations"
         >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-          </svg>
+          <ChevronLeft className="w-5 h-5" strokeWidth={2} />
         </button>
 
         {isEditingTitle ? (

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { MessageSquare } from 'lucide-react';
 import { useChatStore } from '../../stores/chat';
 import { useUIStore } from '../../stores/ui';
 import { useChatEvents } from '../../hooks/useChatEvents';
@@ -145,9 +146,7 @@ export function ChatView() {
         {messages.length === 0 && !isStreaming && (
           <div className="flex flex-col items-center justify-center h-full gap-4 text-center">
             <div className="w-16 h-16 rounded-full bg-[var(--color-bg-card)] flex items-center justify-center">
-              <svg className="w-8 h-8 text-[var(--color-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-              </svg>
+              <MessageSquare className="w-8 h-8 text-[var(--color-accent)]" strokeWidth={2} />
             </div>
             <div>
               <p className="text-[var(--color-text-primary)] font-medium mb-1">Start the conversation</p>

--- a/src/components/chat/ChatViewer.tsx
+++ b/src/components/chat/ChatViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
 import { useChatStore } from '../../stores/chat';
 import { useUIStore } from '../../stores/ui';
 import { useDatabasesStore } from '../../stores/databases';
@@ -49,19 +50,7 @@ export function ChatViewer() {
           className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           aria-label="Close"
         >
-          <svg
-            className="w-5 h-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
+          <X className="w-5 h-5" strokeWidth={2} />
         </button>
       </div>
 

--- a/src/components/chat/ConversationCard.tsx
+++ b/src/components/chat/ConversationCard.tsx
@@ -1,3 +1,4 @@
+import { Trash2 } from 'lucide-react';
 import { ConversationWithTags } from '../../stores/chat';
 import { formatRelativeDate } from '../../lib/date';
 
@@ -63,9 +64,7 @@ export function ConversationCard({ conversation, onClick, onDelete }: Conversati
           className="p-1.5 text-[var(--color-text-tertiary)] hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
           aria-label="Delete conversation"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-          </svg>
+          <Trash2 className="w-4 h-4" strokeWidth={2} />
         </button>
       </div>
     </div>

--- a/src/components/chat/ConversationsList.tsx
+++ b/src/components/chat/ConversationsList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Plus, MessageCircle } from 'lucide-react';
 import { useChatStore, ConversationWithTags } from '../../stores/chat';
 import { ConversationCard } from './ConversationCard';
 import { Modal } from '../ui/Modal';
@@ -72,9 +73,7 @@ export function ConversationsList() {
           onClick={handleNewChat}
           className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-[var(--color-bg-hover)] hover:bg-[var(--color-border)] text-[var(--color-text-primary)] rounded-lg transition-colors"
         >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
+          <Plus className="w-5 h-5" strokeWidth={2} />
           New Conversation
         </button>
       </div>
@@ -84,9 +83,7 @@ export function ConversationsList() {
         {conversations.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full gap-4 p-8 text-center">
             <div className="w-16 h-16 rounded-full bg-[var(--color-bg-card)] flex items-center justify-center">
-              <svg className="w-8 h-8 text-[var(--color-text-secondary)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-              </svg>
+              <MessageCircle className="w-8 h-8 text-[var(--color-text-secondary)]" strokeWidth={2} />
             </div>
             <div>
               <p className="text-[var(--color-text-primary)] font-medium mb-1">No conversations yet</p>

--- a/src/components/chat/ScopeEditor.tsx
+++ b/src/components/chat/ScopeEditor.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
+import { X, Plus } from 'lucide-react';
 import { ConversationWithTags, useChatStore } from '../../stores/chat';
 import { useTagsStore } from '../../stores/tags';
 
@@ -187,9 +188,7 @@ export function ScopeEditor({ conversation }: ScopeEditorProps) {
               className="opacity-0 group-hover:opacity-100 hover:text-red-400 transition-all"
               aria-label={`Remove ${tag.name} from scope`}
             >
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              <X className="w-3 h-3" strokeWidth={2} />
             </button>
           </span>
         ))
@@ -238,9 +237,7 @@ export function ScopeEditor({ conversation }: ScopeEditorProps) {
           onClick={() => setIsAdding(true)}
           className="inline-flex items-center gap-1 px-2 py-0.5 text-sm rounded border border-dashed border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent-light)] transition-colors"
         >
-          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
+          <Plus className="w-3 h-3" strokeWidth={2} />
           Add tag
         </button>
       )}

--- a/src/components/command-palette/CommandInput.tsx
+++ b/src/components/command-palette/CommandInput.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect } from 'react';
+import { Search, Tag, FileText, Loader2 } from 'lucide-react';
 import { PaletteMode } from './types';
 
 interface CommandInputProps {
@@ -12,27 +13,15 @@ interface CommandInputProps {
 const modeConfig: Record<PaletteMode, { placeholder: string; icon: React.ReactNode }> = {
   commands: {
     placeholder: 'Type a command or search...',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-      </svg>
-    ),
+    icon: <Search className="w-5 h-5" strokeWidth={2} />,
   },
   search: {
     placeholder: 'Search atoms...',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-      </svg>
-    ),
+    icon: <FileText className="w-5 h-5" strokeWidth={2} />,
   },
   tags: {
     placeholder: 'Filter by tag...',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-      </svg>
-    ),
+    icon: <Tag className="w-5 h-5" strokeWidth={2} />,
   },
 };
 
@@ -55,21 +44,7 @@ export function CommandInput({
     <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--color-border)]">
       <div className="text-[var(--color-text-secondary)]">
         {isSearching ? (
-          <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
+          <Loader2 className="w-5 h-5 animate-spin" strokeWidth={2} />
         ) : (
           config.icon
         )}

--- a/src/components/command-palette/SearchResults.tsx
+++ b/src/components/command-palette/SearchResults.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useRef } from 'react';
+import { Loader2 } from 'lucide-react';
 import { SemanticSearchResult } from './types';
 
 interface SearchResultsProps {
@@ -30,21 +31,7 @@ export const SearchResults = memo(function SearchResults({
     return (
       <div className="px-4 py-8 text-center text-[var(--color-text-tertiary)] text-sm">
         <span className="inline-flex items-center gap-2">
-          <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
+          <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
           Searching...
         </span>
       </div>

--- a/src/components/command-palette/TagResults.tsx
+++ b/src/components/command-palette/TagResults.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useRef } from 'react';
+import { Tag } from 'lucide-react';
 import { TagWithCount } from './types';
 
 interface TagResultsProps {
@@ -110,19 +111,7 @@ const TagResultItem = memo(function TagResultItem({
         }
       `}
     >
-      <svg
-        className="w-4 h-4 text-[var(--color-text-secondary)] flex-shrink-0"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
-        />
-      </svg>
+      <Tag className="w-4 h-4 text-[var(--color-text-secondary)] flex-shrink-0" strokeWidth={2} />
 
       <span className="flex-1 text-sm text-[var(--color-text-primary)]">
         {highlightedName.map((part, i) => (

--- a/src/components/command-palette/commands.tsx
+++ b/src/components/command-palette/commands.tsx
@@ -1,76 +1,22 @@
+import { Plus, Search, Tag, BookOpen, MessageCircle, LayoutGrid, List as ListIcon, Settings, RefreshCw, GitMerge, X } from 'lucide-react';
 import { getTransport } from '../../lib/transport';
 import { Command, CommandCategory } from './types';
 import { useAtomsStore } from '../../stores/atoms';
 import { useUIStore } from '../../stores/ui';
 import { useTagsStore } from '../../stores/tags';
 
-// Icon components as simple SVG functions
-const PlusIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-  </svg>
-);
-
-const SearchIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-  </svg>
-);
-
-const TagIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-  </svg>
-);
-
-const BookOpenIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-  </svg>
-);
-
-const MessageCircleIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-  </svg>
-);
-
-const LayoutGridIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-  </svg>
-);
-
-const ListIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
-  </svg>
-);
-
-const SettingsIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-  </svg>
-);
-
-const RefreshIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-  </svg>
-);
-
-const MergeIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
-  </svg>
-);
-
-const XIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-  </svg>
-);
+// Icon components as simple wrappers
+const PlusIcon = () => <Plus className="w-4 h-4" strokeWidth={2} />;
+const SearchIcon = () => <Search className="w-4 h-4" strokeWidth={2} />;
+const TagIcon = () => <Tag className="w-4 h-4" strokeWidth={2} />;
+const BookOpenIcon = () => <BookOpen className="w-4 h-4" strokeWidth={2} />;
+const MessageCircleIcon = () => <MessageCircle className="w-4 h-4" strokeWidth={2} />;
+const LayoutGridIcon = () => <LayoutGrid className="w-4 h-4" strokeWidth={2} />;
+const ListIconWrapper = () => <ListIcon className="w-4 h-4" strokeWidth={2} />;
+const SettingsIcon = () => <Settings className="w-4 h-4" strokeWidth={2} />;
+const RefreshIcon = () => <RefreshCw className="w-4 h-4" strokeWidth={2} />;
+const MergeIcon = () => <GitMerge className="w-4 h-4" strokeWidth={2} />;
+const XIcon = () => <X className="w-4 h-4" strokeWidth={2} />;
 
 // Command definitions
 export const commands: Command[] = [
@@ -101,21 +47,35 @@ export const commands: Command[] = [
   },
   {
     id: 'switch-to-grid',
-    label: 'Switch to grid view',
+    label: 'Switch to grid layout',
     category: 'navigation',
-    keywords: ['view', 'grid', 'cards', 'tiles'],
+    keywords: ['view', 'grid', 'cards', 'tiles', 'atoms'],
     icon: LayoutGridIcon,
-    action: () => useUIStore.getState().setViewMode('grid'),
-    isEnabled: () => useUIStore.getState().viewMode !== 'grid',
+    action: () => {
+      const ui = useUIStore.getState();
+      ui.setViewMode('atoms');
+      ui.setAtomsLayout('grid');
+    },
+    isEnabled: () => {
+      const ui = useUIStore.getState();
+      return ui.viewMode !== 'atoms' || ui.atomsLayout !== 'grid';
+    },
   },
   {
     id: 'switch-to-list',
-    label: 'Switch to list view',
+    label: 'Switch to list layout',
     category: 'navigation',
-    keywords: ['view', 'list', 'rows', 'compact'],
-    icon: ListIcon,
-    action: () => useUIStore.getState().setViewMode('list'),
-    isEnabled: () => useUIStore.getState().viewMode !== 'list',
+    keywords: ['view', 'list', 'rows', 'compact', 'atoms'],
+    icon: ListIconWrapper,
+    action: () => {
+      const ui = useUIStore.getState();
+      ui.setViewMode('atoms');
+      ui.setAtomsLayout('list');
+    },
+    isEnabled: () => {
+      const ui = useUIStore.getState();
+      return ui.viewMode !== 'atoms' || ui.atomsLayout !== 'list';
+    },
   },
   {
     id: 'open-settings',

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { dashboardWidgets } from './registry';
+import { useWikiStore } from '../../stores/wiki';
+
+export function DashboardView() {
+  const fetchAllArticles = useWikiStore(s => s.fetchAllArticles);
+
+  useEffect(() => {
+    // Kick off wiki data on dashboard mount. The call is idempotent — safe to
+    // fire every time the user lands on the dashboard so widgets stay fresh.
+    fetchAllArticles();
+  }, [fetchAllArticles]);
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto max-w-4xl px-6 pt-10 pb-16 md:px-10 md:pt-14 md:pb-20">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-10 md:gap-y-12">
+          {dashboardWidgets.map(({ id, span, Component }) => (
+            <div key={id} className={span === 'full' ? 'md:col-span-2' : ''}>
+              <Component />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/Section.tsx
+++ b/src/components/dashboard/Section.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+interface SectionProps {
+  label: string;
+  action?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function Section({ label, action, children, className = '' }: SectionProps) {
+  return (
+    <section className={className}>
+      <header className="flex items-center gap-3 mb-3 h-5">
+        <h3 className="text-[11px] leading-none font-medium uppercase tracking-[0.14em] text-[var(--color-text-tertiary)] whitespace-nowrap">
+          {label}
+        </h3>
+        <div className="flex-1 h-px bg-[var(--color-border)]" />
+        {action && <div className="shrink-0 leading-none">{action}</div>}
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/src/components/dashboard/registry.ts
+++ b/src/components/dashboard/registry.ts
@@ -1,0 +1,20 @@
+import type { FC } from 'react';
+import { BriefingWidget } from './widgets/BriefingWidget';
+import { ActivityWidget } from './widgets/ActivityWidget';
+import { NewWikisWidget } from './widgets/NewWikisWidget';
+import { RevisionsWidget } from './widgets/RevisionsWidget';
+
+export type WidgetSpan = 'full' | 'half';
+
+export interface DashboardWidget {
+  id: string;
+  span: WidgetSpan;
+  Component: FC;
+}
+
+export const dashboardWidgets: DashboardWidget[] = [
+  { id: 'briefing', span: 'full', Component: BriefingWidget },
+  { id: 'activity', span: 'half', Component: ActivityWidget },
+  { id: 'new-wikis', span: 'half', Component: NewWikisWidget },
+  { id: 'revisions', span: 'full', Component: RevisionsWidget },
+];

--- a/src/components/dashboard/widgets/ActivityWidget.tsx
+++ b/src/components/dashboard/widgets/ActivityWidget.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from 'react';
+import { Section } from '../Section';
+import { useAtomsStore } from '../../../stores/atoms';
+import { useWikiStore } from '../../../stores/wiki';
+import { useUIStore } from '../../../stores/ui';
+import { formatShortRelativeDate } from '../../../lib/date';
+
+type FeedItem =
+  | { kind: 'atom'; id: string; title: string; timestamp: string }
+  | { kind: 'wiki'; id: string; tagId: string; title: string; timestamp: string };
+
+const MAX_ITEMS = 8;
+
+export function ActivityWidget() {
+  const atoms = useAtomsStore(s => s.atoms);
+  const articles = useWikiStore(s => s.articles);
+  const openReader = useUIStore(s => s.openReader);
+  const openWikiReader = useUIStore(s => s.openWikiReader);
+
+  const items = useMemo<FeedItem[]>(() => {
+    const atomItems: FeedItem[] = atoms.slice(0, MAX_ITEMS * 2).map(a => ({
+      kind: 'atom',
+      id: a.id,
+      title: a.title || 'Untitled atom',
+      timestamp: a.updated_at,
+    }));
+    const wikiItems: FeedItem[] = articles.slice(0, MAX_ITEMS).map(w => ({
+      kind: 'wiki',
+      id: w.id,
+      tagId: w.tag_id,
+      title: w.tag_name,
+      timestamp: w.updated_at,
+    }));
+    return [...atomItems, ...wikiItems]
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      .slice(0, MAX_ITEMS);
+  }, [atoms, articles]);
+
+  return (
+    <Section label="Recent activity">
+      {items.length === 0 ? (
+        <EmptyState>Activity will appear here as atoms and wikis land.</EmptyState>
+      ) : (
+        <ul className="-mx-2">
+          {items.map(item => (
+            <li key={`${item.kind}-${item.id}`}>
+              <button
+                onClick={() =>
+                  item.kind === 'atom'
+                    ? openReader(item.id)
+                    : openWikiReader(item.tagId, item.title)
+                }
+                className="w-full flex items-baseline gap-3 px-2 py-1.5 rounded hover:bg-[var(--color-bg-hover)]/60 text-left group"
+              >
+                <span className="text-[11px] uppercase tracking-wider text-[var(--color-text-tertiary)] w-10 shrink-0">
+                  {item.kind === 'atom' ? 'atom' : 'wiki'}
+                </span>
+                <span className="flex-1 min-w-0 truncate text-sm text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]">
+                  {item.title}
+                </span>
+                <span className="text-[11px] text-[var(--color-text-tertiary)] tabular-nums shrink-0">
+                  {formatShortRelativeDate(item.timestamp)}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function EmptyState({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="py-6 text-sm text-[var(--color-text-tertiary)]">
+      {children}
+    </div>
+  );
+}

--- a/src/components/dashboard/widgets/BriefingContent.tsx
+++ b/src/components/dashboard/widgets/BriefingContent.tsx
@@ -1,0 +1,65 @@
+import { Fragment, type ReactNode } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { CitationLink } from '../../wiki/CitationLink';
+import type { BriefingCitation } from '../../../stores/briefing';
+
+interface BriefingContentProps {
+  content: string;
+  citations: BriefingCitation[];
+  onCitationClick: (citation: BriefingCitation, element: HTMLElement) => void;
+}
+
+/**
+ * Renders briefing markdown with inline `[N]` citation markers replaced by
+ * clickable CitationLink buttons. Intentionally simpler than WikiArticleContent:
+ * no wiki-links, no search highlighting, no related tags.
+ */
+export function BriefingContent({ content, citations, onCitationClick }: BriefingContentProps) {
+  const citationMap = new Map(citations.map(c => [c.citation_index, c]));
+
+  const processTextWithCitations = (text: string): (string | JSX.Element)[] => {
+    const parts = text.split(/(\[\d+\])/g);
+    return parts.map((part, i) => {
+      const match = part.match(/^\[(\d+)\]$/);
+      if (!match) return part;
+      const index = parseInt(match[1], 10);
+      const citation = citationMap.get(index);
+      if (!citation) return part;
+      return (
+        <CitationLink
+          key={`c-${i}-${index}`}
+          index={index}
+          onClick={(e) => onCitationClick(citation, e.currentTarget)}
+        />
+      );
+    });
+  };
+
+  const processChildren = (children: ReactNode): ReactNode => {
+    if (typeof children === 'string') {
+      return processTextWithCitations(children).map((part, i) =>
+        typeof part === 'string' ? <Fragment key={`t-${i}`}>{part}</Fragment> : part
+      );
+    }
+    if (Array.isArray(children)) {
+      return children.map((child, i) => <Fragment key={i}>{processChildren(child)}</Fragment>);
+    }
+    return children;
+  };
+
+  const components = {
+    p: ({ children }: { children?: ReactNode }) => <p>{processChildren(children)}</p>,
+    li: ({ children }: { children?: ReactNode }) => <li>{processChildren(children)}</li>,
+    strong: ({ children }: { children?: ReactNode }) => <strong>{processChildren(children)}</strong>,
+    em: ({ children }: { children?: ReactNode }) => <em>{processChildren(children)}</em>,
+  };
+
+  return (
+    <div className="prose prose-invert prose-sm md:prose-base max-w-none text-[var(--color-text-secondary)] [&_p]:leading-relaxed [&_p]:my-3 first:[&_p]:mt-0 last:[&_p]:mb-0">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/src/components/dashboard/widgets/BriefingWidget.tsx
+++ b/src/components/dashboard/widgets/BriefingWidget.tsx
@@ -108,7 +108,7 @@ export function BriefingWidget() {
 
   const hasBriefing = latest !== null;
   const eyebrowLabel = hasBriefing
-    ? `TODAY'S BRIEFING · ${formatRelativeDate(latest!.briefing.last_run_at).toUpperCase()}`
+    ? `TODAY'S BRIEFING · ${formatRelativeDate(latest!.briefing.created_at).toUpperCase()}`
     : formatToday(now);
 
   return (

--- a/src/components/dashboard/widgets/BriefingWidget.tsx
+++ b/src/components/dashboard/widgets/BriefingWidget.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ChevronRight, RefreshCw } from 'lucide-react';
+import { ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
 import { SigmaCanvas } from '../../canvas/SigmaCanvas';
 import { CitationPopover } from '../../wiki/CitationPopover';
 import { BriefingContent } from './BriefingContent';
@@ -38,9 +38,13 @@ export function BriefingWidget() {
   const setViewMode = useUIStore(s => s.setViewMode);
   const isMobile = useIsMobile();
 
-  const latest = useBriefingStore(s => s.latest);
+  const active = useBriefingStore(s => s.active);
+  const history = useBriefingStore(s => s.history);
+  const activeIndex = useBriefingStore(s => s.activeIndex);
+  const isLoading = useBriefingStore(s => s.isLoading);
   const isRunning = useBriefingStore(s => s.isRunning);
   const fetchLatest = useBriefingStore(s => s.fetchLatest);
+  const navigate = useBriefingStore(s => s.navigate);
   const runNow = useBriefingStore(s => s.runNow);
 
   // Load on mount and re-fetch whenever the backend emits briefing-ready.
@@ -106,14 +110,36 @@ export function BriefingWidget() {
 
   // ===== Render =====
 
-  const hasBriefing = latest !== null;
+  const hasBriefing = active !== null;
+  const canGoNewer = activeIndex > 0;
+  const canGoOlder = activeIndex < history.length - 1;
   const eyebrowLabel = hasBriefing
-    ? `TODAY'S BRIEFING · ${formatRelativeDate(latest!.briefing.created_at).toUpperCase()}`
+    ? `BRIEFING · ${formatRelativeDate(active!.briefing.created_at).toUpperCase()}`
     : formatToday(now);
 
   return (
     <div className="pb-2">
-      <div className="flex items-center gap-3 mb-3">
+      <div className="flex items-center gap-2 mb-3">
+        {hasBriefing && (
+          <>
+            <button
+              onClick={() => navigate(1)}
+              disabled={!canGoOlder || isLoading}
+              title="Older briefing"
+              className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="w-4 h-4" strokeWidth={2} />
+            </button>
+            <button
+              onClick={() => navigate(-1)}
+              disabled={!canGoNewer || isLoading}
+              title="Newer briefing"
+              className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="w-4 h-4" strokeWidth={2} />
+            </button>
+          </>
+        )}
         <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--color-text-tertiary)]">
           {eyebrowLabel}
         </div>
@@ -121,7 +147,7 @@ export function BriefingWidget() {
           onClick={() => runNow()}
           disabled={isRunning}
           title="Regenerate briefing now"
-          className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors disabled:opacity-50 disabled:cursor-wait"
+          className="ml-1 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors disabled:opacity-50 disabled:cursor-wait"
         >
           <RefreshCw className={`w-3 h-3 ${isRunning ? 'animate-spin' : ''}`} strokeWidth={2} />
         </button>
@@ -149,8 +175,8 @@ export function BriefingWidget() {
 
       {hasBriefing ? (
         <BriefingContent
-          content={latest!.briefing.content}
-          citations={latest!.citations}
+          content={active!.briefing.content}
+          citations={active!.citations}
           onCitationClick={handleCitationClick}
         />
       ) : (
@@ -180,7 +206,7 @@ export function BriefingWidget() {
 
       {hasBriefing && (
         <div className="mt-4 text-[12px] text-[var(--color-text-tertiary)]">
-          Covers {latest!.briefing.atom_count} new atom{latest!.briefing.atom_count === 1 ? '' : 's'}
+          Covers {active!.briefing.atom_count} new atom{active!.briefing.atom_count === 1 ? '' : 's'}
         </div>
       )}
 

--- a/src/components/dashboard/widgets/BriefingWidget.tsx
+++ b/src/components/dashboard/widgets/BriefingWidget.tsx
@@ -78,8 +78,8 @@ export function BriefingWidget() {
   // ===== Fallback stub used when no briefing exists yet =====
 
   const stats = useMemo(() => {
-    const newAtoms24h = atoms.filter(a => withinHours(a.updated_at, 24)).length;
-    const newAtoms7d = atoms.filter(a => withinHours(a.updated_at, 24 * 7)).length;
+    const newAtoms24h = atoms.filter(a => withinHours(a.created_at, 24)).length;
+    const newAtoms7d = atoms.filter(a => withinHours(a.created_at, 24 * 7)).length;
     const latestAtom = atoms[0] ?? null;
     return { newAtoms24h, newAtoms7d, latestAtom, wikiCount: articles.length };
   }, [atoms, articles]);

--- a/src/components/dashboard/widgets/BriefingWidget.tsx
+++ b/src/components/dashboard/widgets/BriefingWidget.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronRight, RefreshCw } from 'lucide-react';
+import { SigmaCanvas } from '../../canvas/SigmaCanvas';
+import { CitationPopover } from '../../wiki/CitationPopover';
+import { BriefingContent } from './BriefingContent';
+import { useIsMobile } from '../../../hooks';
+import { useAtomsStore } from '../../../stores/atoms';
+import { useWikiStore } from '../../../stores/wiki';
+import { useUIStore } from '../../../stores/ui';
+import { useCanvasStore } from '../../../stores/canvas';
+import { useBriefingStore, type BriefingCitation } from '../../../stores/briefing';
+import { getTransport } from '../../../lib/transport';
+import { formatRelativeDate } from '../../../lib/date';
+
+function greeting(date: Date): string {
+  const h = date.getHours();
+  if (h < 5) return 'Working late';
+  if (h < 12) return 'Good morning';
+  if (h < 18) return 'Good afternoon';
+  return 'Good evening';
+}
+
+function withinHours(iso: string, hours: number): boolean {
+  return Date.now() - new Date(iso).getTime() < hours * 60 * 60 * 1000;
+}
+
+function formatToday(date: Date): string {
+  return date
+    .toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' })
+    .toUpperCase();
+}
+
+export function BriefingWidget() {
+  const atoms = useAtomsStore(s => s.atoms);
+  const suggestedArticles = useWikiStore(s => s.suggestedArticles);
+  const articles = useWikiStore(s => s.articles);
+  const openReader = useUIStore(s => s.openReader);
+  const setViewMode = useUIStore(s => s.setViewMode);
+  const isMobile = useIsMobile();
+
+  const latest = useBriefingStore(s => s.latest);
+  const isRunning = useBriefingStore(s => s.isRunning);
+  const fetchLatest = useBriefingStore(s => s.fetchLatest);
+  const runNow = useBriefingStore(s => s.runNow);
+
+  // Load on mount and re-fetch whenever the backend emits briefing-ready.
+  useEffect(() => {
+    fetchLatest();
+    const unsub = getTransport().subscribe('briefing-ready', () => {
+      fetchLatest();
+    });
+    return () => unsub();
+  }, [fetchLatest]);
+
+  const handleOpenCanvas = () => setViewMode('canvas');
+
+  // Citation popover state
+  const [activeCitation, setActiveCitation] = useState<BriefingCitation | null>(null);
+  const [anchorRect, setAnchorRect] = useState<{ top: number; left: number; bottom: number; width: number } | null>(null);
+
+  const handleCitationClick = (citation: BriefingCitation, element: HTMLElement) => {
+    // Drive the preview canvas (the Sigma instance rendered inside this widget)
+    // to zoom to the referenced atom. No-op if the preview controller hasn't
+    // registered yet (still loading).
+    useCanvasStore.getState().previewController?.focusAtom(citation.atom_id);
+
+    // Open the popover anchored to the clicked citation
+    const rect = element.getBoundingClientRect();
+    setActiveCitation(citation);
+    setAnchorRect({ top: rect.top, left: rect.left, bottom: rect.bottom, width: rect.width });
+  };
+
+  const closePopover = () => {
+    setActiveCitation(null);
+    setAnchorRect(null);
+  };
+
+  // ===== Fallback stub used when no briefing exists yet =====
+
+  const stats = useMemo(() => {
+    const newAtoms24h = atoms.filter(a => withinHours(a.updated_at, 24)).length;
+    const newAtoms7d = atoms.filter(a => withinHours(a.updated_at, 24 * 7)).length;
+    const latestAtom = atoms[0] ?? null;
+    return { newAtoms24h, newAtoms7d, latestAtom, wikiCount: articles.length };
+  }, [atoms, articles]);
+
+  const now = new Date();
+  const hello = greeting(now);
+
+  const fallbackSummary = useMemo(() => {
+    if (stats.newAtoms24h > 0) {
+      return `You captured ${stats.newAtoms24h} new atom${stats.newAtoms24h === 1 ? '' : 's'} in the last 24 hours. Your first briefing will generate automatically.`;
+    }
+    if (stats.newAtoms7d > 0) {
+      return `Quiet day. ${stats.newAtoms7d} atom${stats.newAtoms7d === 1 ? '' : 's'} added this week.`;
+    }
+    return 'Your knowledge base is quiet. Add an atom to get the flywheel turning.';
+  }, [stats]);
+
+  const chips: string[] = [
+    `${stats.newAtoms24h} new today`,
+    `${stats.newAtoms7d} this week`,
+    `${stats.wikiCount} wiki${stats.wikiCount === 1 ? '' : 's'}`,
+    `${suggestedArticles.length} suggested`,
+  ];
+
+  // ===== Render =====
+
+  const hasBriefing = latest !== null;
+  const eyebrowLabel = hasBriefing
+    ? `TODAY'S BRIEFING · ${formatRelativeDate(latest!.briefing.last_run_at).toUpperCase()}`
+    : formatToday(now);
+
+  return (
+    <div className="pb-2">
+      <div className="flex items-center gap-3 mb-3">
+        <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--color-text-tertiary)]">
+          {eyebrowLabel}
+        </div>
+        <button
+          onClick={() => runNow()}
+          disabled={isRunning}
+          title="Regenerate briefing now"
+          className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors disabled:opacity-50 disabled:cursor-wait"
+        >
+          <RefreshCw className={`w-3 h-3 ${isRunning ? 'animate-spin' : ''}`} strokeWidth={2} />
+        </button>
+      </div>
+
+      {/* Desktop: canvas floats right so the briefing copy wraps alongside it.
+          Rendered only on desktop to avoid mounting Sigma twice. */}
+      {!isMobile && (
+        <div className="float-right ml-8 mb-2 w-80 aspect-[4/3]">
+          <SigmaCanvas mode="preview" onPreviewClick={handleOpenCanvas} />
+        </div>
+      )}
+
+      <h1 className="text-3xl md:text-4xl font-semibold text-[var(--color-text-primary)] tracking-tight mb-4">
+        {hasBriefing ? `${hello}.` : `${hello}.`}
+      </h1>
+
+      {/* Mobile: canvas stacks full-width between title and content so it
+          never appears above the title. */}
+      {isMobile && (
+        <div className="my-4 w-full aspect-[16/10]">
+          <SigmaCanvas mode="preview" onPreviewClick={handleOpenCanvas} />
+        </div>
+      )}
+
+      {hasBriefing ? (
+        <BriefingContent
+          content={latest!.briefing.content}
+          citations={latest!.citations}
+          onCitationClick={handleCitationClick}
+        />
+      ) : (
+        <p className="text-base md:text-lg text-[var(--color-text-secondary)] leading-relaxed">
+          {fallbackSummary}
+        </p>
+      )}
+
+      {!hasBriefing && (
+        <div className="mt-5 text-[13px] text-[var(--color-text-tertiary)] tabular-nums">
+          {chips.join('  ·  ')}
+        </div>
+      )}
+
+      {!hasBriefing && stats.latestAtom && (
+        <button
+          onClick={() => openReader(stats.latestAtom!.id)}
+          className="mt-4 inline-flex items-center gap-2 text-[13px] text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors group"
+        >
+          <span className="text-[var(--color-text-tertiary)]">Most recent</span>
+          <span className="text-[var(--color-text-secondary)] group-hover:text-[var(--color-accent-light)] truncate max-w-[16rem] md:max-w-sm">
+            {stats.latestAtom.title || 'Untitled'}
+          </span>
+          <ChevronRight className="w-3 h-3 opacity-60 group-hover:opacity-100 transition-opacity" strokeWidth={2} />
+        </button>
+      )}
+
+      {hasBriefing && (
+        <div className="mt-4 text-[12px] text-[var(--color-text-tertiary)]">
+          Covers {latest!.briefing.atom_count} new atom{latest!.briefing.atom_count === 1 ? '' : 's'}
+        </div>
+      )}
+
+      {/* Clear the float so any following sibling (layout-level gap) doesn't collide */}
+      <div className="md:clear-right" />
+
+      {/* Citation popover — shared with wiki, tolerates the BriefingCitation shape
+          because CitationForPopover only requires {citation_index, atom_id, excerpt}. */}
+      {activeCitation && anchorRect && (
+        <CitationPopover
+          citation={activeCitation}
+          anchorRect={anchorRect}
+          onClose={closePopover}
+          onViewAtom={(atomId) => {
+            closePopover();
+            openReader(atomId);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/widgets/NewWikisWidget.tsx
+++ b/src/components/dashboard/widgets/NewWikisWidget.tsx
@@ -1,0 +1,39 @@
+import { Section } from '../Section';
+import { useWikiStore } from '../../../stores/wiki';
+
+const MAX_ITEMS = 5;
+
+export function NewWikisWidget() {
+  const suggestedArticles = useWikiStore(s => s.suggestedArticles);
+  const openAndGenerate = useWikiStore(s => s.openAndGenerate);
+
+  const items = suggestedArticles.slice(0, MAX_ITEMS);
+
+  return (
+    <Section label="Ready to generate">
+      {items.length === 0 ? (
+        <div className="py-6 text-sm text-[var(--color-text-tertiary)]">
+          No wiki suggestions yet. Tag more atoms to build up candidates.
+        </div>
+      ) : (
+        <ul className="-mx-2">
+          {items.map(s => (
+            <li key={s.tag_id}>
+              <button
+                onClick={() => openAndGenerate(s.tag_id, s.tag_name)}
+                className="w-full flex items-baseline gap-3 px-2 py-1.5 rounded hover:bg-[var(--color-bg-hover)]/60 text-left group"
+              >
+                <span className="flex-1 min-w-0 truncate text-sm text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]">
+                  {s.tag_name}
+                </span>
+                <span className="text-[11px] text-[var(--color-text-tertiary)] tabular-nums shrink-0">
+                  {s.atom_count} atoms
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}

--- a/src/components/dashboard/widgets/RevisionsWidget.tsx
+++ b/src/components/dashboard/widgets/RevisionsWidget.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { Section } from '../Section';
+import { useWikiStore } from '../../../stores/wiki';
+import { useTagsStore, type TagWithCount } from '../../../stores/tags';
+import { useUIStore } from '../../../stores/ui';
+
+const MAX_ITEMS = 5;
+
+function findTag(nodes: TagWithCount[], id: string): TagWithCount | null {
+  for (const n of nodes) {
+    if (n.id === id) return n;
+    if (n.children.length) {
+      const found = findTag(n.children, id);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+interface RevisionItem {
+  tagId: string;
+  tagName: string;
+  delta: number;
+}
+
+export function RevisionsWidget() {
+  const articles = useWikiStore(s => s.articles);
+  const tags = useTagsStore(s => s.tags);
+  const openWikiReader = useUIStore(s => s.openWikiReader);
+
+  const items = useMemo<RevisionItem[]>(() => {
+    const results: RevisionItem[] = [];
+    for (const a of articles) {
+      const tag = findTag(tags, a.tag_id);
+      if (!tag) continue;
+      const delta = tag.atom_count - a.atom_count;
+      if (delta > 0) {
+        results.push({ tagId: a.tag_id, tagName: a.tag_name, delta });
+      }
+    }
+    return results.sort((x, y) => y.delta - x.delta).slice(0, MAX_ITEMS);
+  }, [articles, tags]);
+
+  return (
+    <Section label="Revision suggestions">
+      {items.length === 0 ? (
+        <div className="py-6 text-sm text-[var(--color-text-tertiary)]">
+          {articles.length > 0 ? 'All wikis are up to date.' : 'Generate a wiki to start tracking revisions.'}
+        </div>
+      ) : (
+        <ul className="-mx-2">
+          {items.map(item => (
+            <li key={item.tagId}>
+              <button
+                onClick={() => openWikiReader(item.tagId, item.tagName)}
+                className="w-full flex items-baseline gap-3 px-2 py-1.5 rounded hover:bg-[var(--color-bg-hover)]/60 text-left group"
+              >
+                <span className="flex-1 min-w-0 truncate text-sm text-[var(--color-text-secondary)] group-hover:text-[var(--color-text-primary)]">
+                  {item.tagName}
+                </span>
+                <span className="text-[11px] text-amber-400/90 tabular-nums shrink-0">
+                  +{item.delta}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}

--- a/src/components/layout/LeftPanel.tsx
+++ b/src/components/layout/LeftPanel.tsx
@@ -14,18 +14,13 @@ export function LeftPanel() {
   const setLeftPanelOpen = useUIStore(s => s.setLeftPanelOpen);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // Auto-collapse on small screens, auto-expand on large screens.
-  // On mount we only force-close when we're below the breakpoint — force-opening
-  // on desktop mount would clobber store state set by other logic (e.g., the
-  // dashboard view auto-hides the sidebar). Resize events still toggle both ways.
+  // Auto-collapse on small screens, auto-expand on large screens
   useEffect(() => {
     const mq = window.matchMedia(`(max-width: ${COLLAPSE_BREAKPOINT}px)`);
-    if (mq.matches) {
-      setLeftPanelOpen(false);
-    }
-    const handleChange = (e: MediaQueryListEvent) => {
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
       setLeftPanelOpen(!e.matches);
     };
+    handleChange(mq);
     mq.addEventListener('change', handleChange);
     return () => mq.removeEventListener('change', handleChange);
   }, [setLeftPanelOpen]);

--- a/src/components/layout/LeftPanel.tsx
+++ b/src/components/layout/LeftPanel.tsx
@@ -14,13 +14,18 @@ export function LeftPanel() {
   const setLeftPanelOpen = useUIStore(s => s.setLeftPanelOpen);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // Auto-collapse on small screens, auto-expand on large screens
+  // Auto-collapse on small screens, auto-expand on large screens.
+  // On mount we only force-close when we're below the breakpoint — force-opening
+  // on desktop mount would clobber store state set by other logic (e.g., the
+  // dashboard view auto-hides the sidebar). Resize events still toggle both ways.
   useEffect(() => {
     const mq = window.matchMedia(`(max-width: ${COLLAPSE_BREAKPOINT}px)`);
-    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+    if (mq.matches) {
+      setLeftPanelOpen(false);
+    }
+    const handleChange = (e: MediaQueryListEvent) => {
       setLeftPanelOpen(!e.matches);
     };
-    handleChange(mq);
     mq.addEventListener('change', handleChange);
     return () => mq.removeEventListener('change', handleChange);
   }, [setLeftPanelOpen]);

--- a/src/components/layout/MainView.tsx
+++ b/src/components/layout/MainView.tsx
@@ -1,5 +1,28 @@
 import { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
+import {
+  PanelLeft,
+  X,
+  Undo2,
+  Redo2,
+  ChevronLeft,
+  ChevronRight,
+  Sun,
+  Moon,
+  Check,
+  Pencil,
+  Trash2,
+  MoreHorizontal,
+  MessageCircle,
+  LayoutDashboard,
+  LayoutGrid,
+  List as ListIcon,
+  Library,
+  Network,
+  BookOpen,
+  Search,
+  Filter,
+} from 'lucide-react';
 import { AtomGrid } from '../atoms/AtomGrid';
 import { AtomList } from '../atoms/AtomList';
 import { AtomReader } from '../atoms/AtomReader';
@@ -7,6 +30,7 @@ import { FilterBar } from '../atoms/FilterBar';
 import { FilterSheet } from '../atoms/FilterSheet';
 import { SigmaCanvas } from '../canvas/SigmaCanvas';
 import { LocalGraphView } from '../canvas/LocalGraphView';
+import { DashboardView } from '../dashboard/DashboardView';
 import { FAB } from '../ui/FAB';
 import { Modal } from '../ui/Modal';
 import { EmbeddingProgressBanner } from '../ui/EmbeddingProgressBanner';
@@ -38,15 +62,17 @@ export function MainView() {
   const search = useAtomsStore(s => s.search);
   const clearSemanticSearch = useAtomsStore(s => s.clearSemanticSearch);
 
-  const { viewMode, searchQuery } = useUIStore(
+  const { viewMode, atomsLayout, searchQuery } = useUIStore(
     useShallow(s => ({
       viewMode: s.viewMode,
+      atomsLayout: s.atomsLayout,
       searchQuery: s.searchQuery,
     }))
   );
   const leftPanelOpen = useUIStore(s => s.leftPanelOpen);
   const toggleLeftPanel = useUIStore(s => s.toggleLeftPanel);
   const setViewMode = useUIStore(s => s.setViewMode);
+  const setAtomsLayout = useUIStore(s => s.setAtomsLayout);
   const openReader = useUIStore(s => s.openReader);
   const readerState = useUIStore(s => s.readerState);
   const wikiReaderState = useUIStore(s => s.wikiReaderState);
@@ -232,10 +258,7 @@ export function MainView() {
           }`}
           title={leftPanelOpen ? "Hide sidebar" : "Show sidebar"}
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <rect x="3" y="3" width="18" height="18" rx="2" />
-            <line x1="9" y1="3" x2="9" y2="21" />
-          </svg>
+          <PanelLeft className="w-4 h-4" strokeWidth={2} />
         </button>
 
         {readerState.atomId || wikiReaderState.tagId || (localGraph.isOpen && localGraph.centerAtomId) ? (
@@ -247,9 +270,7 @@ export function MainView() {
                 className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
                 title="Close"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
+                <X className="w-4 h-4" strokeWidth={2} />
               </button>
               {/* In edit mode: undo/redo. In view mode: back/forward */}
               {readerState.atomId && readerState.editing ? (
@@ -259,18 +280,14 @@ export function MainView() {
                     className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
                     title="Undo (Cmd+Z)"
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
-                    </svg>
+                    <Undo2 className="w-4 h-4" strokeWidth={2} />
                   </button>
                   <button
                     onClick={() => readerEditorActions.current?.redo()}
                     className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
                     title="Redo (Cmd+Shift+Z)"
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 10H11a5 5 0 00-5 5v2M21 10l-4-4M21 10l-4 4" />
-                    </svg>
+                    <Redo2 className="w-4 h-4" strokeWidth={2} />
                   </button>
                 </>
               ) : (
@@ -281,9 +298,7 @@ export function MainView() {
                     className={`p-1.5 rounded-md transition-colors ${overlayNav.index > 0 ? 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]' : 'text-[var(--color-text-tertiary)] cursor-default'}`}
                     title="Back"
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                    </svg>
+                    <ChevronLeft className="w-4 h-4" strokeWidth={2} />
                   </button>
                   <button
                     onClick={overlayForward}
@@ -291,9 +306,7 @@ export function MainView() {
                     className={`p-1.5 rounded-md transition-colors ${overlayNav.index < overlayNav.stack.length - 1 ? 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]' : 'text-[var(--color-text-tertiary)] cursor-default'}`}
                     title="Forward"
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
+                    <ChevronRight className="w-4 h-4" strokeWidth={2} />
                   </button>
                 </>
               )}
@@ -322,13 +335,9 @@ export function MainView() {
                   title={readerTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                 >
                   {readerTheme === 'dark' ? (
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-                    </svg>
+                    <Sun className="w-4 h-4" strokeWidth={2} />
                   ) : (
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-                    </svg>
+                    <Moon className="w-4 h-4" strokeWidth={2} />
                   )}
                 </button>
                 {/* Edit / Done toggle */}
@@ -345,13 +354,9 @@ export function MainView() {
                   title={readerState.editing ? 'Done (Esc)' : 'Edit'}
                 >
                   {readerState.editing ? (
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
+                    <Check className="w-4 h-4" strokeWidth={2} />
                   ) : (
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                    </svg>
+                    <Pencil className="w-4 h-4" strokeWidth={2} />
                   )}
                 </button>
                 {/* Delete */}
@@ -360,9 +365,7 @@ export function MainView() {
                   className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-[var(--color-bg-hover)] transition-colors"
                   title="Delete"
                 >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
+                  <Trash2 className="w-4 h-4" strokeWidth={2} />
                 </button>
               </div>
             )}
@@ -385,13 +388,9 @@ export function MainView() {
                   title={readerState.editing ? 'Done (Esc)' : 'Edit'}
                 >
                   {readerState.editing ? (
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
+                    <Check className="w-4 h-4" strokeWidth={2} />
                   ) : (
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                    </svg>
+                    <Pencil className="w-4 h-4" strokeWidth={2} />
                   )}
                 </button>
 
@@ -404,11 +403,7 @@ export function MainView() {
                     aria-haspopup="menu"
                     aria-expanded={readerMenuOpen}
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <circle cx="5" cy="12" r="1.5" fill="currentColor" />
-                      <circle cx="12" cy="12" r="1.5" fill="currentColor" />
-                      <circle cx="19" cy="12" r="1.5" fill="currentColor" />
-                    </svg>
+                    <MoreHorizontal className="w-4 h-4" strokeWidth={2} />
                   </button>
                   {readerMenuOpen && (
                     <div
@@ -420,13 +415,11 @@ export function MainView() {
                         onClick={() => { toggleReaderTheme(); setReaderMenuOpen(false); }}
                         className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
                       >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          {readerTheme === 'dark' ? (
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-                          ) : (
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-                          )}
-                        </svg>
+                        {readerTheme === 'dark' ? (
+                          <Sun className="w-4 h-4" strokeWidth={2} />
+                        ) : (
+                          <Moon className="w-4 h-4" strokeWidth={2} />
+                        )}
                         {readerTheme === 'dark' ? 'Light mode' : 'Dark mode'}
                       </button>
                       <button
@@ -434,9 +427,7 @@ export function MainView() {
                         onClick={() => { setShowDeleteModal(true); setReaderMenuOpen(false); }}
                         className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left text-red-400 hover:bg-[var(--color-bg-hover)] transition-colors"
                       >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                        </svg>
+                        <Trash2 className="w-4 h-4" strokeWidth={2} />
                         Delete
                       </button>
                     </div>
@@ -455,9 +446,7 @@ export function MainView() {
               }`}
               title={chatSidebarOpen ? "Hide chat" : "Show chat"}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-              </svg>
+              <MessageCircle className="w-4 h-4" strokeWidth={2} />
             </button>
           </>
         ) : (
@@ -465,65 +454,82 @@ export function MainView() {
           <>
             {/* View Mode Toggle — desktop only; mobile accesses view mode via the filter sheet */}
             {!isMobile && (
-              <div className="flex items-center bg-[var(--color-bg-card)] rounded-md border border-[var(--color-border)] shrink-0">
-                <button
-                  onClick={() => setViewMode('grid')}
-                  className={`p-1.5 rounded-l-md transition-colors ${
-                    viewMode === 'grid'
-                      ? 'bg-[var(--color-accent)] text-white'
-                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-                  }`}
-                  title="Grid view"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-                  </svg>
-                </button>
-                <button
-                  onClick={() => setViewMode('list')}
-                  className={`p-1.5 transition-colors ${
-                    viewMode === 'list'
-                      ? 'bg-[var(--color-accent)] text-white'
-                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-                  }`}
-                  title="List view"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                  </svg>
-                </button>
-                <button
-                  onClick={() => setViewMode('canvas')}
-                  className={`p-1.5 transition-colors ${
-                    viewMode === 'canvas'
-                      ? 'bg-[var(--color-accent)] text-white'
-                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-                  }`}
-                  title="Canvas view"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                    <circle cx="6" cy="6" r="2" />
-                    <circle cx="18" cy="6" r="2" />
-                    <circle cx="6" cy="18" r="2" />
-                    <circle cx="18" cy="18" r="2" />
-                    <circle cx="12" cy="12" r="2" />
-                    <path strokeLinecap="round" d="M8 7l2.5 3.5M16 7l-2.5 3.5M8 17l2.5-3.5M16 17l-2.5-3.5" />
-                  </svg>
-                </button>
-                <button
-                  onClick={() => setViewMode('wiki')}
-                  className={`p-1.5 rounded-r-md transition-colors ${
-                    viewMode === 'wiki'
-                      ? 'bg-[var(--color-accent)] text-white'
-                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
-                  }`}
-                  title="Wiki view"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                  </svg>
-                </button>
-              </div>
+              <>
+                <div className="flex items-center bg-[var(--color-bg-card)] rounded-md border border-[var(--color-border)] shrink-0">
+                  <button
+                    onClick={() => setViewMode('dashboard')}
+                    className={`p-1.5 rounded-l-md transition-colors ${
+                      viewMode === 'dashboard'
+                        ? 'bg-[var(--color-accent)] text-white'
+                        : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                    }`}
+                    title="Dashboard"
+                  >
+                    <LayoutDashboard className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                  <button
+                    onClick={() => setViewMode('atoms')}
+                    className={`p-1.5 transition-colors ${
+                      viewMode === 'atoms'
+                        ? 'bg-[var(--color-accent)] text-white'
+                        : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                    }`}
+                    title="Atoms"
+                  >
+                    <Library className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                  <button
+                    onClick={() => setViewMode('canvas')}
+                    className={`p-1.5 transition-colors ${
+                      viewMode === 'canvas'
+                        ? 'bg-[var(--color-accent)] text-white'
+                        : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                    }`}
+                    title="Canvas view"
+                  >
+                    <Network className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                  <button
+                    onClick={() => setViewMode('wiki')}
+                    className={`p-1.5 rounded-r-md transition-colors ${
+                      viewMode === 'wiki'
+                        ? 'bg-[var(--color-accent)] text-white'
+                        : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                    }`}
+                    title="Wiki view"
+                  >
+                    <BookOpen className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                </div>
+
+                {/* Atoms layout sub-toggle — only visible when on the atoms view */}
+                {viewMode === 'atoms' && (
+                  <div className="flex items-center bg-[var(--color-bg-card)] rounded-md border border-[var(--color-border)] shrink-0">
+                    <button
+                      onClick={() => setAtomsLayout('grid')}
+                      className={`p-1.5 rounded-l-md transition-colors ${
+                        atomsLayout === 'grid'
+                          ? 'text-[var(--color-text-primary)] bg-[var(--color-bg-hover)]'
+                          : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                      }`}
+                      title="Grid layout"
+                    >
+                      <LayoutGrid className="w-4 h-4" strokeWidth={2} />
+                    </button>
+                    <button
+                      onClick={() => setAtomsLayout('list')}
+                      className={`p-1.5 rounded-r-md transition-colors ${
+                        atomsLayout === 'list'
+                          ? 'text-[var(--color-text-primary)] bg-[var(--color-bg-hover)]'
+                          : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]'
+                      }`}
+                      title="List layout"
+                    >
+                      <ListIcon className="w-4 h-4" strokeWidth={2} />
+                    </button>
+                  </div>
+                )}
+              </>
             )}
 
             {/* Search button */}
@@ -532,16 +538,14 @@ export function MainView() {
               className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
               title="Search atoms"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
+              <Search className="w-4 h-4" strokeWidth={2} />
             </button>
 
             <div data-tauri-drag-region className="flex-1 h-full drag-region" />
 
             {/* Filter toggle + atom count — right-aligned. On mobile, always show the
                 filter button (it opens the filter sheet which hosts view mode too). */}
-            {(isMobile || (viewMode !== 'canvas' && viewMode !== 'wiki')) && (
+            {(isMobile || viewMode === 'atoms') && (
               <div className="flex items-center gap-2 shrink-0">
                 <button
                   onClick={() => setFilterBarOpen(!filterBarOpen)}
@@ -552,9 +556,7 @@ export function MainView() {
                   }`}
                   title="Filter & sort"
                 >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-                  </svg>
+                  <Filter className="w-4 h-4" strokeWidth={2} />
                   {hasActiveFilter && !filterBarOpen && (
                     <span className="absolute top-0.5 right-0.5 w-1.5 h-1.5 bg-[var(--color-accent)] rounded-full" />
                   )}
@@ -577,16 +579,14 @@ export function MainView() {
               }`}
               title={chatSidebarOpen ? "Hide chat" : "Show chat"}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-              </svg>
+              <MessageCircle className="w-4 h-4" strokeWidth={2} />
             </button>
           </>
         )}
       </div>
 
-      {/* Search results header - only show for grid/list views */}
-      {isSemanticSearch && viewMode !== 'canvas' && viewMode !== 'wiki' && (
+      {/* Search results header - only show in atoms view */}
+      {isSemanticSearch && viewMode === 'atoms' && (
         <div className="px-4 py-2 text-sm text-[var(--color-text-secondary)] border-b border-[var(--color-border)]">
           {semanticSearchResults.length > 0 ? (
             <span>
@@ -598,8 +598,8 @@ export function MainView() {
         </div>
       )}
 
-      {/* Filter bar — desktop inline strip, grid/list views only */}
-      {!isMobile && !isSemanticSearch && viewMode !== 'canvas' && viewMode !== 'wiki' && filterBarOpen && <FilterBar />}
+      {/* Filter bar — desktop inline strip, atoms view only */}
+      {!isMobile && !isSemanticSearch && viewMode === 'atoms' && filterBarOpen && <FilterBar />}
 
       {/* Filter sheet — mobile bottom sheet hosts view mode + filter + sort */}
       {isMobile && (
@@ -618,11 +618,13 @@ export function MainView() {
           <AtomReader atomId={readerState.atomId} highlightText={readerState.highlightText} initialEditing={readerState.editing} />
         ) : wikiReaderState.tagId && wikiReaderState.tagName ? (
           <WikiReader tagId={wikiReaderState.tagId} tagName={wikiReaderState.tagName} />
+        ) : viewMode === 'dashboard' ? (
+          <DashboardView />
         ) : viewMode === 'wiki' ? (
           <WikiFullView />
         ) : viewMode === 'canvas' ? (
           <SigmaCanvas />
-        ) : viewMode === 'grid' ? (
+        ) : atomsLayout === 'grid' ? (
           <AtomGrid
             atoms={displayAtoms}
             onAtomClick={handleAtomClick}
@@ -647,8 +649,8 @@ export function MainView() {
         )}
       </div>
 
-      {/* FAB — hide in wiki, canvas, reader, and graph */}
-      {viewMode !== 'wiki' && viewMode !== 'canvas' && !readerState.atomId && !wikiReaderState.tagId && !localGraph.isOpen && <FAB onClick={handleNewAtom} title="Create new atom" />}
+      {/* FAB — only on atoms view, and only when no overlay is open */}
+      {viewMode === 'atoms' && !readerState.atomId && !wikiReaderState.tagId && !localGraph.isOpen && <FAB onClick={handleNewAtom} title="Create new atom" />}
 
       {/* Embedding progress overlay */}
       <EmbeddingProgressBanner />

--- a/src/components/onboarding/StepIndicator.tsx
+++ b/src/components/onboarding/StepIndicator.tsx
@@ -1,3 +1,4 @@
+import { Check } from 'lucide-react';
 import { STEPS } from './useOnboardingState';
 
 interface StepIndicatorProps {
@@ -26,9 +27,7 @@ export function StepIndicator({ currentStep, onStepClick }: StepIndicatorProps) 
             disabled={index > currentStep}
           >
             {index < currentStep ? (
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
+              <Check className="w-4 h-4" strokeWidth={2} />
             ) : (
               index + 1
             )}

--- a/src/components/onboarding/steps/IntegrationsStep.tsx
+++ b/src/components/onboarding/steps/IntegrationsStep.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { Button } from '../../ui/Button';
 import { QRCode } from '../QRCode';
 import {
@@ -69,14 +70,10 @@ function Section({
           <h3 className="text-sm font-medium text-[var(--color-text-primary)]">{title}</h3>
           <p className="text-xs text-[var(--color-text-secondary)]">{description}</p>
         </div>
-        <svg
+        <ChevronDown
           className={`w-4 h-4 text-[var(--color-text-secondary)] transition-transform duration-200 shrink-0 ml-3 ${isOpen ? 'rotate-180' : ''}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
+          strokeWidth={2}
+        />
       </button>
       {isOpen && <div className="p-4 border-t border-[var(--color-border)] space-y-3">{children}</div>}
     </div>

--- a/src/components/onboarding/steps/TutorialStep.tsx
+++ b/src/components/onboarding/steps/TutorialStep.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Check, Loader2 } from 'lucide-react';
 import { Button } from '../../ui/Button';
 import { useAtomsStore } from '../../../stores/atoms';
 import { useTagsStore, type TagWithCount } from '../../../stores/tags';
@@ -195,16 +196,11 @@ function StatusItem({ label, done }: { label: string; done: boolean }) {
     <div className="flex items-center gap-3">
       {done ? (
         <div className="w-5 h-5 rounded-full bg-green-500/10 flex items-center justify-center">
-          <svg className="w-3.5 h-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-          </svg>
+          <Check className="w-3.5 h-3.5 text-green-500" strokeWidth={2} />
         </div>
       ) : (
         <div className="w-5 h-5 flex items-center justify-center">
-          <svg className="w-4 h-4 animate-spin text-[var(--color-text-secondary)]" fill="none" viewBox="0 0 24 24">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-          </svg>
+          <Loader2 className="w-4 h-4 animate-spin text-[var(--color-text-secondary)]" strokeWidth={2} />
         </div>
       )}
       <span className={`text-sm ${done ? 'text-[var(--color-text-primary)]' : 'text-[var(--color-text-secondary)]'}`}>

--- a/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/src/components/onboarding/steps/WelcomeStep.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { BookOpen, Check, Copy } from 'lucide-react';
 import { Button } from '../../ui/Button';
 import { isDesktopApp, getTransport, switchTransport } from '../../../lib/transport';
 import { verifyProviderConfigured } from '../../../lib/api';
@@ -120,9 +121,7 @@ export function WelcomeStep({ state, dispatch, onNext, onComplete }: WelcomeStep
     return (
       <div className="flex flex-col items-center justify-center h-full text-center space-y-6 px-8">
         <div className="w-16 h-16 rounded-2xl bg-[var(--color-accent)]/10 flex items-center justify-center">
-          <svg className="w-8 h-8 text-[var(--color-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
-          </svg>
+          <BookOpen className="w-8 h-8 text-[var(--color-accent)]" strokeWidth={2} />
         </div>
 
         <div>
@@ -180,9 +179,7 @@ export function WelcomeStep({ state, dispatch, onNext, onComplete }: WelcomeStep
     return (
       <div className="flex flex-col items-center justify-center h-full text-center space-y-6 px-8">
         <div className="w-16 h-16 rounded-2xl bg-green-500/10 flex items-center justify-center">
-          <svg className="w-8 h-8 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-          </svg>
+          <Check className="w-8 h-8 text-green-500" strokeWidth={2} />
         </div>
 
         <div>
@@ -205,13 +202,9 @@ export function WelcomeStep({ state, dispatch, onNext, onComplete }: WelcomeStep
               title="Copy to clipboard"
             >
               {tokenCopied ? (
-                <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
+                <Check className="w-4 h-4 text-green-500" strokeWidth={2} />
               ) : (
-                <svg className="w-4 h-4 text-[var(--color-text-secondary)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
+                <Copy className="w-4 h-4 text-[var(--color-text-secondary)]" strokeWidth={2} />
               )}
             </button>
           </div>
@@ -234,9 +227,7 @@ export function WelcomeStep({ state, dispatch, onNext, onComplete }: WelcomeStep
     return (
       <div className="flex flex-col items-center justify-center h-full text-center space-y-6 px-8">
         <div className="w-16 h-16 rounded-2xl bg-green-500/10 flex items-center justify-center">
-          <svg className="w-8 h-8 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-          </svg>
+          <Check className="w-8 h-8 text-green-500" strokeWidth={2} />
         </div>
         <div>
           <h2 className="text-2xl font-bold text-[var(--color-text-primary)] mb-2">Connected</h2>
@@ -261,9 +252,7 @@ export function WelcomeStep({ state, dispatch, onNext, onComplete }: WelcomeStep
     return (
       <div className="flex flex-col items-center justify-center h-full text-center space-y-6 px-8">
         <div className="w-16 h-16 rounded-2xl bg-[var(--color-accent)]/10 flex items-center justify-center">
-          <svg className="w-8 h-8 text-[var(--color-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
-          </svg>
+          <BookOpen className="w-8 h-8 text-[var(--color-accent)]" strokeWidth={2} />
         </div>
 
         <div>

--- a/src/components/search/SemanticSearch.tsx
+++ b/src/components/search/SemanticSearch.tsx
@@ -1,33 +1,22 @@
 import { useState, useEffect, useRef } from 'react';
+import { Type, Lightbulb, Keyboard, Search, X, Check, Loader2 } from 'lucide-react';
 import { useAtomsStore, SearchMode } from '../../stores/atoms';
 
 const SEARCH_MODE_CONFIG: Record<SearchMode, { label: string; placeholder: string; icon: React.ReactNode }> = {
   keyword: {
     label: 'Keyword',
     placeholder: 'Search by keywords...',
-    icon: (
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
-      </svg>
-    ),
+    icon: <Type className="w-4 h-4" strokeWidth={2} />,
   },
   semantic: {
     label: 'Semantic',
     placeholder: 'Search by meaning...',
-    icon: (
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-      </svg>
-    ),
+    icon: <Lightbulb className="w-4 h-4" strokeWidth={2} />,
   },
   hybrid: {
     label: 'Hybrid',
     placeholder: 'Search by keywords & meaning...',
-    icon: (
-      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-      </svg>
-    ),
+    icon: <Keyboard className="w-4 h-4" strokeWidth={2} />,
   },
 };
 
@@ -94,44 +83,17 @@ export function SemanticSearch() {
     <div className="relative flex-1 min-w-0" ref={dropdownRef}>
       {/* Search icon button (opens mode dropdown) or loading spinner */}
       {isSearching ? (
-        <svg
+        <Loader2
           className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--color-text-secondary)] animate-spin"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          />
-        </svg>
+          strokeWidth={2}
+        />
       ) : (
         <button
           onClick={() => setShowModeDropdown(!showModeDropdown)}
           className="absolute left-2 top-1/2 -translate-y-1/2 p-1 rounded text-[var(--color-text-secondary)] hover:text-[var(--color-accent)] hover:bg-[var(--color-accent)]/10 transition-colors"
           title={`Search mode: ${currentConfig.label} (click to change)`}
         >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
-          </svg>
+          <Search className="w-4 h-4" strokeWidth={2} />
         </button>
       )}
 
@@ -159,14 +121,7 @@ export function SemanticSearch() {
           }}
           className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
+          <X className="w-4 h-4" strokeWidth={2} />
         </button>
       )}
 
@@ -196,9 +151,7 @@ export function SemanticSearch() {
                 {config.icon}
                 <span>{config.label}</span>
                 {isActive && (
-                  <svg className="w-3.5 h-3.5 ml-auto" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                  </svg>
+                  <Check className="w-3.5 h-3.5 ml-auto" strokeWidth={2} />
                 )}
               </button>
             );

--- a/src/components/settings/SettingsButton.tsx
+++ b/src/components/settings/SettingsButton.tsx
@@ -1,3 +1,5 @@
+import { Settings } from 'lucide-react';
+
 interface SettingsButtonProps {
   onClick: () => void;
 }
@@ -9,10 +11,7 @@ export function SettingsButton({ onClick }: SettingsButtonProps) {
       className="p-1.5 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
       title="Settings"
     >
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-      </svg>
+      <Settings className="w-5 h-5" strokeWidth={2} />
     </button>
   );
 }

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,6 +1,22 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { toast } from 'sonner';
+import {
+  X,
+  Check,
+  Copy,
+  Eye,
+  EyeOff,
+  Loader2,
+  Pause,
+  Play,
+  Pencil,
+  RefreshCw,
+  Trash2,
+  Upload,
+  ChevronRight,
+  AlertCircle,
+} from 'lucide-react';
 import { Button } from '../ui/Button';
 import { CustomSelect } from '../ui/CustomSelect';
 import { SearchableSelect } from '../ui/SearchableSelect';
@@ -317,9 +333,7 @@ function DatabasesTab() {
                   className="p-1.5 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
                   title="Rename"
                 >
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M12.146.854a.5.5 0 0 1 .708 0l2.292 2.292a.5.5 0 0 1 0 .708l-9.5 9.5a.5.5 0 0 1-.168.11l-4 1.5a.5.5 0 0 1-.65-.65l1.5-4a.5.5 0 0 1 .11-.168l9.5-9.5z"/>
-                  </svg>
+                  <Pencil width="14" height="14" strokeWidth={2} />
                 </button>
                 {!db.is_default && (
                   <button
@@ -327,10 +341,7 @@ function DatabasesTab() {
                     className="p-1.5 text-[var(--color-text-tertiary)] hover:text-red-400 hover:bg-[var(--color-bg-hover)] rounded transition-colors"
                     title="Delete database"
                   >
-                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                      <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
-                      <path fillRule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4L4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118z"/>
-                    </svg>
+                    <Trash2 width="14" height="14" strokeWidth={2} />
                   </button>
                 )}
               </div>
@@ -1077,9 +1088,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
               onClick={onClose}
               className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              <X className="w-5 h-5" strokeWidth={2} />
             </button>
           </div>
 
@@ -1212,10 +1221,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                     {/* Connection status — shown inline after provider */}
                     {provider === 'openrouter' && isTesting && (
                       <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-                        <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                        </svg>
+                        <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
                         Testing connection...
                       </div>
                     )}
@@ -1258,14 +1264,9 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                             className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
                           >
                             {showApiKey ? (
-                              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                              </svg>
+                              <EyeOff className="w-5 h-5" strokeWidth={2} />
                             ) : (
-                              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                              </svg>
+                              <Eye className="w-5 h-5" strokeWidth={2} />
                             )}
                           </button>
                         </div>
@@ -1608,10 +1609,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                         />
                         {openaiCompatStatus === 'checking' && (
                           <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-                            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                            </svg>
+                            <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
                             Testing connection...
                           </div>
                         )}
@@ -1651,14 +1649,9 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                             className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
                           >
                             {openaiCompatShowApiKey ? (
-                              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                              </svg>
+                              <EyeOff className="w-5 h-5" strokeWidth={2} />
                             ) : (
-                              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                              </svg>
+                              <Eye className="w-5 h-5" strokeWidth={2} />
                             )}
                           </button>
                         </div>
@@ -1822,10 +1815,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                           >
                             {reembedding ? (
                               <>
-                                <svg className="w-4 h-4 animate-spin mr-1" fill="none" viewBox="0 0 24 24">
-                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                                </svg>
+                                <Loader2 className="w-4 h-4 animate-spin mr-1" strokeWidth={2} />
                                 Starting...
                               </>
                             ) : 'Confirm Re-embed'}
@@ -1994,14 +1984,10 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                         onClick={() => setShowTokenSection(!showTokenSection)}
                         className="flex items-center gap-2 text-sm font-medium text-[var(--color-text-primary)] hover:text-white transition-colors w-full"
                       >
-                        <svg
+                        <ChevronRight
                           className={`w-4 h-4 transition-transform ${showTokenSection ? 'rotate-90' : ''}`}
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                        </svg>
+                          strokeWidth={2}
+                        />
                         API Tokens
                         {apiTokens.filter(t => !t.is_revoked).length > 0 && (
                           <span className="text-xs text-[var(--color-text-secondary)]">
@@ -2019,10 +2005,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                           {/* Token list */}
                           {isLoadingTokens ? (
                             <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-                              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                              </svg>
+                              <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
                               Loading tokens...
                             </div>
                           ) : apiTokens.length === 0 ? (
@@ -2101,13 +2084,9 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                                   title="Copy to clipboard"
                                 >
                                   {tokenCopied ? (
-                                    <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                                    </svg>
+                                    <Check className="w-4 h-4 text-green-500" strokeWidth={2} />
                                   ) : (
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                    </svg>
+                                    <Copy className="w-4 h-4" strokeWidth={2} />
                                   )}
                                 </button>
                               </div>
@@ -2165,10 +2144,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                       <Button onClick={handleIngestUrl} disabled={!ingestUrlValue.trim() || ingesting}>
                         {ingesting ? (
                           <>
-                            <svg className="w-4 h-4 animate-spin mr-1" fill="none" viewBox="0 0 24 24">
-                              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                            </svg>
+                            <Loader2 className="w-4 h-4 animate-spin mr-1" strokeWidth={2} />
                             Ingesting...
                           </>
                         ) : 'Ingest'}
@@ -2221,10 +2197,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                     {/* Feed list */}
                     {feedsLoading ? (
                       <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)] py-4">
-                        <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                        </svg>
+                        <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
                         Loading feeds...
                       </div>
                     ) : feeds.length === 0 ? (
@@ -2276,14 +2249,9 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                                   title="Poll now"
                                 >
                                   {pollingFeedId === feed.id ? (
-                                    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                                    </svg>
+                                    <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
                                   ) : (
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                                    </svg>
+                                    <RefreshCw className="w-4 h-4" strokeWidth={2} />
                                   )}
                                 </button>
                                 <button
@@ -2293,14 +2261,9 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                                   title={feed.is_paused ? 'Resume' : 'Pause'}
                                 >
                                   {feed.is_paused ? (
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                    </svg>
+                                    <Play className="w-4 h-4" strokeWidth={2} />
                                   ) : (
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                    </svg>
+                                    <Pause className="w-4 h-4" strokeWidth={2} />
                                   )}
                                 </button>
                                 <button
@@ -2310,9 +2273,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                                   className="p-1.5 text-[var(--color-text-secondary)] hover:text-red-400 hover:bg-[var(--color-bg-hover)] rounded transition-colors disabled:opacity-50"
                                   title="Delete feed"
                                 >
-                                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                                  </svg>
+                                  <Trash2 className="w-4 h-4" strokeWidth={2} />
                                 </button>
                               </div>
                             </div>
@@ -2334,10 +2295,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                       <Button variant="secondary" onClick={handleAddFeed} disabled={!newFeedUrl.trim() || addingFeed}>
                         {addingFeed ? (
                           <>
-                            <svg className="w-4 h-4 animate-spin mr-1" fill="none" viewBox="0 0 24 24">
-                              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                            </svg>
+                            <Loader2 className="w-4 h-4 animate-spin mr-1" strokeWidth={2} />
                             Adding...
                           </>
                         ) : 'Add Feed'}
@@ -2381,19 +2339,14 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                       >
                         {isImporting ? (
                           <>
-                            <svg className="w-4 h-4 animate-spin mr-2" fill="none" viewBox="0 0 24 24">
-                              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                            </svg>
+                            <Loader2 className="w-4 h-4 animate-spin mr-2" strokeWidth={2} />
                             {importProgress
                               ? `Importing ${importProgress.current}/${importProgress.total}...`
                               : 'Importing...'}
                           </>
                         ) : (
                           <>
-                            <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-                            </svg>
+                            <Upload className="w-4 h-4 mr-2" strokeWidth={2} />
                             Import Markdown Folder
                           </>
                         )}
@@ -2436,14 +2389,10 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                         onClick={handleMcpExpand}
                         className="flex items-center gap-2 text-sm font-medium text-[var(--color-text-primary)] hover:text-white transition-colors w-full"
                       >
-                        <svg
+                        <ChevronRight
                           className={`w-4 h-4 transition-transform ${showMcpSetup ? 'rotate-90' : ''}`}
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                        </svg>
+                          strokeWidth={2}
+                        />
                         Claude Desktop Integration
                       </button>
 
@@ -2478,13 +2427,9 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                               title="Copy to clipboard"
                             >
                               {mcpConfigCopied ? (
-                                <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                                </svg>
+                                <Check className="w-4 h-4 text-green-500" strokeWidth={2} />
                               ) : (
-                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                                </svg>
+                                <Copy className="w-4 h-4" strokeWidth={2} />
                               )}
                             </button>
                           </div>
@@ -2516,9 +2461,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
         {saveError && (
           <div className="px-6 py-3 border-t border-[var(--color-border)]">
             <div className="flex items-start gap-2 text-sm text-red-500">
-              <svg className="w-4 h-4 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
+              <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" strokeWidth={2} />
               <span>{saveError}</span>
             </div>
           </div>

--- a/src/components/tags/TagChip.tsx
+++ b/src/components/tags/TagChip.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { X } from 'lucide-react';
 
 interface TagChipProps {
   name: string;
@@ -32,9 +33,7 @@ export const TagChip = memo(function TagChip({ name, onClick, onRemove, size = '
           }}
           className="ml-0.5 hover:text-white transition-colors shrink-0"
         >
-          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          <X className="w-3 h-3" strokeWidth={2} />
         </button>
       )}
     </span>

--- a/src/components/tags/TagNode.tsx
+++ b/src/components/tags/TagNode.tsx
@@ -1,4 +1,5 @@
 import { memo, MouseEvent, useCallback } from 'react';
+import { ChevronRight, MessageCircle, FileText } from 'lucide-react';
 import { TagWithCount, useTagsStore } from '../../stores/tags';
 import { useUIStore } from '../../stores/ui';
 
@@ -60,14 +61,7 @@ export const TagNode = memo(function TagNode({ tag, level, selectedTagId, onSele
           onClick={handleToggle}
           className="w-4 h-4 flex items-center justify-center text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
         >
-          <svg
-            className={`w-3 h-3 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-          </svg>
+          <ChevronRight className={`w-3 h-3 transition-transform ${isExpanded ? 'rotate-90' : ''}`} strokeWidth={2} />
         </button>
       ) : (
         <span className="w-4" />
@@ -81,9 +75,7 @@ export const TagNode = memo(function TagNode({ tag, level, selectedTagId, onSele
             className="w-5 h-5 flex items-center justify-center opacity-0 group-hover:opacity-100 text-[var(--color-text-secondary)] hover:text-[var(--color-accent-light)] transition-all"
             title="Chat with this tag"
           >
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
+            <MessageCircle className="w-3.5 h-3.5" strokeWidth={2} />
           </button>
           {/* Article icon - visible on hover */}
           <button
@@ -91,9 +83,7 @@ export const TagNode = memo(function TagNode({ tag, level, selectedTagId, onSele
             className="w-5 h-5 flex items-center justify-center opacity-0 group-hover:opacity-100 text-[var(--color-text-secondary)] hover:text-[var(--color-accent-light)] transition-all"
             title="View wiki article"
           >
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
+            <FileText className="w-3.5 h-3.5" strokeWidth={2} />
           </button>
         </>
       )}

--- a/src/components/tags/TagSelector.tsx
+++ b/src/components/tags/TagSelector.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { Plus } from 'lucide-react';
 import { TagChip } from './TagChip';
 import { Input } from '../ui/Input';
 import { useTagsStore, TagWithCount } from '../../stores/tags';
@@ -249,9 +250,7 @@ export function TagSelector({ selectedTags, onTagsChange }: TagSelectorProps) {
                 disabled={isCreating}
                 className="w-full px-3 py-2 text-left text-sm text-[var(--color-accent)] hover:bg-[var(--color-bg-hover)] transition-colors flex items-center gap-2"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                </svg>
+                <Plus className="w-4 h-4" strokeWidth={2} />
                 Create "{inputValue}"
               </button>
             )}

--- a/src/components/tags/TagTree.tsx
+++ b/src/components/tags/TagTree.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useMemo, useEffect, MouseEvent } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { Pencil, Plus, Trash2, Inbox, Search } from 'lucide-react';
 import { TagNode } from './TagNode';
 import { ContextMenu } from '../ui/ContextMenu';
 import { Modal } from '../ui/Modal';
@@ -171,9 +172,7 @@ export function TagTree({ onOpenTagSettings }: TagTreeProps = {}) {
             });
           },
           icon: (
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
+            <Pencil className="w-4 h-4" strokeWidth={2} />
           ),
         },
         {
@@ -186,9 +185,7 @@ export function TagTree({ onOpenTagSettings }: TagTreeProps = {}) {
             });
           },
           icon: (
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
+            <Plus className="w-4 h-4" strokeWidth={2} />
           ),
         },
         {
@@ -202,9 +199,7 @@ export function TagTree({ onOpenTagSettings }: TagTreeProps = {}) {
           },
           danger: true,
           icon: (
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
+            <Trash2 className="w-4 h-4" strokeWidth={2} />
           ),
         },
       ]
@@ -221,9 +216,7 @@ export function TagTree({ onOpenTagSettings }: TagTreeProps = {}) {
         }`}
         onClick={() => handleSelectTag(null)}
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-        </svg>
+        <Inbox className="w-4 h-4" strokeWidth={2} />
         <span className="flex-1 text-sm font-medium">All Atoms</span>
       </div>
 
@@ -240,9 +233,7 @@ export function TagTree({ onOpenTagSettings }: TagTreeProps = {}) {
           className="p-1 rounded hover:bg-[var(--color-bg-hover)] text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors"
           title="Search tags"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
+          <Search className="w-4 h-4" strokeWidth={2} />
         </button>
       </div>
 
@@ -321,9 +312,7 @@ export function TagTree({ onOpenTagSettings }: TagTreeProps = {}) {
           className="w-full flex items-center justify-start gap-1.5 px-2 py-1.5 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded-md transition-colors"
           onClick={() => setNewTagModal({ isOpen: true, parentId: null, name: '' })}
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
+          <Plus className="w-3.5 h-3.5" strokeWidth={2} />
           New Tag
         </button>
       </div>

--- a/src/components/ui/ConnectionStatus.tsx
+++ b/src/components/ui/ConnectionStatus.tsx
@@ -1,12 +1,11 @@
+import { Loader2 } from 'lucide-react';
+
 export function ConnectionStatus({ status, error }: { status: 'checking' | 'connected' | 'disconnected'; error?: string }) {
   return (
     <div className="flex items-center gap-2 text-sm">
       {status === 'checking' && (
         <>
-          <svg className="w-4 h-4 animate-spin text-[var(--color-text-secondary)]" fill="none" viewBox="0 0 24 24">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-          </svg>
+          <Loader2 className="w-4 h-4 animate-spin text-[var(--color-text-secondary)]" strokeWidth={2} />
           <span className="text-[var(--color-text-secondary)]">Checking connection...</span>
         </>
       )}

--- a/src/components/ui/CustomSelect.tsx
+++ b/src/components/ui/CustomSelect.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { ChevronDown } from 'lucide-react';
 
 export interface SelectOption {
   value: string;
@@ -41,14 +42,10 @@ export function CustomSelect({ value, onChange, options }: CustomSelectProps) {
         className="w-full px-3 py-2 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-md text-[var(--color-text-primary)] text-left text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:border-transparent transition-colors duration-150 flex items-center justify-between"
       >
         <span>{selectedOption?.label || value}</span>
-        <svg
+        <ChevronDown
           className={`w-4 h-4 text-[var(--color-text-secondary)] transition-transform ${isOpen ? 'rotate-180' : ''}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
+          strokeWidth={2}
+        />
       </button>
 
       {isOpen && (

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AlertTriangle } from 'lucide-react';
 
 interface Props {
   children: React.ReactNode;
@@ -14,9 +15,7 @@ function ErrorFallback({ error, onReset }: { error: Error | null; onReset: () =>
     <div className="flex h-screen items-center justify-center bg-[var(--color-bg-main)]">
       <div className="max-w-md w-full mx-4 p-6 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-xl shadow-lg">
         <div className="flex items-center gap-3 mb-4">
-          <svg className="w-6 h-6 text-red-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-          </svg>
+          <AlertTriangle className="w-6 h-6 text-red-400 shrink-0" strokeWidth={2} />
           <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">Something went wrong</h2>
         </div>
         {error && (

--- a/src/components/ui/FAB.tsx
+++ b/src/components/ui/FAB.tsx
@@ -1,4 +1,5 @@
 import { ButtonHTMLAttributes } from 'react';
+import { Plus } from 'lucide-react';
 
 interface FABProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: React.ReactNode;
@@ -11,9 +12,7 @@ export function FAB({ icon, className = '', ...props }: FABProps) {
       {...props}
     >
       {icon || (
-        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-        </svg>
+        <Plus className="w-6 h-6" strokeWidth={2} />
       )}
     </button>
   );

--- a/src/components/ui/LoadingIndicator.tsx
+++ b/src/components/ui/LoadingIndicator.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react';
 import { useUIStore } from '../../stores/ui';
 
 export function LoadingIndicator() {
@@ -17,26 +18,11 @@ export function LoadingIndicator() {
     >
       <div className="flex items-center gap-3">
         {/* Spinner */}
-        <svg
+        <Loader2
           className="w-4 h-4 animate-spin text-[var(--color-accent)]"
-          fill="none"
-          viewBox="0 0 24 24"
+          strokeWidth={2}
           aria-hidden="true"
-        >
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          />
-        </svg>
+        />
 
         {/* Message */}
         <span className="text-sm text-[var(--color-text-primary)]">{latestOp.message}</span>

--- a/src/components/ui/MarkdownImage.tsx
+++ b/src/components/ui/MarkdownImage.tsx
@@ -1,4 +1,5 @@
 import { useState, SyntheticEvent } from 'react';
+import { Image as ImageIcon, AlertTriangle } from 'lucide-react';
 
 interface MarkdownImageProps {
   src?: string;
@@ -18,16 +19,12 @@ export function MarkdownImage({ src, alt }: MarkdownImageProps) {
     <span className="markdown-image-wrapper">
       {status === 'loading' && (
         <span className="markdown-image-placeholder">
-          <svg className="w-8 h-8 text-[var(--color-text-tertiary)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-          </svg>
+          <ImageIcon className="w-8 h-8 text-[var(--color-text-tertiary)]" strokeWidth={2} />
         </span>
       )}
       {status === 'error' && (
         <span className="markdown-image-error">
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-          </svg>
+          <AlertTriangle className="w-6 h-6" strokeWidth={2} />
           <span>Failed to load image</span>
         </span>
       )}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
 import { Button } from './Button';
 
 interface ModalProps {
@@ -67,9 +68,7 @@ export function Modal({
             onClick={onClose}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
         <div className="px-6 py-4 text-[var(--color-text-primary)]">

--- a/src/components/ui/SearchBar.tsx
+++ b/src/components/ui/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { Search, ChevronUp, ChevronDown, X, Loader2 } from 'lucide-react';
 
 const DEBOUNCE_MS = 200;
 
@@ -84,10 +85,7 @@ export function SearchBar({
     if (isPending) {
       // Animated ring loader
       return (
-        <svg className="w-4 h-4 animate-spin text-[var(--color-accent)]" fill="none" viewBox="0 0 24 24">
-          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
-          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-        </svg>
+        <Loader2 className="w-4 h-4 animate-spin text-[var(--color-accent)]" strokeWidth={2} />
       );
     }
     if (totalMatches === 0) return 'No matches';
@@ -98,19 +96,7 @@ export function SearchBar({
     <div className="sticky left-0 right-0 top-0 z-20 px-4 py-2 bg-[var(--color-bg-card)] border-b border-[var(--color-border)] shadow-lg">
       <div className="flex items-center gap-2">
         {/* Search icon */}
-        <svg
-          className="w-4 h-4 text-[var(--color-text-secondary)] flex-shrink-0"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-          />
-        </svg>
+        <Search className="w-4 h-4 text-[var(--color-text-secondary)] flex-shrink-0" strokeWidth={2} />
 
         {/* Search input */}
         <input
@@ -142,9 +128,7 @@ export function SearchBar({
             className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             title="Previous match (Shift+Enter)"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-            </svg>
+            <ChevronUp className="w-4 h-4" strokeWidth={2} />
           </button>
           <button
             onClick={onNext}
@@ -152,9 +136,7 @@ export function SearchBar({
             className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             title="Next match (Enter)"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
+            <ChevronDown className="w-4 h-4" strokeWidth={2} />
           </button>
         </div>
 
@@ -164,9 +146,7 @@ export function SearchBar({
           className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           title="Close (Escape)"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          <X className="w-4 h-4" strokeWidth={2} />
         </button>
       </div>
     </div>

--- a/src/components/ui/SearchableSelect.tsx
+++ b/src/components/ui/SearchableSelect.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { ChevronDown, Loader2 } from 'lucide-react';
 import type { AvailableModel } from '../../lib/api';
 
 // Fuzzy search function - checks if search chars appear in order in target
@@ -147,14 +148,10 @@ export function SearchableSelect({ value, onChange, options, isLoading, placehol
         <span className={selectedOption ? '' : 'text-[var(--color-text-secondary)]'}>
           {isLoading ? 'Loading models...' : (selectedOption?.name || value || placeholder)}
         </span>
-        <svg
+        <ChevronDown
           className={`w-4 h-4 text-[var(--color-text-secondary)] transition-transform ${isOpen ? 'rotate-180' : ''}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
+          strokeWidth={2}
+        />
       </button>
 
       {/* Dropdown */}
@@ -181,10 +178,7 @@ export function SearchableSelect({ value, onChange, options, isLoading, placehol
           <div ref={listRef} className="max-h-60 overflow-y-auto">
             {isLoading ? (
               <div className="px-3 py-4 text-center text-sm text-[var(--color-text-secondary)]">
-                <svg className="w-5 h-5 animate-spin mx-auto mb-2" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                </svg>
+                <Loader2 className="w-5 h-5 animate-spin mx-auto mb-2" strokeWidth={2} />
                 Loading models...
               </div>
             ) : filteredOptions.length === 0 ? (

--- a/src/components/wiki/CitationPopover.tsx
+++ b/src/components/wiki/CitationPopover.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { ArrowRight } from 'lucide-react';
 import { useKeyboard } from '../../hooks/useKeyboard';
 
 // Generic citation interface that works with both WikiCitation and ChatCitation
@@ -129,9 +130,7 @@ export function CitationPopover({ citation, anchorRect, onClose, onViewAtom }: C
           className="flex items-center gap-1 text-sm text-[var(--color-accent)] hover:text-[var(--color-accent-light)] transition-colors"
         >
           View full atom
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
-          </svg>
+          <ArrowRight className="w-4 h-4" strokeWidth={2} />
         </button>
       </div>
     </div>,

--- a/src/components/wiki/NewWikiModal.tsx
+++ b/src/components/wiki/NewWikiModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
 import { Modal } from '../ui/Modal';
 import { useTagsStore, TagWithCount } from '../../stores/tags';
 import { useWikiStore } from '../../stores/wiki';
@@ -250,9 +251,7 @@ export function NewWikiModal({ isOpen, onClose }: NewWikiModalProps) {
               // Tag already has an article
               <div className="space-y-3">
                 <div className="flex items-center gap-2 text-amber-500">
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                  </svg>
+                  <AlertTriangle className="w-5 h-5" strokeWidth={2} />
                   <span className="font-medium">Article already exists</span>
                 </div>
                 <p className="text-sm text-[var(--color-text-secondary)]">
@@ -294,10 +293,7 @@ export function NewWikiModal({ isOpen, onClose }: NewWikiModalProps) {
                   >
                     {isGenerating ? (
                       <>
-                        <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                        </svg>
+                        <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
                         Generating...
                       </>
                     ) : (

--- a/src/components/wiki/WikiArticleCard.tsx
+++ b/src/components/wiki/WikiArticleCard.tsx
@@ -1,3 +1,4 @@
+import { BookOpen } from 'lucide-react';
 import { WikiArticleSummary } from '../../stores/wiki';
 import { formatRelativeDate } from '../../lib/date';
 
@@ -42,9 +43,7 @@ export function WikiArticleCard({ article, isActive, onClick }: WikiArticleCardP
 
         {/* Wiki icon indicator */}
         <div className="p-1.5 text-[var(--color-text-tertiary)]">
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-          </svg>
+          <BookOpen className="w-4 h-4" strokeWidth={2} />
         </div>
       </div>
     </div>

--- a/src/components/wiki/WikiArticleContent.tsx
+++ b/src/components/wiki/WikiArticleContent.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, Fragment, ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { Plus } from 'lucide-react';
 import { WikiArticle, WikiCitation, WikiLink, RelatedTag } from '../../stores/wiki';
 import { CitationLink } from './CitationLink';
 import { CitationPopover } from './CitationPopover';
@@ -305,9 +306,7 @@ export function WikiArticleContent({ article, citations, wikiLinks, relatedTags,
                     </div>
                   </div>
                   <div className="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity ml-2">
-                    <svg className="w-4 h-4 text-[var(--color-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                    </svg>
+                    <Plus className="w-4 h-4 text-[var(--color-accent)]" strokeWidth={2} />
                   </div>
                 </button>
               ))}

--- a/src/components/wiki/WikiArticlesList.tsx
+++ b/src/components/wiki/WikiArticlesList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { BookOpen, Plus } from 'lucide-react';
 import { useWikiStore } from '../../stores/wiki';
 import { WikiArticleCard } from './WikiArticleCard';
 import { NewWikiModal } from './NewWikiModal';
@@ -36,9 +37,7 @@ export function WikiArticlesList() {
         {articles.length === 0 && suggestedArticles.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full gap-4 p-8 text-center">
             <div className="w-16 h-16 rounded-full bg-[var(--color-bg-card)] flex items-center justify-center">
-              <svg className="w-8 h-8 text-[var(--color-text-secondary)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-              </svg>
+              <BookOpen className="w-8 h-8 text-[var(--color-text-secondary)]" strokeWidth={2} />
             </div>
             <div>
               <p className="text-[var(--color-text-primary)] font-medium mb-1">No wiki articles yet</p>
@@ -94,9 +93,7 @@ export function WikiArticlesList() {
                         </div>
                       </div>
                       <div className="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity ml-2">
-                        <svg className="w-4 h-4 text-[var(--color-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                        </svg>
+                        <Plus className="w-4 h-4 text-[var(--color-accent)]" strokeWidth={2} />
                       </div>
                     </button>
                   ))}
@@ -113,9 +110,7 @@ export function WikiArticlesList() {
           onClick={() => setIsModalOpen(true)}
           className="w-full flex items-center justify-start gap-1.5 px-2 py-1.5 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded-md transition-colors"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
+          <Plus className="w-3.5 h-3.5" strokeWidth={2} />
           New Article
         </button>
       </div>

--- a/src/components/wiki/WikiCard.tsx
+++ b/src/components/wiki/WikiCard.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Sparkles, BookOpen, Link2 } from 'lucide-react';
 import { WikiArticleSummary, SuggestedArticle } from '../../stores/wiki';
 import { formatRelativeDate, formatShortRelativeDate } from '../../lib/date';
 
@@ -29,9 +30,7 @@ export const WikiCard = memo(function WikiCard(props: WikiCardProps) {
             <p className="text-sm font-medium text-[var(--color-text-primary)] line-clamp-1">
               {suggestion.tag_name}
             </p>
-            <svg className="w-4 h-4 text-[var(--color-accent)] shrink-0 opacity-60 group-hover:opacity-100 transition-opacity" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
-            </svg>
+            <Sparkles className="w-4 h-4 text-[var(--color-accent)] shrink-0 opacity-60 group-hover:opacity-100 transition-opacity" strokeWidth={2} />
           </div>
           <p className="text-xs text-[var(--color-text-tertiary)] mt-2 leading-relaxed">
             Generate a wiki article from {suggestion.atom_count} atom{suggestion.atom_count !== 1 ? 's' : ''}
@@ -69,16 +68,12 @@ export const WikiCard = memo(function WikiCard(props: WikiCardProps) {
       <div className="mt-3 pt-3 border-t border-[var(--color-border)]">
         <div className="flex items-center gap-3">
           <span className="flex items-center gap-1 text-xs text-[var(--color-text-tertiary)]">
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-            </svg>
+            <BookOpen className="w-3.5 h-3.5" strokeWidth={2} />
             {article.atom_count} source{article.atom_count !== 1 ? 's' : ''}
           </span>
           {article.inbound_links > 0 && (
             <span className="flex items-center gap-1 text-xs text-[var(--color-accent-light)]">
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-              </svg>
+              <Link2 className="w-3.5 h-3.5" strokeWidth={2} />
               {article.inbound_links} link{article.inbound_links !== 1 ? 's' : ''}
             </span>
           )}

--- a/src/components/wiki/WikiEmptyState.tsx
+++ b/src/components/wiki/WikiEmptyState.tsx
@@ -1,3 +1,5 @@
+import { FilePlus, Loader2, Zap } from 'lucide-react';
+
 interface WikiEmptyStateProps {
   tagName: string;
   atomCount: number;
@@ -10,9 +12,7 @@ export function WikiEmptyState({ tagName, atomCount, onGenerate, isGenerating }:
     <div className="flex flex-col items-center justify-center h-full px-6 py-12 text-center">
       {/* Document icon with plus */}
       <div className="w-16 h-16 mb-4 rounded-full bg-[var(--color-bg-card)] flex items-center justify-center">
-        <svg className="w-8 h-8 text-[var(--color-text-secondary)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-3-3v6m-7 4h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-        </svg>
+        <FilePlus className="w-8 h-8 text-[var(--color-text-secondary)]" strokeWidth={2} />
       </div>
       
       <h3 className="text-lg font-medium text-[var(--color-text-primary)] mb-2">
@@ -30,17 +30,12 @@ export function WikiEmptyState({ tagName, atomCount, onGenerate, isGenerating }:
       >
         {isGenerating ? (
           <>
-            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-            </svg>
+            <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
             Generating...
           </>
         ) : (
           <>
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-            </svg>
+            <Zap className="w-4 h-4" strokeWidth={2} />
             Generate Article
           </>
         )}

--- a/src/components/wiki/WikiGenerating.tsx
+++ b/src/components/wiki/WikiGenerating.tsx
@@ -1,3 +1,5 @@
+import { Loader2 } from 'lucide-react';
+
 interface WikiGeneratingProps {
   tagName: string;
   atomCount: number;
@@ -7,12 +9,7 @@ export function WikiGenerating({ tagName, atomCount }: WikiGeneratingProps) {
   return (
     <div className="flex flex-col items-center justify-center h-full px-6 py-12 text-center">
       {/* Spinner */}
-      <div className="w-16 h-16 mb-6">
-        <svg className="w-full h-full animate-spin text-[var(--color-accent)]" fill="none" viewBox="0 0 24 24">
-          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
-          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-        </svg>
-      </div>
+      <Loader2 className="w-16 h-16 mb-6 animate-spin text-[var(--color-accent)]" strokeWidth={2} />
       
       <h3 className="text-lg font-medium text-[var(--color-text-primary)] mb-2">
         Synthesizing article about "{tagName}"...

--- a/src/components/wiki/WikiGrid.tsx
+++ b/src/components/wiki/WikiGrid.tsx
@@ -1,4 +1,5 @@
 import { memo, useRef, useMemo } from 'react';
+import { BookOpen } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { WikiArticleSummary, SuggestedArticle } from '../../stores/wiki';
 import { WikiCard } from './WikiCard';
@@ -84,19 +85,7 @@ export const WikiGrid = memo(function WikiGrid({
   if (gridItems.length === 0) {
     return (
       <div ref={parentRef} className="flex flex-col items-center justify-center h-full text-center p-8">
-        <svg
-          className="w-16 h-16 text-[var(--color-border)] mb-4"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-          />
-        </svg>
+        <BookOpen className="w-16 h-16 text-[var(--color-border)] mb-4" strokeWidth={1.5} />
         <h3 className="text-lg font-medium text-[var(--color-text-primary)] mb-2">No wiki articles yet</h3>
         <p className="text-sm text-[var(--color-text-secondary)] max-w-sm">
           Generate a wiki article from your atoms to synthesize knowledge across related notes.

--- a/src/components/wiki/WikiHeader.tsx
+++ b/src/components/wiki/WikiHeader.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { ChevronLeft, Clock, RefreshCw, X, Loader2 } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
 import { formatRelativeTime } from '../../lib/date';
@@ -85,9 +86,7 @@ export function WikiHeader({
               size="sm"
               onClick={onBack}
             >
-              <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-              </svg>
+              <ChevronLeft className="w-4 h-4 mr-1" strokeWidth={2} />
               Back
             </Button>
           )}
@@ -99,9 +98,7 @@ export function WikiHeader({
                 size="sm"
                 onClick={() => setShowVersions(!showVersions)}
               >
-                <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
+                <Clock className="w-4 h-4 mr-1" strokeWidth={2} />
                 History ({versions.length})
               </Button>
               {showVersions && (
@@ -144,18 +141,14 @@ export function WikiHeader({
             onClick={() => setShowRegenerateModal(true)}
             disabled={isUpdating || isViewingVersion}
           >
-            <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-            </svg>
+            <RefreshCw className="w-4 h-4 mr-1" strokeWidth={2} />
             Regenerate
           </Button>
           <button
             onClick={onClose}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors p-1"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
       </div>
@@ -193,10 +186,7 @@ export function WikiHeader({
           >
             {isProposing ? (
               <>
-                <svg className="w-3 h-3 mr-1 animate-spin" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                </svg>
+                <Loader2 className="w-3 h-3 mr-1 animate-spin" strokeWidth={2} />
                 Generating...
               </>
             ) : (

--- a/src/components/wiki/WikiListViewer.tsx
+++ b/src/components/wiki/WikiListViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { X, ChevronLeft, Loader2, AlertTriangle } from 'lucide-react';
 import { useWikiStore } from '../../stores/wiki';
 import { useUIStore } from '../../stores/ui';
 import { WikiArticlesList } from './WikiArticlesList';
@@ -122,9 +123,7 @@ export function WikiListViewer() {
             className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
             aria-label="Close"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
 
@@ -147,9 +146,7 @@ export function WikiListViewer() {
               className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
               aria-label="Back to list"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-              </svg>
+              <ChevronLeft className="w-5 h-5" strokeWidth={2} />
             </button>
             <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">{currentTagName}</h2>
           </div>
@@ -157,18 +154,11 @@ export function WikiListViewer() {
             onClick={closeDrawer}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
         <div className="flex-1 flex items-center justify-center">
-          <div className="w-8 h-8 animate-spin">
-            <svg className="w-full h-full text-[var(--color-accent)]" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
-          </div>
+          <Loader2 className="w-8 h-8 text-[var(--color-accent)] animate-spin" strokeWidth={2} />
         </div>
       </div>
     );
@@ -185,9 +175,7 @@ export function WikiListViewer() {
               className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
               aria-label="Back to list"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-              </svg>
+              <ChevronLeft className="w-5 h-5" strokeWidth={2} />
             </button>
             <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">{currentTagName}</h2>
           </div>
@@ -195,16 +183,12 @@ export function WikiListViewer() {
             onClick={closeDrawer}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
         <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
           <div className="w-12 h-12 mb-4 rounded-full bg-red-500/10 flex items-center justify-center">
-            <svg className="w-6 h-6 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-            </svg>
+            <AlertTriangle className="w-6 h-6 text-red-500" strokeWidth={2} />
           </div>
           <p className="text-[var(--color-text-primary)] mb-2">Failed to load article</p>
           <p className="text-sm text-[var(--color-text-secondary)] mb-4">{error}</p>
@@ -234,9 +218,7 @@ export function WikiListViewer() {
               className="p-1 text-[var(--color-text-tertiary)] cursor-not-allowed"
               aria-label="Back to list"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-              </svg>
+              <ChevronLeft className="w-5 h-5" strokeWidth={2} />
             </button>
             <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">{currentTagName}</h2>
           </div>
@@ -244,9 +226,7 @@ export function WikiListViewer() {
             onClick={closeDrawer}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
         <WikiGenerating tagName={currentTagName || ''} atomCount={articleStatus?.current_atom_count || 0} />
@@ -265,9 +245,7 @@ export function WikiListViewer() {
               className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
               aria-label="Back to list"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-              </svg>
+              <ChevronLeft className="w-5 h-5" strokeWidth={2} />
             </button>
             <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">{currentTagName}</h2>
           </div>
@@ -275,9 +253,7 @@ export function WikiListViewer() {
             onClick={closeDrawer}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
         <WikiEmptyState

--- a/src/components/wiki/WikiReader.tsx
+++ b/src/components/wiki/WikiReader.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { Clock, RefreshCw } from 'lucide-react';
 import { useWikiStore } from '../../stores/wiki';
 import { useUIStore } from '../../stores/ui';
 import { WikiArticleContent } from './WikiArticleContent';
@@ -221,9 +222,7 @@ export function WikiReader({ tagId, tagName }: WikiReaderProps) {
                 {versions.length > 0 && (
                   <div className="relative" ref={versionsRef}>
                     <Button variant="ghost" size="sm" onClick={() => setShowVersions(!showVersions)}>
-                      <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
+                      <Clock className="w-4 h-4 mr-1" strokeWidth={2} />
                       {versions.length}
                     </Button>
                     {showVersions && (
@@ -259,9 +258,7 @@ export function WikiReader({ tagId, tagName }: WikiReaderProps) {
                   onClick={() => setShowRegenerateModal(true)}
                   disabled={isUpdating || !!selectedVersion}
                 >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                  </svg>
+                  <RefreshCw className="w-4 h-4" strokeWidth={2} />
                 </Button>
               </>
             }

--- a/src/components/wiki/WikiViewer.tsx
+++ b/src/components/wiki/WikiViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { X, Loader2, AlertTriangle } from 'lucide-react';
 import { useWikiStore } from '../../stores/wiki';
 import { useUIStore } from '../../stores/ui';
 import { WikiHeader } from './WikiHeader';
@@ -125,18 +126,11 @@ export function WikiViewer({ tagId, tagName }: WikiViewerProps) {
             onClick={closeDrawer}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
         <div className="flex-1 flex items-center justify-center">
-          <div className="w-8 h-8 animate-spin">
-            <svg className="w-full h-full text-[var(--color-accent)]" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
-          </div>
+          <Loader2 className="w-8 h-8 text-[var(--color-accent)] animate-spin" strokeWidth={2} />
         </div>
       </div>
     );
@@ -152,16 +146,12 @@ export function WikiViewer({ tagId, tagName }: WikiViewerProps) {
             onClick={closeDrawer}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
         <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
           <div className="w-12 h-12 mb-4 rounded-full bg-red-500/10 flex items-center justify-center">
-            <svg className="w-6 h-6 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-            </svg>
+            <AlertTriangle className="w-6 h-6 text-red-500" strokeWidth={2} />
           </div>
           <p className="text-[var(--color-text-primary)] mb-2">Failed to generate article</p>
           <p className="text-sm text-[var(--color-text-secondary)] mb-4">{error}</p>
@@ -189,9 +179,7 @@ export function WikiViewer({ tagId, tagName }: WikiViewerProps) {
             onClick={closeDrawer}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
         <WikiGenerating tagName={tagName} atomCount={articleStatus?.current_atom_count || 0} />
@@ -209,9 +197,7 @@ export function WikiViewer({ tagId, tagName }: WikiViewerProps) {
             onClick={closeDrawer}
             className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="w-5 h-5" strokeWidth={2} />
           </button>
         </div>
         <WikiEmptyState

--- a/src/lib/transport/command-map.ts
+++ b/src/lib/transport/command-map.ts
@@ -213,6 +213,10 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
       return `/api/briefings${params.toString() ? `?${params}` : ''}`;
     },
   },
+  get_briefing: {
+    method: 'GET',
+    path: (a) => `/api/briefings/${encodeURIComponent(a.id as string)}`,
+  },
   run_briefing_now: {
     method: 'POST',
     path: '/api/briefings/run',

--- a/src/lib/transport/command-map.ts
+++ b/src/lib/transport/command-map.ts
@@ -200,6 +200,24 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
     transformResponse: (d: any) => d.status as string,
   },
 
+  // ==================== Briefings ====================
+  get_latest_briefing: {
+    method: 'GET',
+    path: '/api/briefings/latest',
+  },
+  list_briefings: {
+    method: 'GET',
+    path: (a) => {
+      const params = new URLSearchParams();
+      if (a.limit != null) params.set('limit', String(a.limit));
+      return `/api/briefings${params.toString() ? `?${params}` : ''}`;
+    },
+  },
+  run_briefing_now: {
+    method: 'POST',
+    path: '/api/briefings/run',
+  },
+
   // ==================== Wiki ====================
   get_all_wiki_articles: {
     method: 'GET',

--- a/src/lib/transport/event-normalizer.ts
+++ b/src/lib/transport/event-normalizer.ts
@@ -54,6 +54,8 @@ export function normalizeServerEvent(data: Record<string, unknown>): NormalizedE
       return { event: 'feed-poll-failed', payload: { feed_id: data.feed_id, error: data.error } };
     case 'BatchProgress':
       return { event: 'batch-progress', payload: { batch_id: data.batch_id, phase: data.phase, completed: data.completed, total: data.total } };
+    case 'BriefingReady':
+      return { event: 'briefing-ready', payload: { db_id: data.db_id, briefing_id: data.briefing_id } };
     default:
       console.warn('Unknown server event type:', type);
       return null;

--- a/src/stores/briefing.ts
+++ b/src/stores/briefing.ts
@@ -24,18 +24,32 @@ export interface BriefingWithCitations {
 }
 
 interface BriefingStore {
-  latest: BriefingWithCitations | null;
+  /// Full recent history (no citations), newest first. `activeIndex` points into this.
+  history: Briefing[];
+  /// Which entry in `history` the widget is currently displaying.
+  activeIndex: number;
+  /// The full briefing (with citations) for the active index. Lazy-loaded on nav.
+  active: BriefingWithCitations | null;
   isLoading: boolean;
   isRunning: boolean;
   error: string | null;
 
+  /// Load the latest briefing and surrounding history. Called on mount and
+  /// whenever the backend emits `briefing-ready`.
   fetchLatest: () => Promise<void>;
+  /// Step by `delta` (+1 = older, -1 = newer). No-op at edges.
+  navigate: (delta: number) => Promise<void>;
+  /// Generate a new briefing and reset the view to the newest entry.
   runNow: () => Promise<void>;
   reset: () => void;
 }
 
-export const useBriefingStore = create<BriefingStore>((set) => ({
-  latest: null,
+const HISTORY_LIMIT = 30;
+
+export const useBriefingStore = create<BriefingStore>((set, get) => ({
+  history: [],
+  activeIndex: 0,
+  active: null,
   isLoading: false,
   isRunning: false,
   error: null,
@@ -43,28 +57,52 @@ export const useBriefingStore = create<BriefingStore>((set) => ({
   fetchLatest: async () => {
     set({ isLoading: true, error: null });
     try {
-      const latest = await getTransport().invoke<BriefingWithCitations | null>('get_latest_briefing');
-      set({ latest, isLoading: false });
+      const transport = getTransport();
+      const history = await transport.invoke<Briefing[]>('list_briefings', { limit: HISTORY_LIMIT });
+      if (history.length === 0) {
+        set({ history: [], activeIndex: 0, active: null, isLoading: false });
+        return;
+      }
+      const active = await transport.invoke<BriefingWithCitations>('get_briefing', { id: history[0].id });
+      set({ history, activeIndex: 0, active, isLoading: false });
     } catch (error) {
       const msg = String(error);
       // A 404 just means no briefing has been generated yet — not an error state.
       if (msg.includes('404') || msg.toLowerCase().includes('not found')) {
-        set({ latest: null, isLoading: false });
+        set({ history: [], activeIndex: 0, active: null, isLoading: false });
       } else {
         set({ error: msg, isLoading: false });
       }
     }
   },
 
+  navigate: async (delta: number) => {
+    const { history, activeIndex } = get();
+    const next = activeIndex + delta;
+    if (next < 0 || next >= history.length) return;
+    set({ activeIndex: next, isLoading: true, error: null });
+    try {
+      const active = await getTransport().invoke<BriefingWithCitations>('get_briefing', { id: history[next].id });
+      set({ active, isLoading: false });
+    } catch (error) {
+      set({ error: String(error), isLoading: false });
+    }
+  },
+
   runNow: async () => {
     set({ isRunning: true, error: null });
     try {
-      const latest = await getTransport().invoke<BriefingWithCitations>('run_briefing_now');
-      set({ latest, isRunning: false });
+      const transport = getTransport();
+      const active = await transport.invoke<BriefingWithCitations>('run_briefing_now');
+      // Refresh history so the new briefing is at index 0; keep the freshly-returned
+      // active object so we don't need a second round-trip.
+      const history = await transport.invoke<Briefing[]>('list_briefings', { limit: HISTORY_LIMIT });
+      set({ history, activeIndex: 0, active, isRunning: false });
     } catch (error) {
       set({ error: String(error), isRunning: false });
     }
   },
 
-  reset: () => set({ latest: null, isLoading: false, isRunning: false, error: null }),
+  reset: () =>
+    set({ history: [], activeIndex: 0, active: null, isLoading: false, isRunning: false, error: null }),
 }));

--- a/src/stores/briefing.ts
+++ b/src/stores/briefing.ts
@@ -1,0 +1,70 @@
+import { create } from 'zustand';
+import { getTransport } from '../lib/transport';
+
+export interface Briefing {
+  id: string;
+  content: string;
+  created_at: string;
+  atom_count: number;
+  last_run_at: string;
+}
+
+export interface BriefingCitation {
+  id: string;
+  briefing_id: string;
+  citation_index: number;
+  atom_id: string;
+  excerpt: string;
+  source_url?: string | null;
+}
+
+export interface BriefingWithCitations {
+  briefing: Briefing;
+  citations: BriefingCitation[];
+}
+
+interface BriefingStore {
+  latest: BriefingWithCitations | null;
+  isLoading: boolean;
+  isRunning: boolean;
+  error: string | null;
+
+  fetchLatest: () => Promise<void>;
+  runNow: () => Promise<void>;
+  reset: () => void;
+}
+
+export const useBriefingStore = create<BriefingStore>((set) => ({
+  latest: null,
+  isLoading: false,
+  isRunning: false,
+  error: null,
+
+  fetchLatest: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const latest = await getTransport().invoke<BriefingWithCitations | null>('get_latest_briefing');
+      set({ latest, isLoading: false });
+    } catch (error) {
+      const msg = String(error);
+      // A 404 just means no briefing has been generated yet — not an error state.
+      if (msg.includes('404') || msg.toLowerCase().includes('not found')) {
+        set({ latest: null, isLoading: false });
+      } else {
+        set({ error: msg, isLoading: false });
+      }
+    }
+  },
+
+  runNow: async () => {
+    set({ isRunning: true, error: null });
+    try {
+      const latest = await getTransport().invoke<BriefingWithCitations>('run_briefing_now');
+      set({ latest, isRunning: false });
+    } catch (error) {
+      set({ error: String(error), isRunning: false });
+    }
+  },
+
+  reset: () => set({ latest: null, isLoading: false, isRunning: false, error: null }),
+}));

--- a/src/stores/canvas.ts
+++ b/src/stores/canvas.ts
@@ -1,29 +1,40 @@
 import { create } from 'zustand';
 import type { GlobalCanvasData } from '../lib/api';
 
-interface CanvasController {
+export interface CanvasController {
   zoomToCluster: (label: string) => void;
   focusAtom: (atomId: string) => void;
 }
 
 interface CanvasStore {
-  // Registered controller functions (set by SigmaCanvas on mount)
+  // Main canvas controller — owned by the full SigmaCanvas view, driven by the
+  // chat agent's tool calls (zoom_to_cluster, focus_atom).
   controller: CanvasController | null;
   registerController: (ctrl: CanvasController) => void;
   unregisterController: () => void;
 
+  // Preview canvas controller — owned by whichever <SigmaCanvas mode="preview" />
+  // is currently mounted (e.g. the dashboard briefing widget). Distinct from the
+  // main controller so chat agent actions never accidentally drive a thumbnail.
+  previewController: CanvasController | null;
+  registerPreviewController: (ctrl: CanvasController) => void;
+  unregisterPreviewController: () => void;
+
   // Canvas data (clusters for chat context)
   canvasData: GlobalCanvasData | null;
   setCanvasData: (data: GlobalCanvasData) => void;
-
 }
 
 export const useCanvasStore = create<CanvasStore>()((set) => ({
   controller: null,
+  previewController: null,
   canvasData: null,
 
   registerController: (ctrl) => set({ controller: ctrl }),
   unregisterController: () => set({ controller: null }),
+
+  registerPreviewController: (ctrl) => set({ previewController: ctrl }),
+  unregisterPreviewController: () => set({ previewController: null }),
 
   setCanvasData: (data) => set({ canvasData: data }),
 }));

--- a/src/stores/databases.ts
+++ b/src/stores/databases.ts
@@ -5,6 +5,7 @@ import { useAtomsStore } from './atoms';
 import { useTagsStore } from './tags';
 import { useWikiStore } from './wiki';
 import { useChatStore } from './chat';
+import { useBriefingStore } from './briefing';
 
 export interface DatabaseInfo {
   id: string;
@@ -94,8 +95,10 @@ export const useDatabasesStore = create<DatabasesStore>((set, get) => ({
         useTagsStore.getState().reset();
         useWikiStore.getState().reset();
         useChatStore.getState().reset();
+        useBriefingStore.getState().reset();
         useTagsStore.getState().fetchTags();
         useAtomsStore.getState().fetchAtoms();
+        useBriefingStore.getState().fetchLatest();
       }
     } catch (e) {
       toast.error('Failed to delete database', { description: String(e) });
@@ -135,10 +138,12 @@ export const useDatabasesStore = create<DatabasesStore>((set, get) => ({
       useTagsStore.getState().reset();
       useWikiStore.getState().reset();
       useChatStore.getState().reset();
+      useBriefingStore.getState().reset();
 
       // Refetch data for the new database
       useTagsStore.getState().fetchTags();
       useAtomsStore.getState().fetchAtoms();
+      useBriefingStore.getState().fetchLatest();
     } catch (e) {
       toast.error('Failed to switch database', { description: String(e) });
       throw e;

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -438,9 +438,23 @@ export const useUIStore = create<UIStore>()(
       clearChatSidebarInitial: () =>
         set({ chatSidebarInitialTagId: null, chatSidebarInitialConversationId: null }),
 
-      setViewMode: (mode: ViewMode) => set({
-        viewMode: mode,
-      }),
+      setViewMode: (mode: ViewMode) =>
+        set((state) => {
+          // Dashboard is a focus view — auto-hide the left sidebar on entry
+          // and restore it when returning to a spatial view (atoms/canvas).
+          // Wiki view is left alone since the sidebar there is the wiki list,
+          // which users may want open or closed independent of this rule.
+          if (mode === 'dashboard') {
+            return { viewMode: mode, leftPanelOpen: false };
+          }
+          if (
+            state.viewMode === 'dashboard' &&
+            (mode === 'atoms' || mode === 'canvas')
+          ) {
+            return { viewMode: mode, leftPanelOpen: true };
+          }
+          return { viewMode: mode };
+        }),
 
       setAtomsLayout: (layout: AtomsLayout) => set({ atomsLayout: layout }),
 
@@ -562,6 +576,17 @@ export const useUIStore = create<UIStore>()(
           state.viewMode = 'atoms';
         }
         return state;
+      },
+      // leftPanelOpen is not persisted — derive its initial value from the
+      // rehydrated viewMode so the first paint already has the sidebar closed
+      // when loading into dashboard view. (onRehydrateStorage would run after
+      // the first render and cause a visible slide-in.)
+      merge: (persistedState, currentState) => {
+        const merged = { ...currentState, ...(persistedState as object) } as UIStore;
+        if ((persistedState as { viewMode?: ViewMode } | undefined)?.viewMode === 'dashboard') {
+          merged.leftPanelOpen = false;
+        }
+        return merged;
       },
     }
   )

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -438,23 +438,9 @@ export const useUIStore = create<UIStore>()(
       clearChatSidebarInitial: () =>
         set({ chatSidebarInitialTagId: null, chatSidebarInitialConversationId: null }),
 
-      setViewMode: (mode: ViewMode) =>
-        set((state) => {
-          // Dashboard is a focus view — auto-hide the left sidebar on entry
-          // and restore it when returning to a spatial view (atoms/canvas).
-          // Wiki view is left alone since the sidebar there is the wiki list,
-          // which users may want open or closed independent of this rule.
-          if (mode === 'dashboard') {
-            return { viewMode: mode, leftPanelOpen: false };
-          }
-          if (
-            state.viewMode === 'dashboard' &&
-            (mode === 'atoms' || mode === 'canvas')
-          ) {
-            return { viewMode: mode, leftPanelOpen: true };
-          }
-          return { viewMode: mode };
-        }),
+      setViewMode: (mode: ViewMode) => set({
+        viewMode: mode,
+      }),
 
       setAtomsLayout: (layout: AtomsLayout) => set({ atomsLayout: layout }),
 
@@ -576,17 +562,6 @@ export const useUIStore = create<UIStore>()(
           state.viewMode = 'atoms';
         }
         return state;
-      },
-      // leftPanelOpen is not persisted — derive its initial value from the
-      // rehydrated viewMode so the first paint already has the sidebar closed
-      // when loading into dashboard view. (onRehydrateStorage would run after
-      // the first render and cause a visible slide-in.)
-      merge: (persistedState, currentState) => {
-        const merged = { ...currentState, ...(persistedState as object) } as UIStore;
-        if ((persistedState as { viewMode?: ViewMode } | undefined)?.viewMode === 'dashboard') {
-          merged.leftPanelOpen = false;
-        }
-        return merged;
       },
     }
   )

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -4,7 +4,8 @@ import type { CanvasLevel } from '../lib/api';
 import { getCanvasLevel } from '../lib/api';
 
 export type DrawerMode = 'editor' | 'viewer' | 'wiki';
-export type ViewMode = 'grid' | 'list' | 'canvas' | 'wiki';
+export type ViewMode = 'dashboard' | 'atoms' | 'canvas' | 'wiki';
+export type AtomsLayout = 'grid' | 'list';
 
 interface DrawerState {
   isOpen: boolean;
@@ -63,6 +64,7 @@ interface UIStore {
   wikiReaderState: WikiReaderState;
   overlayNav: OverlayNav;
   viewMode: ViewMode;
+  atomsLayout: AtomsLayout;
   searchQuery: string;
   loadingOperations: LoadingOperation[];
   // Panel state
@@ -113,6 +115,7 @@ interface UIStore {
   openChatSidebar: (tagId?: string, conversationId?: string) => void;
   clearChatSidebarInitial: () => void;
   setViewMode: (mode: ViewMode) => void;
+  setAtomsLayout: (layout: AtomsLayout) => void;
   setSearchQuery: (query: string) => void;
   addLoadingOperation: (id: string, message: string) => void;
   removeLoadingOperation: (id: string) => void;
@@ -160,7 +163,8 @@ export const useUIStore = create<UIStore>()(
         stack: [],
         index: -1,
       },
-      viewMode: 'grid',
+      viewMode: 'atoms',
+      atomsLayout: 'grid',
       searchQuery: '',
       loadingOperations: [],
       localGraph: {
@@ -438,6 +442,8 @@ export const useUIStore = create<UIStore>()(
         viewMode: mode,
       }),
 
+      setAtomsLayout: (layout: AtomsLayout) => set({ atomsLayout: layout }),
+
       setSearchQuery: (query: string) => set({ searchQuery: query }),
 
       addLoadingOperation: (id: string, message: string) =>
@@ -540,7 +546,23 @@ export const useUIStore = create<UIStore>()(
     }),
     {
       name: 'atomic-ui-storage',
-      partialize: (state) => ({ viewMode: state.viewMode, readerTheme: state.readerTheme, chatSidebarOpen: state.chatSidebarOpen }),
+      version: 1,
+      partialize: (state) => ({
+        viewMode: state.viewMode,
+        atomsLayout: state.atomsLayout,
+        readerTheme: state.readerTheme,
+        chatSidebarOpen: state.chatSidebarOpen,
+      }),
+      // v0 → v1: 'grid' and 'list' were top-level ViewMode values. They're now
+      // collapsed into a single 'atoms' view with a separate atomsLayout field.
+      migrate: (persistedState: unknown, _version: number) => {
+        const state = (persistedState ?? {}) as Record<string, unknown>;
+        if (state.viewMode === 'grid' || state.viewMode === 'list') {
+          state.atomsLayout = state.viewMode;
+          state.viewMode = 'atoms';
+        }
+        return state;
+      },
     }
   )
 );


### PR DESCRIPTION
Adds a new action-oriented Dashboard view alongside Grid/Canvas/Wiki, built on a modular widget registry. The headline widget is an AI daily briefing: a 2-3 paragraph summary of newly captured atoms with inline [N] citations, generated by a reusable agent loop.

Framework — recurring tasks:
- New atomic-core/src/scheduler/ module with ScheduledTask trait, TaskRegistry, per-task lock, TaskEvent, and per-db settings helpers (task.{id}.last_run / enabled / interval_hours).
- Scheduler loop spawned in atomic-server/main.rs alongside feed polling, ticks every 60s, iterates databases, fires due tasks via tokio::spawn with per-(task, db) lock guards.

Daily briefing (first consumer):
- atomic-core/src/briefing/ with agentic loop mirroring wiki/agentic.rs. Tools: read_atom (line-paginated to match the MCP server pattern), semantic_search (context-only, not citable), done().
- Final pass uses structured output with temperature 0.3 and 2 retries on transient errors, mirroring wiki synthesis.
- Migration v12 adds briefings + briefing_citations tables.
- Edge cases: 0 atoms -> hardcoded message, no LLM call; 100+ atoms ->
  clipped to most recent 100 with a note in the prompt; LLM failure -> last_run not advanced, retries next tick; concurrent runs -> locked.
- Reuses wiki_model setting (no new briefing_model).
- REST: GET /briefings/latest, GET /briefings, POST /briefings/run.
- ServerEvent::BriefingReady broadcast over the WebSocket.

Dashboard UI:
- New src/components/dashboard/ with DashboardView, widget registry, Section shell (editorial no-card style), BriefingContent renderer.
- Widgets: briefing (hero with floated preview canvas), activity, new wikis, revisions, all mobile-first with md:grid-cols-2.
- BriefingWidget fetches the latest briefing on mount, subscribes to briefing-ready events, and falls back to a template stub when no briefing exists yet. Clicking a citation opens the popover AND focuses the embedded preview canvas on the referenced atom.
- src/stores/briefing.ts with fetchLatest + runNow.

SigmaCanvas preview mode:
- Added mode: 'main' | 'preview' prop. Preview mode skips the chat controller registration, the mount animation, the theme picker, the edge slider, and the atom popover. Background becomes transparent (page color) so the thumbnail blends into the dashboard.
- Canvas store gains a second controller slot (previewController) so dashboard citations can drive the thumbnail without touching the chat agent's main canvas target.

ViewMode refactor:
- Collapsed 'grid' and 'list' into a single 'atoms' view with a persisted atomsLayout sub-toggle (grid | list). Zustand persist migration v1 maps existing localStorage state.
- Desktop titlebar: 4-button primary segmented control (dashboard, atoms, canvas, wiki) + compact grid/list sub-toggle visible only on atoms. Mobile FilterSheet mirrors the structure.

Lucide icon migration:
- Added lucide-react, migrated ~170 inline SVGs across ~45 files. Only graph-rendering SVGs remain inline. Bundle is ~4 kB gzipped smaller due to tree-shaking.