### PR TITLE
Add Obsidian chat + upgrade tool-call UX

### DIFF
--- a/crates/atomic-core/src/agent.rs
+++ b/crates/atomic-core/src/agent.rs
@@ -254,7 +254,13 @@ fn execute_get_atom(
     let lines: Vec<&str> = content.lines().collect();
     let total = lines.len();
 
-    if offset >= total && total > 0 {
+    // Empty atom — return empty before the range math, otherwise a nonzero
+    // offset would produce lines[offset..0] and panic.
+    if total == 0 {
+        return Ok(Some(String::new()));
+    }
+
+    if offset >= total {
         return Ok(Some(format!(
             "[offset={} is past end of atom ({} total lines)]",
             offset, total

--- a/crates/atomic-core/src/agent.rs
+++ b/crates/atomic-core/src/agent.rs
@@ -85,13 +85,26 @@ fn get_tools() -> Vec<ToolDefinition> {
         ),
         ToolDefinition::new(
             "get_atom",
-            "Get the full content of a specific atom by its ID. Use this when you need more detail about an atom returned from search.",
+            "Get the content of a specific atom by its ID. Returns up to `limit` lines starting at `offset` (defaults: offset=0, limit=500). If the atom has more content, the response includes a line-count header indicating how to continue reading via a follow-up call with a higher offset.",
             json!({
                 "type": "object",
                 "properties": {
                     "atom_id": {
                         "type": "string",
                         "description": "The ID of the atom to retrieve"
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": "Line number to start reading from (0-indexed). Use the value from a prior response's header to continue reading a truncated atom.",
+                        "minimum": 0,
+                        "default": 0
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of lines to return. Defaults to 500; prefer the default unless you know you need more.",
+                        "minimum": 1,
+                        "maximum": 2000,
+                        "default": 500
                     }
                 },
                 "required": ["atom_id"]
@@ -219,8 +232,63 @@ async fn execute_search_atoms(
     Ok(crate::search::merge_search_results_rrf(semantic, keyword, limit))
 }
 
-fn execute_get_atom(storage: &StorageBackend, atom_id: &str) -> Result<Option<String>, String> {
-    storage.get_atom_content_impl(atom_id).map_err(|e| e.to_string())
+/// Default line limit for a single `get_atom` call. Chosen to keep context
+/// usage bounded on long atoms (imports, pasted articles) while being large
+/// enough that most notes fit in one call.
+const GET_ATOM_DEFAULT_LIMIT: usize = 500;
+const GET_ATOM_MAX_LIMIT: usize = 2000;
+
+fn execute_get_atom(
+    storage: &StorageBackend,
+    atom_id: &str,
+    offset: usize,
+    limit: usize,
+) -> Result<Option<String>, String> {
+    let Some(content) = storage
+        .get_atom_content_impl(atom_id)
+        .map_err(|e| e.to_string())?
+    else {
+        return Ok(None);
+    };
+
+    let lines: Vec<&str> = content.lines().collect();
+    let total = lines.len();
+
+    if offset >= total && total > 0 {
+        return Ok(Some(format!(
+            "[offset={} is past end of atom ({} total lines)]",
+            offset, total
+        )));
+    }
+
+    let end = (offset + limit).min(total);
+    let slice = lines[offset..end].join("\n");
+
+    // Only annotate when we truncated or started partway through, so short
+    // atoms (the common case) read clean without metadata noise.
+    if offset == 0 && end == total {
+        return Ok(Some(slice));
+    }
+
+    let header = if end < total {
+        format!(
+            "[lines {}-{} of {}. {} more lines. Call get_atom again with offset={} to continue.]\n",
+            offset + 1,
+            end,
+            total,
+            total - end,
+            end,
+        )
+    } else {
+        format!(
+            "[lines {}-{} of {} (end of atom).]\n",
+            offset + 1,
+            end,
+            total,
+        )
+    };
+
+    Ok(Some(format!("{}{}", header, slice)))
 }
 
 // ==================== System Prompt ====================
@@ -518,7 +586,17 @@ where
                     }
                     "get_atom" => {
                         let atom_id = tool_args["atom_id"].as_str().unwrap_or("");
-                        match execute_get_atom(&storage, atom_id) {
+                        let offset = tool_args
+                            .get("offset")
+                            .and_then(|v| v.as_u64())
+                            .map(|v| v as usize)
+                            .unwrap_or(0);
+                        let limit = tool_args
+                            .get("limit")
+                            .and_then(|v| v.as_u64())
+                            .map(|v| (v as usize).clamp(1, GET_ATOM_MAX_LIMIT))
+                            .unwrap_or(GET_ATOM_DEFAULT_LIMIT);
+                        match execute_get_atom(&storage, atom_id, offset, limit) {
                             Ok(Some(content)) => (content, 1),
                             Ok(None) => ("Atom not found".to_string(), 0),
                             Err(e) => (format!("Error: {}", e), 0),

--- a/plugins/obsidian-plugin/src/atomic-client.ts
+++ b/plugins/obsidian-plugin/src/atomic-client.ts
@@ -33,6 +33,7 @@ export interface TagWithCount {
   name: string;
   parent_id: string | null;
   created_at: string;
+  is_autotag_target: boolean;
   atom_count: number;
   children_total: number;
   children: TagWithCount[];
@@ -81,6 +82,64 @@ export interface WikiCitation {
 export interface WikiArticleWithCitations {
   article: WikiArticle;
   citations: WikiCitation[];
+}
+
+// Chat
+
+export interface Conversation {
+  id: string;
+  title: string | null;
+  created_at: string;
+  updated_at: string;
+  is_archived: boolean;
+}
+
+export interface ConversationWithTags extends Conversation {
+  tags: Tag[];
+  message_count: number;
+  last_message_preview: string | null;
+}
+
+export interface ChatMessage {
+  id: string;
+  conversation_id: string;
+  role: "user" | "assistant" | "system" | "tool";
+  content: string;
+  created_at: string;
+  message_index: number;
+}
+
+export interface ChatToolCall {
+  id: string;
+  message_id: string;
+  tool_name: string;
+  tool_input: unknown;
+  tool_output: unknown | null;
+  status: "pending" | "running" | "complete" | "failed";
+  created_at: string;
+  completed_at: string | null;
+}
+
+export interface ChatCitation {
+  id: string;
+  message_id: string;
+  citation_index: number;
+  atom_id: string;
+  chunk_index: number | null;
+  excerpt: string;
+  relevance_score: number | null;
+  /** Source URL of the cited atom (populated by server for client linking). */
+  source_url?: string | null;
+}
+
+export interface ChatMessageWithContext extends ChatMessage {
+  tool_calls: ChatToolCall[];
+  citations: ChatCitation[];
+}
+
+export interface ConversationWithMessages extends Conversation {
+  tags: Tag[];
+  messages: ChatMessageWithContext[];
 }
 
 export interface CreateAtomRequest {
@@ -248,6 +307,74 @@ export class AtomicClient {
   async getWikiSuggestions(query: string): Promise<TagWithCount[]> {
     return this.request({
       url: `${this.baseUrl}/api/wiki/suggestions?q=${encodeURIComponent(query)}`,
+      method: "GET",
+    });
+  }
+
+  // Chat
+
+  async listConversations(filterTagId?: string, limit = 50): Promise<ConversationWithTags[]> {
+    const params = new URLSearchParams();
+    if (filterTagId) params.set("filter_tag_id", filterTagId);
+    params.set("limit", String(limit));
+    return this.request({
+      url: `${this.baseUrl}/api/conversations?${params}`,
+      method: "GET",
+    });
+  }
+
+  async createConversation(tagIds: string[] = [], title?: string): Promise<ConversationWithTags> {
+    return this.request({
+      url: `${this.baseUrl}/api/conversations`,
+      method: "POST",
+      body: JSON.stringify({ tag_ids: tagIds, title: title ?? null }),
+    });
+  }
+
+  async getConversation(id: string): Promise<ConversationWithMessages> {
+    return this.request({
+      url: `${this.baseUrl}/api/conversations/${id}`,
+      method: "GET",
+    });
+  }
+
+  async updateConversation(
+    id: string,
+    update: { title?: string | null; is_archived?: boolean }
+  ): Promise<ConversationWithTags> {
+    return this.request({
+      url: `${this.baseUrl}/api/conversations/${id}`,
+      method: "PUT",
+      body: JSON.stringify(update),
+    });
+  }
+
+  async deleteConversation(id: string): Promise<void> {
+    await this.request({
+      url: `${this.baseUrl}/api/conversations/${id}`,
+      method: "DELETE",
+    });
+  }
+
+  async setConversationScope(id: string, tagIds: string[]): Promise<ConversationWithTags> {
+    return this.request({
+      url: `${this.baseUrl}/api/conversations/${id}/scope`,
+      method: "PUT",
+      body: JSON.stringify({ tag_ids: tagIds }),
+    });
+  }
+
+  async sendChatMessage(conversationId: string, content: string): Promise<ChatMessageWithContext> {
+    return this.request({
+      url: `${this.baseUrl}/api/conversations/${conversationId}/messages`,
+      method: "POST",
+      body: JSON.stringify({ content }),
+    });
+  }
+
+  async getAtom(id: string): Promise<AtomWithTags> {
+    return this.request({
+      url: `${this.baseUrl}/api/atoms/${id}`,
       method: "GET",
     });
   }

--- a/plugins/obsidian-plugin/src/chat-view.ts
+++ b/plugins/obsidian-plugin/src/chat-view.ts
@@ -1,0 +1,733 @@
+import {
+  ItemView,
+  MarkdownRenderer,
+  Notice,
+  WorkspaceLeaf,
+  setIcon,
+} from "obsidian";
+import {
+  AtomicClient,
+  type AtomWithTags,
+  type ChatCitation,
+  type ChatMessageWithContext,
+  type ChatToolCall,
+  type ConversationWithMessages,
+  type ConversationWithTags,
+  type Tag,
+  type TagWithCount,
+} from "./atomic-client";
+import type { AtomicWebSocket, ServerEvent } from "./ws-client";
+
+export const CHAT_VIEW_TYPE = "atomic-chat";
+
+interface StreamingMessage {
+  content: string;
+  toolCalls: Map<string, ChatToolCall>;
+}
+
+export class ChatView extends ItemView {
+  private client: AtomicClient;
+  private ws: AtomicWebSocket;
+  private getVaultName: () => string;
+
+  private conversations: ConversationWithTags[] = [];
+  private active: ConversationWithMessages | null = null;
+  private allTags: TagWithCount[] = [];
+  private atomCache = new Map<string, AtomWithTags>();
+
+  private loading = false;
+  private sending = false;
+  private streaming: StreamingMessage | null = null;
+  private conversationListOpen = false;
+  private scopeEditorOpen = false;
+
+  private unsubscribeWs: (() => void) | null = null;
+
+  // DOM roots we update in place so streaming re-renders are cheap.
+  private threadEl: HTMLElement | null = null;
+  private headerEl: HTMLElement | null = null;
+  private convListEl: HTMLElement | null = null;
+  private inputEl: HTMLTextAreaElement | null = null;
+  private sendBtn: HTMLButtonElement | null = null;
+
+  constructor(
+    leaf: WorkspaceLeaf,
+    client: AtomicClient,
+    ws: AtomicWebSocket,
+    getVaultName: () => string
+  ) {
+    super(leaf);
+    this.client = client;
+    this.ws = ws;
+    this.getVaultName = getVaultName;
+  }
+
+  getViewType(): string {
+    return CHAT_VIEW_TYPE;
+  }
+
+  getDisplayText(): string {
+    return "Atomic Chat";
+  }
+
+  getIcon(): string {
+    return "messages-square";
+  }
+
+  async onOpen(): Promise<void> {
+    this.ws.open();
+    this.unsubscribeWs = this.ws.on((evt) => this.handleWsEvent(evt));
+
+    this.renderShell();
+    await Promise.all([this.loadConversations(), this.loadTags()]);
+
+    // Open the most recent conversation, or start a fresh one.
+    const latest = this.conversations.find((c) => !c.is_archived);
+    if (latest) {
+      await this.selectConversation(latest.id);
+    } else {
+      await this.startNewConversation([]);
+    }
+  }
+
+  async onClose(): Promise<void> {
+    this.unsubscribeWs?.();
+    this.unsubscribeWs = null;
+  }
+
+  // ------------------------------------------------------------------
+  // Data loading
+  // ------------------------------------------------------------------
+
+  private async loadConversations(): Promise<void> {
+    try {
+      this.conversations = await this.client.listConversations();
+    } catch (e) {
+      console.error("[Atomic] failed to load conversations:", e);
+      this.conversations = [];
+    }
+  }
+
+  private async loadTags(): Promise<void> {
+    try {
+      this.allTags = await this.client.getTags(0);
+    } catch (e) {
+      console.error("[Atomic] failed to load tags:", e);
+      this.allTags = [];
+    }
+  }
+
+  private async selectConversation(id: string): Promise<void> {
+    this.loading = true;
+    this.streaming = null;
+    this.renderThread();
+    try {
+      this.active = await this.client.getConversation(id);
+    } catch (e) {
+      console.error("[Atomic] failed to load conversation:", e);
+      new Notice("Failed to load conversation");
+    } finally {
+      this.loading = false;
+      this.renderHeader();
+      this.renderThread();
+    }
+  }
+
+  private async startNewConversation(tagIds: string[]): Promise<void> {
+    try {
+      const created = await this.client.createConversation(tagIds);
+      this.active = {
+        ...created,
+        messages: [],
+      };
+      await this.loadConversations();
+    } catch (e) {
+      console.error("[Atomic] failed to create conversation:", e);
+      new Notice("Failed to create conversation");
+      return;
+    }
+    this.streaming = null;
+    this.conversationListOpen = false;
+    this.renderHeader();
+    this.renderConversationList();
+    this.renderThread();
+  }
+
+  // ------------------------------------------------------------------
+  // Sending + streaming
+  // ------------------------------------------------------------------
+
+  private async send(): Promise<void> {
+    if (!this.active || this.sending || !this.inputEl) return;
+    const content = this.inputEl.value.trim();
+    if (!content) return;
+
+    this.sending = true;
+    this.streaming = { content: "", toolCalls: new Map() };
+
+    // Optimistic user message — the server response (HTTP) contains the
+    // definitive stored record, but we show the bubble immediately.
+    const now = new Date().toISOString();
+    this.active.messages.push({
+      id: `local-${Date.now()}`,
+      conversation_id: this.active.id,
+      role: "user",
+      content,
+      created_at: now,
+      message_index: this.active.messages.length,
+      tool_calls: [],
+      citations: [],
+    });
+
+    this.inputEl.value = "";
+    this.autoResizeInput();
+    this.renderThread();
+    this.updateSendButton();
+
+    try {
+      // The HTTP call blocks until the agent loop finishes and returns the
+      // final assistant message; the WS ChatComplete event usually arrives
+      // first. Both deliver the same message — dedupe by id so only one is
+      // appended.
+      const finalMsg = await this.client.sendChatMessage(this.active.id, content);
+      if (!this.active.messages.some((m) => m.id === finalMsg.id)) {
+        this.active.messages.push(finalMsg);
+      }
+      this.streaming = null;
+    } catch (e) {
+      console.error("[Atomic] send failed:", e);
+      new Notice(`Chat error: ${e instanceof Error ? e.message : String(e)}`);
+      this.streaming = null;
+    } finally {
+      this.sending = false;
+      this.renderThread();
+      this.updateSendButton();
+    }
+  }
+
+  private handleWsEvent(evt: ServerEvent): void {
+    if (!this.active) return;
+    const convId = (evt as { conversation_id?: string }).conversation_id;
+    if (convId !== this.active.id) return;
+
+    switch (evt.type) {
+      case "ChatStreamDelta": {
+        if (!this.streaming) this.streaming = { content: "", toolCalls: new Map() };
+        this.streaming.content += (evt as { content: string }).content;
+        this.renderStreamingBubble();
+        break;
+      }
+      case "ChatToolStart": {
+        if (!this.streaming) this.streaming = { content: "", toolCalls: new Map() };
+        const e = evt as {
+          tool_call_id: string;
+          tool_name: string;
+          tool_input: unknown;
+        };
+        this.streaming.toolCalls.set(e.tool_call_id, {
+          id: e.tool_call_id,
+          message_id: "",
+          tool_name: e.tool_name,
+          tool_input: e.tool_input,
+          tool_output: null,
+          status: "running",
+          created_at: new Date().toISOString(),
+          completed_at: null,
+        });
+        this.renderStreamingBubble();
+        break;
+      }
+      case "ChatToolComplete": {
+        const e = evt as { tool_call_id: string; results_count: number };
+        const existing = this.streaming?.toolCalls.get(e.tool_call_id);
+        if (existing) {
+          existing.status = "complete";
+          existing.tool_output = { results_count: e.results_count };
+          existing.completed_at = new Date().toISOString();
+        }
+        this.renderStreamingBubble();
+        break;
+      }
+      case "ChatComplete": {
+        const e = evt as { message: ChatMessageWithContext };
+        if (this.active && !this.active.messages.some((m) => m.id === e.message.id)) {
+          this.active.messages.push(e.message);
+        }
+        this.streaming = null;
+        this.renderThread();
+        break;
+      }
+      case "ChatError": {
+        const e = evt as { error: string };
+        new Notice(`Chat error: ${e.error}`);
+        this.streaming = null;
+        this.renderThread();
+        break;
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Rendering
+  // ------------------------------------------------------------------
+
+  private renderShell(): void {
+    const container = this.containerEl.children[1];
+    container.empty();
+    container.addClass("atomic-chat-root");
+
+    this.headerEl = container.createDiv({ cls: "atomic-chat-header" });
+    this.convListEl = container.createDiv({ cls: "atomic-chat-conv-list hidden" });
+    this.threadEl = container.createDiv({ cls: "atomic-chat-thread" });
+
+    const inputWrap = container.createDiv({ cls: "atomic-chat-input-wrap" });
+    this.inputEl = inputWrap.createEl("textarea", {
+      cls: "atomic-chat-input",
+      attr: { placeholder: "Ask your knowledge base…", rows: "1" },
+    });
+    this.inputEl.addEventListener("input", () => {
+      this.autoResizeInput();
+      this.updateSendButton();
+    });
+    this.inputEl.addEventListener("keydown", (evt) => {
+      if (evt.key === "Enter" && !evt.shiftKey && !evt.isComposing) {
+        evt.preventDefault();
+        void this.send();
+      }
+    });
+
+    this.sendBtn = inputWrap.createEl("button", {
+      cls: "atomic-chat-send",
+      attr: { "aria-label": "Send" },
+    });
+    setIcon(this.sendBtn, "send-horizontal");
+    this.sendBtn.addEventListener("click", () => void this.send());
+
+    this.renderHeader();
+  }
+
+  private renderHeader(): void {
+    if (!this.headerEl) return;
+    this.headerEl.empty();
+
+    const title = this.headerEl.createDiv({ cls: "atomic-chat-title" });
+    title.setText(this.conversationTitle());
+
+    const actions = this.headerEl.createDiv({ cls: "atomic-chat-actions" });
+
+    const scopeChip = actions.createEl("button", { cls: "atomic-chat-scope-chip" });
+    scopeChip.setText(this.scopeLabel());
+    scopeChip.addEventListener("click", () => this.toggleScopeEditor(scopeChip));
+
+    const listBtn = actions.createEl("button", {
+      cls: "atomic-chat-icon-btn",
+      attr: { "aria-label": "Conversations" },
+    });
+    setIcon(listBtn, "list");
+    listBtn.addEventListener("click", () => {
+      this.conversationListOpen = !this.conversationListOpen;
+      this.renderConversationList();
+    });
+
+    const newBtn = actions.createEl("button", {
+      cls: "atomic-chat-icon-btn",
+      attr: { "aria-label": "New conversation" },
+    });
+    setIcon(newBtn, "plus");
+    newBtn.addEventListener("click", () => void this.startNewConversation([]));
+  }
+
+  private conversationTitle(): string {
+    if (!this.active) return "Atomic Chat";
+    if (this.active.title) return this.active.title;
+    const firstUser = this.active.messages.find((m) => m.role === "user");
+    if (firstUser) {
+      const snippet = firstUser.content.slice(0, 40);
+      return snippet + (firstUser.content.length > 40 ? "…" : "");
+    }
+    return "New conversation";
+  }
+
+  private scopeLabel(): string {
+    if (!this.active || this.active.tags.length === 0) return "All notes";
+    if (this.active.tags.length === 1) return `#${this.active.tags[0].name}`;
+    return `${this.active.tags.length} tags`;
+  }
+
+  private renderConversationList(): void {
+    if (!this.convListEl) return;
+    this.convListEl.empty();
+    this.convListEl.toggleClass("hidden", !this.conversationListOpen);
+    if (!this.conversationListOpen) return;
+
+    if (this.conversations.length === 0) {
+      this.convListEl.createDiv({
+        cls: "atomic-chat-conv-empty",
+        text: "No conversations yet.",
+      });
+      return;
+    }
+
+    for (const conv of this.conversations) {
+      if (conv.is_archived) continue;
+      const row = this.convListEl.createDiv({ cls: "atomic-chat-conv-row" });
+      if (this.active?.id === conv.id) row.addClass("active");
+      const title = conv.title || conv.last_message_preview || "New conversation";
+      row.createDiv({ cls: "atomic-chat-conv-title", text: title });
+      if (conv.tags.length > 0) {
+        const tagsEl = row.createDiv({ cls: "atomic-chat-conv-tags" });
+        tagsEl.setText(conv.tags.map((t) => `#${t.name}`).join(" "));
+      }
+      row.addEventListener("click", async () => {
+        this.conversationListOpen = false;
+        this.renderConversationList();
+        await this.selectConversation(conv.id);
+      });
+    }
+  }
+
+  private toggleScopeEditor(anchor: HTMLElement): void {
+    // Remove any existing popover.
+    const existing = this.containerEl.querySelector(".atomic-chat-scope-popover");
+    if (existing) {
+      existing.remove();
+      this.scopeEditorOpen = false;
+      return;
+    }
+    this.scopeEditorOpen = true;
+
+    const popover = this.containerEl.createDiv({ cls: "atomic-chat-scope-popover" });
+    const rect = anchor.getBoundingClientRect();
+    const rootRect = this.containerEl.getBoundingClientRect();
+    popover.style.top = `${rect.bottom - rootRect.top + 4}px`;
+    popover.style.right = `${rootRect.right - rect.right}px`;
+
+    const currentTags = new Map<string, Tag>(
+      this.active?.tags.map((t) => [t.id, t]) ?? []
+    );
+
+    const chipsEl = popover.createDiv({ cls: "atomic-chat-scope-chips" });
+    const renderChips = () => {
+      chipsEl.empty();
+      for (const tag of currentTags.values()) {
+        const chip = chipsEl.createEl("span", { cls: "atomic-chat-scope-pill" });
+        chip.setText(`#${tag.name}`);
+        const x = chip.createEl("button", { cls: "atomic-chat-scope-remove", text: "×" });
+        x.addEventListener("click", async () => {
+          currentTags.delete(tag.id);
+          renderChips();
+          await this.commitScope([...currentTags.keys()]);
+        });
+      }
+      if (currentTags.size === 0) {
+        chipsEl.createDiv({
+          cls: "atomic-chat-scope-empty",
+          text: "No tag filter (search all notes).",
+        });
+      }
+    };
+    renderChips();
+
+    const input = popover.createEl("input", {
+      cls: "atomic-chat-scope-input",
+      attr: { placeholder: "Type a tag name…", type: "text" },
+    });
+    const suggestions = popover.createDiv({ cls: "atomic-chat-scope-suggestions" });
+
+    const flatTags = this.flatTags();
+    const updateSuggestions = () => {
+      suggestions.empty();
+      const q = input.value.trim().toLowerCase();
+      if (!q) return;
+      const matches = flatTags
+        .filter((t) => t.name.toLowerCase().includes(q) && !currentTags.has(t.id))
+        .slice(0, 8);
+      for (const tag of matches) {
+        const row = suggestions.createDiv({ cls: "atomic-chat-scope-suggest-row" });
+        row.setText(`#${tag.name}`);
+        row.addEventListener("click", async () => {
+          currentTags.set(tag.id, {
+            id: tag.id,
+            name: tag.name,
+            parent_id: tag.parent_id,
+            created_at: tag.created_at,
+          });
+          input.value = "";
+          updateSuggestions();
+          renderChips();
+          await this.commitScope([...currentTags.keys()]);
+        });
+      }
+    };
+    input.addEventListener("input", updateSuggestions);
+    input.focus();
+
+    const close = (evt: MouseEvent) => {
+      if (!popover.contains(evt.target as Node) && evt.target !== anchor) {
+        popover.remove();
+        this.scopeEditorOpen = false;
+        document.removeEventListener("mousedown", close, true);
+      }
+    };
+    document.addEventListener("mousedown", close, true);
+  }
+
+  private flatTags(): TagWithCount[] {
+    const out: TagWithCount[] = [];
+    const walk = (nodes: TagWithCount[]) => {
+      for (const n of nodes) {
+        // Hide autotag category roots (Topics, People, …) — real tags are
+        // their children. Matches the filtering we do in the wiki view.
+        if (!n.is_autotag_target) out.push(n);
+        if (n.children.length > 0) walk(n.children);
+      }
+    };
+    walk(this.allTags);
+    return out;
+  }
+
+  private async commitScope(tagIds: string[]): Promise<void> {
+    if (!this.active) return;
+    try {
+      const updated = await this.client.setConversationScope(this.active.id, tagIds);
+      this.active.tags = updated.tags;
+      this.renderHeader();
+    } catch (e) {
+      console.error("[Atomic] failed to update scope:", e);
+      new Notice("Failed to update scope");
+    }
+  }
+
+  private renderThread(): void {
+    if (!this.threadEl) return;
+    this.threadEl.empty();
+
+    if (this.loading) {
+      this.threadEl.createDiv({ cls: "atomic-chat-loading", text: "Loading…" });
+      return;
+    }
+
+    if (!this.active) return;
+
+    if (this.active.messages.length === 0 && !this.streaming) {
+      this.threadEl.createDiv({
+        cls: "atomic-chat-empty",
+        text: "Ask a question — I'll search your notes for context.",
+      });
+      return;
+    }
+
+    for (const msg of this.active.messages) {
+      this.renderMessage(msg);
+    }
+    if (this.streaming) {
+      this.renderStreamingBubble();
+    }
+    this.scrollToBottom();
+  }
+
+  private renderMessage(msg: ChatMessageWithContext): void {
+    if (!this.threadEl) return;
+    const bubble = this.threadEl.createDiv({
+      cls: `atomic-chat-msg atomic-chat-msg-${msg.role}`,
+    });
+
+    if (msg.tool_calls.length > 0) {
+      this.renderToolCalls(bubble, msg.tool_calls);
+    }
+
+    const body = bubble.createDiv({ cls: "atomic-chat-msg-body" });
+    const rewritten = this.rewriteCitations(msg.content, msg.citations);
+    const sourcePath = this.app.workspace.getActiveFile()?.path ?? "";
+    MarkdownRenderer.render(this.app, rewritten, body, sourcePath, this);
+    this.wireLinkClicks(body, sourcePath, msg.citations);
+  }
+
+  private renderStreamingBubble(): void {
+    if (!this.threadEl || !this.streaming) return;
+    // Remove any prior streaming bubble and re-add at the end.
+    this.threadEl.querySelectorAll(".atomic-chat-msg-streaming").forEach((el) => el.remove());
+
+    const bubble = this.threadEl.createDiv({
+      cls: "atomic-chat-msg atomic-chat-msg-assistant atomic-chat-msg-streaming",
+    });
+
+    if (this.streaming.toolCalls.size > 0) {
+      this.renderToolCalls(bubble, [...this.streaming.toolCalls.values()]);
+    }
+
+    const body = bubble.createDiv({ cls: "atomic-chat-msg-body" });
+    if (this.streaming.content) {
+      MarkdownRenderer.render(
+        this.app,
+        this.streaming.content,
+        body,
+        this.app.workspace.getActiveFile()?.path ?? "",
+        this
+      );
+    } else {
+      body.createDiv({ cls: "atomic-chat-typing" }).setText("•••");
+    }
+    this.scrollToBottom();
+  }
+
+  private renderToolCalls(parent: HTMLElement, calls: ChatToolCall[]): void {
+    const wrap = parent.createDiv({ cls: "atomic-chat-tool-calls" });
+    for (const call of calls) {
+      const details = wrap.createEl("details", { cls: "atomic-chat-tool-call" });
+      details.addClass(`status-${call.status}`);
+      const summary = details.createEl("summary");
+      const icon = summary.createSpan({ cls: "atomic-chat-tool-icon" });
+      setIcon(icon, call.status === "running" ? "loader" : "wrench");
+      summary.createSpan({ cls: "atomic-chat-tool-name", text: call.tool_name });
+      summary.createSpan({
+        cls: "atomic-chat-tool-status",
+        text:
+          call.status === "running"
+            ? "running…"
+            : call.status === "complete"
+            ? "done"
+            : call.status,
+      });
+      const body = details.createDiv({ cls: "atomic-chat-tool-body" });
+      body.createEl("pre", {
+        cls: "atomic-chat-tool-input",
+        text: JSON.stringify(call.tool_input, null, 2),
+      });
+      if (call.tool_output !== null && call.tool_output !== undefined) {
+        body.createEl("pre", {
+          cls: "atomic-chat-tool-output",
+          text: JSON.stringify(call.tool_output, null, 2),
+        });
+      }
+    }
+  }
+
+  /**
+   * Same citation strategy as the wiki view: `[N]` → `[[vault-path|N]]` when
+   * the cited atom's source URL points into this vault, else left as plain
+   * text. Chat citations don't include source_url on the wire, so we look up
+   * atoms lazily and rewrite what we already have cached. Uncached citations
+   * become clickable inline markers that fetch on demand.
+   */
+  private rewriteCitations(content: string, citations: ChatCitation[]): string {
+    const byIndex = new Map<number, ChatCitation>();
+    for (const c of citations) byIndex.set(c.citation_index, c);
+    const vaultPrefix = `obsidian://${this.getVaultName()}/`;
+
+    return content.replace(/\[(\d+)\]/g, (match, idxStr) => {
+      const index = parseInt(idxStr, 10);
+      const cit = byIndex.get(index);
+      if (!cit) return match;
+
+      const atom = this.atomCache.get(cit.atom_id);
+      const url = atom?.source_url ?? null;
+      if (url && url.startsWith(vaultPrefix)) {
+        try {
+          const encoded = url.slice(vaultPrefix.length);
+          const path = encoded
+            .split("/")
+            .map((seg) => decodeURIComponent(seg))
+            .join("/")
+            .replace(/\.md$/i, "");
+          return `[[${path}|${index}]]`;
+        } catch {
+          return match;
+        }
+      }
+      // Not cached (or not a vault atom) — render as a sentinel marker that
+      // our click handler can recognize. We use a Markdown footnote-style
+      // anchor so react-markdown renders it as a link we can intercept.
+      return `[${index}](atomic-citation:${cit.atom_id})`;
+    });
+  }
+
+  private wireLinkClicks(
+    root: HTMLElement,
+    sourcePath: string,
+    citations: ChatCitation[]
+  ): void {
+    root.addEventListener(
+      "click",
+      async (evt) => {
+        const target = evt.target as HTMLElement | null;
+        const link = target?.closest("a") as HTMLAnchorElement | null;
+        if (!link) return;
+        evt.preventDefault();
+        evt.stopPropagation();
+
+        const href = link.getAttribute("data-href") ?? link.getAttribute("href") ?? "";
+
+        // Uncached citation marker — fetch atom, cache, then either open the
+        // vault note or show the excerpt.
+        if (href.startsWith("atomic-citation:")) {
+          const atomId = href.slice("atomic-citation:".length);
+          await this.handleCitationClick(atomId, citations);
+          return;
+        }
+
+        // Cross-wiki reference — switch the wiki view isn't available here,
+        // so fall back to Obsidian's link resolution, which will treat it as
+        // a vault note if one exists.
+        const newLeaf = evt.ctrlKey || evt.metaKey;
+        this.app.workspace.openLinkText(href, sourcePath, newLeaf);
+      },
+      true
+    );
+  }
+
+  private async handleCitationClick(atomId: string, citations: ChatCitation[]): Promise<void> {
+    let atom = this.atomCache.get(atomId);
+    if (!atom) {
+      try {
+        atom = await this.client.getAtom(atomId);
+        this.atomCache.set(atomId, atom);
+      } catch (e) {
+        console.error("[Atomic] failed to fetch cited atom:", e);
+        new Notice("Could not fetch cited atom");
+        return;
+      }
+    }
+
+    const vaultPrefix = `obsidian://${this.getVaultName()}/`;
+    if (atom.source_url && atom.source_url.startsWith(vaultPrefix)) {
+      try {
+        const path = atom.source_url
+          .slice(vaultPrefix.length)
+          .split("/")
+          .map((s) => decodeURIComponent(s))
+          .join("/");
+        await this.app.workspace.openLinkText(path, "", false);
+      } catch (e) {
+        console.error("[Atomic] open note failed:", e);
+      }
+      return;
+    }
+
+    const cit = citations.find((c) => c.atom_id === atomId);
+    const excerpt = cit?.excerpt ?? atom.snippet ?? "";
+    new Notice(
+      `${atom.title || "Cited atom"}\n\n${excerpt.slice(0, 200)}${
+        excerpt.length > 200 ? "…" : ""
+      }`,
+      8000
+    );
+  }
+
+  private autoResizeInput(): void {
+    if (!this.inputEl) return;
+    this.inputEl.style.height = "auto";
+    this.inputEl.style.height = `${Math.min(this.inputEl.scrollHeight, 200)}px`;
+  }
+
+  private updateSendButton(): void {
+    if (!this.sendBtn || !this.inputEl) return;
+    const hasText = this.inputEl.value.trim().length > 0;
+    this.sendBtn.disabled = !hasText || this.sending;
+  }
+
+  private scrollToBottom(): void {
+    if (!this.threadEl) return;
+    this.threadEl.scrollTop = this.threadEl.scrollHeight;
+  }
+}

--- a/plugins/obsidian-plugin/src/main.ts
+++ b/plugins/obsidian-plugin/src/main.ts
@@ -6,6 +6,8 @@ import { SyncState, type SyncStateData } from "./sync-state";
 import { SearchModal } from "./search-modal";
 import { SimilarView, SIMILAR_VIEW_TYPE } from "./similar-view";
 import { WikiView, WIKI_VIEW_TYPE } from "./wiki-view";
+import { ChatView, CHAT_VIEW_TYPE } from "./chat-view";
+import { AtomicWebSocket } from "./ws-client";
 import { OnboardingModal } from "./onboarding-modal";
 
 interface PluginData {
@@ -16,12 +18,14 @@ interface PluginData {
 export default class AtomicPlugin extends Plugin {
   settings: AtomicSettings = DEFAULT_SETTINGS;
   client: AtomicClient = new AtomicClient(this.settings);
+  ws: AtomicWebSocket = new AtomicWebSocket(this.settings);
   syncEngine!: SyncEngine;
   private syncState: SyncState = new SyncState();
 
   async onload(): Promise<void> {
     await this.loadSettings();
     this.client = new AtomicClient(this.settings);
+    this.ws = new AtomicWebSocket(this.settings);
 
     this.syncEngine = new SyncEngine(
       this.app,
@@ -71,6 +75,12 @@ export default class AtomicPlugin extends Plugin {
     });
 
     this.addCommand({
+      id: "open-chat",
+      name: "Open Chat",
+      callback: () => this.activateView(CHAT_VIEW_TYPE),
+    });
+
+    this.addCommand({
       id: "setup-wizard",
       name: "Setup Wizard",
       callback: () => new OnboardingModal(this.app, this).open(),
@@ -85,6 +95,13 @@ export default class AtomicPlugin extends Plugin {
     this.registerView(WIKI_VIEW_TYPE, (leaf) => new WikiView(
       leaf,
       this.client,
+      () => this.settings.vaultName || this.app.vault.getName(),
+    ));
+
+    this.registerView(CHAT_VIEW_TYPE, (leaf) => new ChatView(
+      leaf,
+      this.client,
+      this.ws,
       () => this.settings.vaultName || this.app.vault.getName(),
     ));
 
@@ -109,6 +126,7 @@ export default class AtomicPlugin extends Plugin {
 
   async onunload(): Promise<void> {
     this.syncEngine.stopWatching();
+    this.ws.close();
   }
 
   async loadSettings(): Promise<void> {
@@ -117,6 +135,7 @@ export default class AtomicPlugin extends Plugin {
   }
 
   async saveSettings(): Promise<void> {
+    this.ws.updateSettings(this.settings);
     await this.savePluginData();
   }
 

--- a/plugins/obsidian-plugin/src/wiki-view.ts
+++ b/plugins/obsidian-plugin/src/wiki-view.ts
@@ -10,6 +10,7 @@ export class WikiView extends ItemView {
   private selectedTagId: string | null = null;
   private article: WikiArticleWithCitations | null = null;
   private loading = false;
+  private generatingAtomCount: number | null = null;
 
   constructor(leaf: WorkspaceLeaf, client: AtomicClient, getVaultName: () => string) {
     super(leaf);
@@ -45,6 +46,16 @@ export class WikiView extends ItemView {
   private flattenTags(tags: TagWithCount[], depth = 0): Array<{ tag: TagWithCount; depth: number }> {
     const result: Array<{ tag: TagWithCount; depth: number }> = [];
     for (const tag of tags) {
+      // Autotag category roots (Topics, People, Locations, …) aren't meaningful
+      // wiki subjects on their own — they're buckets for extracted tags. Skip
+      // the bucket itself but surface its children at the current depth so the
+      // real tags remain selectable.
+      if (tag.is_autotag_target) {
+        if (tag.children.length > 0) {
+          result.push(...this.flattenTags(tag.children, depth));
+        }
+        continue;
+      }
       result.push({ tag, depth });
       if (tag.children.length > 0) {
         result.push(...this.flattenTags(tag.children, depth + 1));
@@ -110,7 +121,8 @@ export class WikiView extends ItemView {
     wrapper.querySelectorAll(".atomic-wiki-content, .atomic-wiki-empty, .atomic-wiki-actions").forEach((el) => el.remove());
 
     if (this.loading) {
-      wrapper.createDiv({ cls: "atomic-wiki-empty", text: "Loading..." });
+      const name = this.findTagName(this.selectedTagId ?? "") ?? "";
+      this.renderGenerating(wrapper, name, this.generatingAtomCount);
       return;
     }
 
@@ -135,15 +147,18 @@ export class WikiView extends ItemView {
           genBtn.setText("Tag not found");
           return;
         }
-        genBtn.disabled = true;
-        genBtn.setText("Generating...");
+        this.generatingAtomCount = this.findTagAtomCount(this.selectedTagId);
+        this.loading = true;
+        this.renderContent(wrapper);
         try {
           this.article = await this.client.generateWikiArticle(this.selectedTagId, tagName);
-          this.renderContent(wrapper);
         } catch (e) {
-          genBtn.setText("Failed - Retry");
-          genBtn.disabled = false;
           console.error("Atomic: Failed to generate wiki:", e);
+          this.article = null;
+        } finally {
+          this.loading = false;
+          this.generatingAtomCount = null;
+          this.renderContent(wrapper);
         }
       });
       return;
@@ -154,7 +169,37 @@ export class WikiView extends ItemView {
       this.article.article.content,
       this.article.citations
     );
-    MarkdownRenderer.render(this.app, rewritten, contentEl, "", this);
+    const sourcePath = this.app.workspace.getActiveFile()?.path ?? "";
+    MarkdownRenderer.render(this.app, rewritten, contentEl, sourcePath, this);
+
+    // Obsidian's global click handler for .internal-link is scoped to
+    // markdown file views, not custom ItemViews — wire it up manually.
+    contentEl.addEventListener("click", async (evt) => {
+      const target = evt.target as HTMLElement | null;
+      const link = target?.closest("a") as HTMLAnchorElement | null;
+      if (!link) return;
+      evt.preventDefault();
+      evt.stopPropagation();
+      const href = link.getAttribute("data-href") ?? link.getAttribute("href");
+      if (!href) return;
+
+      // Cross-wiki references: the LLM emits `[[Other Topic]]` when another
+      // wiki article exists for that tag. These look identical to Obsidian
+      // wikilinks, so we check the tag list first and switch the view when
+      // the target matches a known tag (case-insensitive, same as the core).
+      const tagMatch = this.findTagByName(href);
+      if (tagMatch) {
+        this.selectedTagId = tagMatch.id;
+        const select = wrapper.querySelector<HTMLSelectElement>(".atomic-wiki-tag-select");
+        if (select) select.value = tagMatch.id;
+        await this.loadArticle(tagMatch.id);
+        this.renderContent(wrapper);
+        return;
+      }
+
+      const newLeaf = evt.ctrlKey || evt.metaKey;
+      this.app.workspace.openLinkText(href, sourcePath, newLeaf);
+    }, true);
   }
 
   /**
@@ -202,8 +247,63 @@ export class WikiView extends ItemView {
         return ""; // malformed encoding — strip rather than render garbage
       }
       const target = path.replace(/\.md$/i, "");
-      return `[[${target}]]`;
+      // Use a wikilink alias so the citation renders as `[N]` inline
+      // instead of the full note name, which was swamping the prose.
+      // Obsidian resolves `[[target|alias]]` to the target file on click.
+      return `[[${target}|${index}]]`;
     });
+  }
+
+  private renderGenerating(wrapper: HTMLElement, tagName: string, atomCount: number | null): void {
+    const el = wrapper.createDiv({ cls: "atomic-wiki-generating" });
+
+    const spinner = el.createDiv({ cls: "atomic-wiki-spinner" });
+    spinner.innerHTML = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>`;
+
+    const title = tagName
+      ? `Synthesizing article about "${tagName}"…`
+      : "Loading…";
+    el.createEl("h3", { cls: "atomic-wiki-generating-title", text: title });
+
+    if (atomCount !== null && atomCount > 0) {
+      el.createEl("p", {
+        cls: "atomic-wiki-generating-sub",
+        text: `Processing ${atomCount} source${atomCount === 1 ? "" : "s"}`,
+      });
+    }
+    el.createEl("p", {
+      cls: "atomic-wiki-generating-hint",
+      text: "This may take a moment",
+    });
+  }
+
+  private findTagByName(name: string): TagWithCount | null {
+    const needle = name.trim().toLowerCase();
+    const search = (nodes: TagWithCount[]): TagWithCount | null => {
+      for (const node of nodes) {
+        if (node.name.toLowerCase() === needle) return node;
+        if (node.children.length > 0) {
+          const found = search(node.children);
+          if (found) return found;
+        }
+      }
+      return null;
+    };
+    return search(this.tags);
+  }
+
+  private findTagAtomCount(tagId: string): number | null {
+    const search = (nodes: TagWithCount[]): number | null => {
+      for (const node of nodes) {
+        if (node.id === tagId) return node.atom_count;
+        if (node.children.length > 0) {
+          const found = search(node.children);
+          if (found !== null) return found;
+        }
+      }
+      return null;
+    };
+    return search(this.tags);
   }
 
   private findTagName(tagId: string): string | null {

--- a/plugins/obsidian-plugin/src/ws-client.ts
+++ b/plugins/obsidian-plugin/src/ws-client.ts
@@ -1,0 +1,138 @@
+import type { AtomicSettings } from "./settings";
+
+/**
+ * ServerEvent types from atomic-server (wire tag is PascalCase on the `type` field).
+ * We only declare the subset the Obsidian plugin currently listens for; other
+ * events are passed through to subscribers that care.
+ */
+export type ServerEvent =
+  | { type: "ChatStreamDelta"; conversation_id: string; content: string }
+  | {
+      type: "ChatToolStart";
+      conversation_id: string;
+      tool_call_id: string;
+      tool_name: string;
+      tool_input: unknown;
+    }
+  | {
+      type: "ChatToolComplete";
+      conversation_id: string;
+      tool_call_id: string;
+      results_count: number;
+    }
+  | { type: "ChatComplete"; conversation_id: string; message: unknown }
+  | { type: "ChatError"; conversation_id: string; error: string }
+  | { type: string; [key: string]: unknown };
+
+export type EventHandler = (event: ServerEvent) => void;
+
+/**
+ * Thin WebSocket wrapper: connects to `{wsBase}/ws?token=…`, reconnects with
+ * exponential backoff while `open()` has been called, and fans events out to
+ * registered handlers. Handlers should filter by `event.type` themselves.
+ */
+export class AtomicWebSocket {
+  private settings: AtomicSettings;
+  private socket: WebSocket | null = null;
+  private handlers = new Set<EventHandler>();
+  private wantOpen = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: number | null = null;
+
+  constructor(settings: AtomicSettings) {
+    this.settings = settings;
+  }
+
+  updateSettings(settings: AtomicSettings): void {
+    const reconnectNeeded =
+      this.wantOpen &&
+      (settings.serverUrl !== this.settings.serverUrl ||
+        settings.authToken !== this.settings.authToken);
+    this.settings = settings;
+    if (reconnectNeeded) {
+      this.close();
+      this.open();
+    }
+  }
+
+  on(handler: EventHandler): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+
+  open(): void {
+    this.wantOpen = true;
+    if (this.socket && this.socket.readyState <= WebSocket.OPEN) return;
+    this.connect();
+  }
+
+  close(): void {
+    this.wantOpen = false;
+    if (this.reconnectTimer !== null) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+  }
+
+  private connect(): void {
+    const url = this.buildUrl();
+    if (!url) return;
+    try {
+      this.socket = new WebSocket(url);
+    } catch (e) {
+      console.error("[Atomic] WS construct failed:", e);
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.socket.addEventListener("open", () => {
+      this.reconnectAttempt = 0;
+    });
+    this.socket.addEventListener("message", (evt) => {
+      let data: ServerEvent;
+      try {
+        data = JSON.parse(evt.data);
+      } catch {
+        return;
+      }
+      for (const handler of this.handlers) {
+        try {
+          handler(data);
+        } catch (e) {
+          console.error("[Atomic] WS handler threw:", e);
+        }
+      }
+    });
+    this.socket.addEventListener("close", () => {
+      this.socket = null;
+      if (this.wantOpen) this.scheduleReconnect();
+    });
+    this.socket.addEventListener("error", () => {
+      // "close" fires after error; let that path handle reconnect.
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.wantOpen || this.reconnectTimer !== null) return;
+    // 500ms, 1s, 2s, 4s, 8s, 15s (cap) — matches what users tolerate when the
+    // server is briefly restarting during dev.
+    const delays = [500, 1000, 2000, 4000, 8000, 15000];
+    const delay = delays[Math.min(this.reconnectAttempt, delays.length - 1)];
+    this.reconnectAttempt++;
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay);
+  }
+
+  private buildUrl(): string | null {
+    const base = this.settings.serverUrl.replace(/\/+$/, "");
+    if (!base || !this.settings.authToken) return null;
+    const wsBase = base.replace(/^http:/i, "ws:").replace(/^https:/i, "wss:");
+    return `${wsBase}/ws?token=${encodeURIComponent(this.settings.authToken)}`;
+  }
+}

--- a/plugins/obsidian-plugin/styles.css
+++ b/plugins/obsidian-plugin/styles.css
@@ -82,6 +82,425 @@
   padding: 32px 16px;
 }
 
+.atomic-wiki-generating {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 48px 24px;
+}
+
+.atomic-wiki-spinner {
+  width: 64px;
+  height: 64px;
+  color: var(--interactive-accent);
+  margin-bottom: 24px;
+  animation: atomic-wiki-spin 1s linear infinite;
+}
+
+.atomic-wiki-spinner svg {
+  width: 100%;
+  height: 100%;
+}
+
+.atomic-wiki-generating-title {
+  font-size: 1.05em;
+  font-weight: 500;
+  color: var(--text-normal);
+  margin: 0 0 6px;
+}
+
+.atomic-wiki-generating-sub {
+  font-size: 0.85em;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.atomic-wiki-generating-hint {
+  font-size: 0.75em;
+  color: var(--text-faint);
+  margin: 12px 0 0;
+}
+
+@keyframes atomic-wiki-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Chat view */
+.atomic-chat-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 0;
+}
+
+.atomic-chat-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.atomic-chat-title {
+  flex: 1;
+  font-weight: 600;
+  font-size: 0.95em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.atomic-chat-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.atomic-chat-scope-chip {
+  background: var(--background-modifier-hover);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 12px;
+  padding: 2px 10px;
+  font-size: 0.8em;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.atomic-chat-scope-chip:hover {
+  color: var(--text-normal);
+  border-color: var(--interactive-accent);
+}
+
+.atomic-chat-icon-btn {
+  background: transparent;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  color: var(--text-muted);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.atomic-chat-icon-btn:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+.atomic-chat-conv-list {
+  border-bottom: 1px solid var(--background-modifier-border);
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--background-secondary);
+}
+
+.atomic-chat-conv-list.hidden {
+  display: none;
+}
+
+.atomic-chat-conv-row {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--background-modifier-border);
+  cursor: pointer;
+}
+
+.atomic-chat-conv-row:hover {
+  background: var(--background-modifier-hover);
+}
+
+.atomic-chat-conv-row.active {
+  background: var(--background-modifier-hover);
+  border-left: 2px solid var(--interactive-accent);
+}
+
+.atomic-chat-conv-title {
+  font-size: 0.9em;
+  color: var(--text-normal);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.atomic-chat-conv-tags {
+  font-size: 0.75em;
+  color: var(--text-faint);
+  margin-top: 2px;
+}
+
+.atomic-chat-conv-empty {
+  padding: 16px;
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 0.85em;
+}
+
+.atomic-chat-thread {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.atomic-chat-empty,
+.atomic-chat-loading {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 24px 12px;
+  font-size: 0.9em;
+}
+
+.atomic-chat-msg {
+  max-width: 90%;
+  padding: 8px 12px;
+  border-radius: 10px;
+  line-height: 1.5;
+  font-size: 0.9em;
+  word-wrap: break-word;
+}
+
+.atomic-chat-msg p {
+  margin: 0 0 8px;
+}
+
+.atomic-chat-msg p:last-child {
+  margin-bottom: 0;
+}
+
+.atomic-chat-msg pre {
+  font-size: 0.85em;
+  overflow-x: auto;
+}
+
+.atomic-chat-msg-user {
+  align-self: flex-end;
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+}
+
+.atomic-chat-msg-user a {
+  color: var(--text-on-accent);
+  text-decoration: underline;
+}
+
+.atomic-chat-msg-assistant {
+  align-self: flex-start;
+  background: var(--background-secondary);
+}
+
+.atomic-chat-msg-tool {
+  align-self: stretch;
+  background: transparent;
+  padding: 0;
+}
+
+.atomic-chat-typing {
+  color: var(--text-muted);
+  letter-spacing: 2px;
+  animation: atomic-chat-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes atomic-chat-pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+.atomic-chat-tool-calls {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.atomic-chat-tool-call {
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-primary);
+  font-size: 0.8em;
+}
+
+.atomic-chat-tool-call summary {
+  padding: 4px 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  list-style: none;
+}
+
+.atomic-chat-tool-call summary::-webkit-details-marker {
+  display: none;
+}
+
+.atomic-chat-tool-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-muted);
+}
+
+.atomic-chat-tool-call.status-running .atomic-chat-tool-icon {
+  color: var(--interactive-accent);
+  animation: atomic-wiki-spin 1s linear infinite;
+}
+
+.atomic-chat-tool-call.status-failed .atomic-chat-tool-icon {
+  color: var(--color-red);
+}
+
+.atomic-chat-tool-name {
+  font-family: var(--font-monospace);
+  color: var(--text-normal);
+}
+
+.atomic-chat-tool-status {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 0.9em;
+}
+
+.atomic-chat-tool-body {
+  padding: 6px 8px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.atomic-chat-tool-body pre {
+  margin: 0 0 4px;
+  font-size: 0.85em;
+  background: var(--background-secondary);
+  padding: 6px;
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.atomic-chat-input-wrap {
+  display: flex;
+  gap: 6px;
+  padding: 8px 10px;
+  border-top: 1px solid var(--background-modifier-border);
+  align-items: flex-end;
+}
+
+.atomic-chat-input {
+  flex: 1;
+  resize: none;
+  min-height: 32px;
+  max-height: 200px;
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: 0.9em;
+  line-height: 1.4;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-primary);
+  color: var(--text-normal);
+}
+
+.atomic-chat-input:focus {
+  outline: none;
+  border-color: var(--interactive-accent);
+}
+
+.atomic-chat-send {
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border: none;
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.atomic-chat-send:disabled {
+  background: var(--background-modifier-border);
+  color: var(--text-faint);
+  cursor: not-allowed;
+}
+
+/* Scope editor popover */
+.atomic-chat-scope-popover {
+  position: absolute;
+  min-width: 240px;
+  max-width: 320px;
+  background: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  padding: 10px;
+  z-index: 100;
+}
+
+.atomic-chat-scope-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.atomic-chat-scope-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--background-modifier-hover);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 10px;
+  padding: 2px 4px 2px 8px;
+  font-size: 0.8em;
+}
+
+.atomic-chat-scope-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1em;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.atomic-chat-scope-remove:hover {
+  color: var(--color-red);
+}
+
+.atomic-chat-scope-empty {
+  font-size: 0.8em;
+  color: var(--text-faint);
+  padding: 2px 0;
+}
+
+.atomic-chat-scope-input {
+  width: 100%;
+  padding: 4px 8px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  background: var(--background-primary);
+  color: var(--text-normal);
+  font-size: 0.85em;
+}
+
+.atomic-chat-scope-suggestions {
+  margin-top: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.atomic-chat-scope-suggest-row {
+  padding: 4px 8px;
+  font-size: 0.85em;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.atomic-chat-scope-suggest-row:hover {
+  background: var(--background-modifier-hover);
+}
+
 /* Onboarding wizard */
 .atomic-onboarding-modal .modal-content {
   padding: 0;

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, Fragment, ReactNode } from 'react';
-import { ChatMessageWithContext, ChatCitation } from '../../stores/chat';
+import { CheckCircle2, Loader2, Wrench, XCircle } from 'lucide-react';
+import { ChatMessageWithContext, ChatCitation, ChatToolCall } from '../../stores/chat';
 import { CitationLink, CitationPopover } from '../wiki';
 import { MarkdownImage } from '../ui/MarkdownImage';
 import ReactMarkdown from 'react-markdown';
@@ -180,16 +181,35 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
               : 'bg-[var(--color-bg-card)] text-[var(--color-text-primary)]'
           }`}
         >
+          {/* Tool calls — render above message content so users see the
+              retrieval steps before the prose that references them. Rendered
+              during streaming (from streamingToolCalls) and persisted after
+              completion (from message.tool_calls). */}
+          {isAssistant && message.tool_calls && message.tool_calls.length > 0 && (
+            <ToolCallList calls={message.tool_calls} />
+          )}
+
           {/* Message content */}
           {isAssistant ? (
-            <div className="prose prose-invert prose-sm max-w-none prose-headings:text-[var(--color-text-primary)] prose-p:text-[var(--color-text-primary)] prose-a:text-[var(--color-text-primary)] prose-a:underline prose-a:decoration-[var(--color-border-hover)] prose-a:hover:decoration-current prose-strong:text-[var(--color-text-primary)] prose-code:text-[var(--color-accent-light)] prose-code:bg-[var(--color-bg-card)] prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-[var(--color-bg-card)] prose-pre:border prose-pre:border-[var(--color-border)] prose-blockquote:border-l-[var(--color-accent)] prose-blockquote:text-[var(--color-text-secondary)] prose-li:text-[var(--color-text-primary)] prose-hr:border-[var(--color-border)]">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                components={markdownComponents}
-              >
-                {message.content}
-              </ReactMarkdown>
-            </div>
+            message.content ? (
+              <div className="prose prose-invert prose-sm max-w-none prose-headings:text-[var(--color-text-primary)] prose-p:text-[var(--color-text-primary)] prose-a:text-[var(--color-text-primary)] prose-a:underline prose-a:decoration-[var(--color-border-hover)] prose-a:hover:decoration-current prose-strong:text-[var(--color-text-primary)] prose-code:text-[var(--color-accent-light)] prose-code:bg-[var(--color-bg-card)] prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-[var(--color-bg-card)] prose-pre:border prose-pre:border-[var(--color-border)] prose-blockquote:border-l-[var(--color-accent)] prose-blockquote:text-[var(--color-text-secondary)] prose-li:text-[var(--color-text-primary)] prose-hr:border-[var(--color-border)]">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={markdownComponents}
+                >
+                  {message.content}
+                </ReactMarkdown>
+              </div>
+            ) : isStreaming ? (
+              <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+                <div className="flex gap-1">
+                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-bounce" style={{ animationDelay: '0ms' }} />
+                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-bounce" style={{ animationDelay: '150ms' }} />
+                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-bounce" style={{ animationDelay: '300ms' }} />
+                </div>
+                <span>Thinking…</span>
+              </div>
+            ) : null
           ) : (
             <p className="whitespace-pre-wrap text-sm">
               {searchQuery.trim() && highlightText
@@ -198,8 +218,8 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
             </p>
           )}
 
-          {/* Streaming indicator */}
-          {isStreaming && (
+          {/* Streaming indicator (cursor) — only once content has started */}
+          {isStreaming && message.content && (
             <span className="inline-block w-2 h-4 ml-1 bg-[var(--color-accent-light)] animate-pulse" />
           )}
 
@@ -222,27 +242,6 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
             </div>
           )}
 
-          {/* Tool calls (collapsible) */}
-          {isAssistant && message.tool_calls && message.tool_calls.length > 0 && (
-            <details className="mt-3 pt-3 border-t border-[var(--color-border)]">
-              <summary className="text-xs text-[var(--color-text-secondary)] cursor-pointer hover:text-[var(--color-accent-light)]">
-                {message.tool_calls.length} retrieval step{message.tool_calls.length !== 1 ? 's' : ''}
-              </summary>
-              <div className="mt-2 space-y-2">
-                {message.tool_calls.map((toolCall) => (
-                  <div
-                    key={toolCall.id}
-                    className="text-xs p-2 bg-[var(--color-bg-main)] rounded"
-                  >
-                    <span className="text-[var(--color-accent)]">{toolCall.tool_name}</span>
-                    <span className="text-[var(--color-text-tertiary)] ml-2">
-                      {toolCall.status === 'complete' ? '✓' : toolCall.status}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </details>
-          )}
         </div>
       </div>
 
@@ -256,5 +255,76 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
         />
       )}
     </>
+  );
+}
+
+function ToolCallList({ calls }: { calls: ChatToolCall[] }) {
+  return (
+    <div className="mb-2 space-y-1">
+      {calls.map((call) => (
+        <ToolCallCard key={call.id} call={call} />
+      ))}
+    </div>
+  );
+}
+
+function ToolCallCard({ call }: { call: ChatToolCall }) {
+  const statusIcon =
+    call.status === 'running' ? (
+      <Loader2 className="w-3.5 h-3.5 text-[var(--color-accent-light)] animate-spin" />
+    ) : call.status === 'failed' ? (
+      <XCircle className="w-3.5 h-3.5 text-red-400" />
+    ) : call.status === 'complete' ? (
+      <CheckCircle2 className="w-3.5 h-3.5 text-[var(--color-accent-light)]" />
+    ) : (
+      <Wrench className="w-3.5 h-3.5 text-[var(--color-text-tertiary)]" />
+    );
+
+  const resultsCount =
+    call.tool_output && typeof call.tool_output === 'object' && call.tool_output !== null
+      ? (call.tool_output as { results_count?: number }).results_count
+      : undefined;
+
+  const summaryText =
+    call.status === 'running'
+      ? 'running…'
+      : resultsCount !== undefined
+      ? `${resultsCount} result${resultsCount === 1 ? '' : 's'}`
+      : call.status;
+
+  return (
+    <details className="group text-xs bg-[var(--color-bg-main)] rounded border border-[var(--color-border)] open:border-[var(--color-border-hover)]">
+      <summary className="flex items-center gap-2 px-2 py-1.5 cursor-pointer list-none hover:bg-[var(--color-bg-hover)]">
+        {statusIcon}
+        <span className="font-mono text-[var(--color-accent)]">{call.tool_name}</span>
+        <span className="ml-auto text-[var(--color-text-tertiary)]">{summaryText}</span>
+      </summary>
+      <div className="px-2 pb-2 pt-1 border-t border-[var(--color-border)] space-y-2">
+        <ToolJsonBlock label="input" value={call.tool_input} />
+        {call.tool_output !== null && call.tool_output !== undefined && (
+          <ToolJsonBlock label="output" value={call.tool_output} />
+        )}
+      </div>
+    </details>
+  );
+}
+
+function ToolJsonBlock({ label, value }: { label: string; value: unknown }) {
+  const formatted = (() => {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  })();
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wide text-[var(--color-text-tertiary)] mb-0.5">
+        {label}
+      </div>
+      <pre className="text-[11px] whitespace-pre-wrap break-words bg-[var(--color-bg-card)] rounded px-2 py-1.5 text-[var(--color-text-secondary)]">
+        {formatted}
+      </pre>
+    </div>
   );
 }

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import { MessageSquare, Search as SearchIcon } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
 import { useChatStore } from '../../stores/chat';
 import { useUIStore } from '../../stores/ui';
 import { useChatEvents } from '../../hooks/useChatEvents';
@@ -15,7 +15,7 @@ export function ChatView() {
   const isLoading = useChatStore(s => s.isLoading);
   const isStreaming = useChatStore(s => s.isStreaming);
   const streamingContent = useChatStore(s => s.streamingContent);
-  const retrievalSteps = useChatStore(s => s.retrievalSteps);
+  const streamingToolCalls = useChatStore(s => s.streamingToolCalls);
   const error = useChatStore(s => s.error);
   const sendMessage = useChatStore(s => s.sendMessage);
   const goBack = useChatStore(s => s.goBack);
@@ -168,41 +168,11 @@ export function ChatView() {
           />
         ))}
 
-        {/* Thinking indicator — before any streaming content arrives */}
-        {isStreaming && !streamingContent && (
-          <div className="flex justify-start">
-            <div className="max-w-[85%] rounded-lg px-4 py-3 bg-[var(--color-bg-card)] text-[var(--color-text-primary)]">
-              <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-                <div className="flex gap-1">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-bounce" style={{ animationDelay: '0ms' }} />
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-bounce" style={{ animationDelay: '150ms' }} />
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)] animate-bounce" style={{ animationDelay: '300ms' }} />
-                </div>
-                <span>Thinking…</span>
-              </div>
-              {retrievalSteps.length > 0 && (
-                <div className="mt-2 space-y-1">
-                  {retrievalSteps.map((step, i) => {
-                    let displayQuery = step.query;
-                    try {
-                      const parsed = JSON.parse(step.query);
-                      displayQuery = parsed.query || parsed.search || parsed.text || step.query;
-                    } catch { /* use raw */ }
-                    return (
-                      <div key={i} className="flex items-center gap-2 text-xs text-[var(--color-text-tertiary)]">
-                        <SearchIcon className="w-3 h-3 flex-shrink-0 animate-pulse" />
-                        <span className="truncate">Searching: {displayQuery}</span>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-
-        {/* Streaming message */}
-        {isStreaming && streamingContent && (
+        {/* Streaming bubble — rendered for the whole streaming turn so tool
+            calls show up while the model is still thinking and persist as
+            streaming content flows in. ChatMessage handles the empty-content
+            "Thinking…" fallback. */}
+        {isStreaming && (
           <ChatMessage
             message={{
               id: 'streaming',
@@ -211,7 +181,7 @@ export function ChatView() {
               content: streamingContent,
               created_at: new Date().toISOString(),
               message_index: messages.length,
-              tool_calls: [],
+              tool_calls: streamingToolCalls,
               citations: [],
             }}
             isStreaming

--- a/src/hooks/useChatEvents.ts
+++ b/src/hooks/useChatEvents.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { getTransport } from '../lib/transport';
-import { useChatStore, ChatMessageWithContext, RetrievalStep } from '../stores/chat';
+import { useChatStore, ChatMessageWithContext } from '../stores/chat';
 
 interface ChatStreamDelta {
   conversation_id: string;
@@ -32,7 +32,8 @@ interface ChatError {
 
 export function useChatEvents(conversationId: string | null) {
   const appendStreamContent = useChatStore(s => s.appendStreamContent);
-  const addRetrievalStep = useChatStore(s => s.addRetrievalStep);
+  const startStreamingToolCall = useChatStore(s => s.startStreamingToolCall);
+  const completeStreamingToolCall = useChatStore(s => s.completeStreamingToolCall);
   const completeMessage = useChatStore(s => s.completeMessage);
   const setStreamingError = useChatStore(s => s.setStreamingError);
 
@@ -42,43 +43,37 @@ export function useChatEvents(conversationId: string | null) {
     const transport = getTransport();
     const unsubs: Array<() => void> = [];
 
-    // Listen for streaming content
     unsubs.push(transport.subscribe<ChatStreamDelta>('chat-stream-delta', (payload) => {
       if (payload.conversation_id === conversationId) {
         appendStreamContent(payload.content);
       }
     }));
 
-    // Listen for tool start
     unsubs.push(transport.subscribe<ChatToolStart>('chat-tool-start', (payload) => {
       if (payload.conversation_id === conversationId) {
-        const step: RetrievalStep = {
-          step_number: Date.now(), // Temporary, will be replaced
+        startStreamingToolCall({
+          tool_call_id: payload.tool_call_id,
           tool_name: payload.tool_name,
-          query: JSON.stringify(payload.tool_input),
-          results_count: 0,
-          timestamp: new Date().toISOString(),
-        };
-        addRetrievalStep(step);
+          tool_input: payload.tool_input,
+        });
       }
     }));
 
-    // Listen for tool complete
     unsubs.push(transport.subscribe<ChatToolComplete>('chat-tool-complete', (payload) => {
       if (payload.conversation_id === conversationId) {
-        // Update the last retrieval step with results count
-        // For now, this is handled by the store
+        completeStreamingToolCall({
+          tool_call_id: payload.tool_call_id,
+          results_count: payload.results_count,
+        });
       }
     }));
 
-    // Listen for completion
     unsubs.push(transport.subscribe<ChatComplete>('chat-complete', (payload) => {
       if (payload.conversation_id === conversationId) {
         completeMessage(payload.message);
       }
     }));
 
-    // Listen for errors
     unsubs.push(transport.subscribe<ChatError>('chat-error', (payload) => {
       if (payload.conversation_id === conversationId) {
         setStreamingError(payload.error);
@@ -88,5 +83,5 @@ export function useChatEvents(conversationId: string | null) {
     return () => {
       unsubs.forEach((unsub) => unsub());
     };
-  }, [conversationId, appendStreamContent, addRetrievalStep, completeMessage, setStreamingError]);
+  }, [conversationId, appendStreamContent, startStreamingToolCall, completeStreamingToolCall, completeMessage, setStreamingError]);
 }

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -66,13 +66,6 @@ export interface ConversationWithMessages extends Conversation {
   messages: ChatMessageWithContext[];
 }
 
-export interface RetrievalStep {
-  step_number: number;
-  tool_name: string;
-  query: string;
-  results_count: number;
-  timestamp: string;
-}
 
 // ==================== Store ====================
 
@@ -95,7 +88,13 @@ interface ChatStore {
   isStreaming: boolean;
   streamingContent: string;
   streamingMessageId: string | null;
-  retrievalSteps: RetrievalStep[];
+  /**
+   * Tool calls fired during the current streaming turn. Populated from
+   * chat-tool-start / chat-tool-complete events so the UI can render
+   * collapsible cards that persist through streaming and get superseded
+   * (not discarded) when the final ChatComplete message arrives.
+   */
+  streamingToolCalls: ChatToolCall[];
 
   // Error state
   error: string | null;
@@ -123,7 +122,8 @@ interface ChatStore {
 
   // Actions - Streaming updates (called from event handlers)
   appendStreamContent: (delta: string) => void;
-  addRetrievalStep: (step: RetrievalStep) => void;
+  startStreamingToolCall: (call: { tool_call_id: string; tool_name: string; tool_input: unknown }) => void;
+  completeStreamingToolCall: (update: { tool_call_id: string; results_count: number }) => void;
   completeMessage: (message: ChatMessageWithContext) => void;
   setStreamingError: (error: string) => void;
 
@@ -143,7 +143,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   isStreaming: false,
   streamingContent: '',
   streamingMessageId: null,
-  retrievalSteps: [],
+  streamingToolCalls: [],
   error: null,
 
   // Navigation
@@ -221,7 +221,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       currentConversation: null,
       messages: [],
       streamingContent: '',
-      retrievalSteps: [],
+      streamingToolCalls: [],
     });
     useUIStore.getState().setChatSidebarConversationId(null);
     get().fetchConversations(listFilterTagId ?? undefined);
@@ -368,7 +368,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       messages: [...messages, userMessage],
       isStreaming: true,
       streamingContent: '',
-      retrievalSteps: [],
+      streamingToolCalls: [],
       error: null,
     });
 
@@ -417,9 +417,38 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set({ streamingContent: content });
   },
 
-  addRetrievalStep: (step: RetrievalStep) => {
+  startStreamingToolCall: ({ tool_call_id, tool_name, tool_input }) => {
+    const now = new Date().toISOString();
     set((state) => ({
-      retrievalSteps: [...state.retrievalSteps, step],
+      streamingToolCalls: [
+        ...state.streamingToolCalls,
+        {
+          id: tool_call_id,
+          message_id: '',
+          tool_name,
+          tool_input,
+          tool_output: null,
+          status: 'running',
+          created_at: now,
+          completed_at: null,
+        },
+      ],
+    }));
+  },
+
+  completeStreamingToolCall: ({ tool_call_id, results_count }) => {
+    const now = new Date().toISOString();
+    set((state) => ({
+      streamingToolCalls: state.streamingToolCalls.map((call) =>
+        call.id === tool_call_id
+          ? {
+              ...call,
+              status: 'complete' as const,
+              tool_output: { results_count },
+              completed_at: now,
+            }
+          : call
+      ),
     }));
   },
 
@@ -432,7 +461,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           isStreaming: false,
           streamingContent: '',
           streamingMessageId: null,
-          retrievalSteps: [],
+          streamingToolCalls: [],
         };
       }
       return {
@@ -440,7 +469,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         isStreaming: false,
         streamingContent: '',
         streamingMessageId: null,
-        retrievalSteps: [],
+        streamingToolCalls: [],
       };
     });
   },
@@ -467,7 +496,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       isStreaming: false,
       streamingContent: '',
       streamingMessageId: null,
-      retrievalSteps: [],
+      streamingToolCalls: [],
       error: null,
     }),
 }));


### PR DESCRIPTION
Obsidian plugin:
- New ChatView with conversation dropdown, tag-scoped text-autocomplete, streaming message thread, and persistent expandable tool-call cards
- WebSocket client with auto-reconnect for chat streaming events
- Wiki view: filter out autotag category roots from selector, proper spinner loading state, clickable citations with cross-wiki navigation

Atomic proper:
- Replace ephemeral retrievalSteps with streamingToolCalls that preserve tool_input/tool_output through streaming and carry through to the persisted message
- Per-call collapsible <details> with status icon, tool name, results count, and pretty-printed input/output JSON
- Tool calls now render above message content and persist after completion