### PR TITLE
Dashboard first run

### DIFF
--- a/crates/atomic-core/src/briefing/mod.rs
+++ b/crates/atomic-core/src/briefing/mod.rs
@@ -62,24 +62,21 @@ pub struct BriefingWithCitations {
 /// on busy days.
 const MAX_NEW_ATOMS: usize = 100;
 
-/// Hardcoded briefing content returned when no new atoms exist.
-fn empty_briefing_content(since: &DateTime<Utc>) -> String {
-    format!("Nothing new since {}.", since.to_rfc3339())
-}
-
 /// Generate a daily briefing for all atoms created after `since`.
 ///
 /// Flow:
 /// 1. Fetch up to [`MAX_NEW_ATOMS`] atoms with `created_at > since`,
 ///    ordered by `created_at DESC`.
-/// 2. If zero atoms: insert a placeholder briefing ("Nothing new since ...")
-///    and return it without invoking the LLM.
+/// 2. If zero atoms: return `Ok(None)` — nothing is persisted. The caller
+///    still bumps `last_run` so the scheduler waits the full interval before
+///    re-polling. This keeps the UI from showing a stub "Nothing new since
+///    ..." briefing when the knowledge base is quiet.
 /// 3. Otherwise: run the agentic loop over the new atoms, synthesize the
-///    briefing, extract `[N]` citations, and persist.
+///    briefing, extract `[N]` citations, persist, and return `Ok(Some(_))`.
 pub async fn run_briefing(
     core: &AtomicCore,
     since: DateTime<Utc>,
-) -> Result<BriefingWithCitations, AtomicCoreError> {
+) -> Result<Option<BriefingWithCitations>, AtomicCoreError> {
     let since_str = since.to_rfc3339();
     tracing::info!(since = %since_str, "[briefing] Starting daily briefing run");
 
@@ -98,23 +95,11 @@ pub async fn run_briefing(
         "[briefing] Fetched new atoms"
     );
 
-    // Zero-atom fast path: no LLM call.
+    // Zero-atom fast path: skip the LLM call and do not persist anything.
+    // The caller updates `last_run` so we don't rescan the same empty window.
     if new_atoms.is_empty() {
-        let id = uuid::Uuid::new_v4().to_string();
-        let now = Utc::now().to_rfc3339();
-        let briefing = Briefing {
-            id: id.clone(),
-            content: empty_briefing_content(&since),
-            created_at: now.clone(),
-            atom_count: 0,
-            last_run_at: since_str.clone(),
-        };
-        let saved = core
-            .storage()
-            .insert_briefing_sync(&briefing, &[])
-            .await?;
-        tracing::info!(briefing_id = %saved.briefing.id, "[briefing] Saved empty briefing (no new atoms)");
-        return Ok(saved);
+        tracing::info!("[briefing] No new atoms — skipping briefing creation");
+        return Ok(None);
     }
 
     // Run the agent loop.
@@ -159,5 +144,5 @@ pub async fn run_briefing(
         citations = saved.citations.len(),
         "[briefing] Saved briefing"
     );
-    Ok(saved)
+    Ok(Some(saved))
 }

--- a/crates/atomic-core/src/briefing/task.rs
+++ b/crates/atomic-core/src/briefing/task.rs
@@ -60,10 +60,13 @@ impl ScheduledTask for DailyBriefingTask {
         // first-run lookback) and persists a fresh `last_run` on success.
         match core.run_daily_briefing().await {
             Ok(result) => {
+                // `result` is None when the window had no new atoms; we still
+                // emit Completed so the scheduler records a clean run, but
+                // there's no briefing id to surface.
                 (ctx.event_cb)(TaskEvent::Completed {
                     task_id: TASK_ID.to_string(),
                     db_id,
-                    result_id: Some(result.briefing.id.clone()),
+                    result_id: result.as_ref().map(|r| r.briefing.id.clone()),
                 });
                 Ok(())
             }

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -1500,11 +1500,15 @@ impl AtomicCore {
     /// persisted `task.daily_briefing.last_run` (or a 7-day lookback on the
     /// first run), invokes the agentic loop, and persists the result.
     ///
+    /// Returns `Ok(None)` when there are no new atoms in the window — no
+    /// briefing row is written in that case. `last_run` is still bumped so
+    /// the scheduler waits the full interval before re-polling.
+    ///
     /// Updates `task.daily_briefing.last_run` on success so the next
     /// scheduled tick correctly waits for the full interval. On failure the
     /// error bubbles up and `last_run` is left unchanged — the scheduler
     /// will retry on the next tick.
-    pub async fn run_daily_briefing(&self) -> Result<briefing::BriefingWithCitations, AtomicCoreError> {
+    pub async fn run_daily_briefing(&self) -> Result<Option<briefing::BriefingWithCitations>, AtomicCoreError> {
         let _guard = self.briefing_lock.try_lock().map_err(|_| {
             AtomicCoreError::Conflict("A daily briefing is already running".to_string())
         })?;

--- a/crates/atomic-server/src/routes/briefings.rs
+++ b/crates/atomic-server/src/routes/briefings.rs
@@ -70,6 +70,7 @@ pub async fn get_briefing(db: Db, path: web::Path<String>) -> HttpResponse {
     path = "/api/briefings/run",
     responses(
         (status = 200, description = "Briefing generated", body = atomic_core::BriefingWithCitations),
+        (status = 204, description = "No new atoms in the window — no briefing was generated"),
         (status = 400, description = "Error", body = ApiErrorResponse)
     ),
     tag = "briefings"
@@ -95,13 +96,14 @@ pub async fn run_briefing_now(
         .unwrap_or_else(|| "default".to_string());
 
     match core.run_daily_briefing().await {
-        Ok(result) => {
+        Ok(Some(result)) => {
             let _ = state.event_tx.send(ServerEvent::BriefingReady {
                 db_id,
                 briefing_id: result.briefing.id.clone(),
             });
             HttpResponse::Ok().json(result)
         }
+        Ok(None) => HttpResponse::NoContent().finish(),
         Err(e) => error_response(e),
     }
 }

--- a/crates/atomic-server/src/routes/settings.rs
+++ b/crates/atomic-server/src/routes/settings.rs
@@ -94,16 +94,14 @@ pub struct TestOpenRouterBody {
 pub async fn test_openrouter_connection(
     body: web::Json<TestOpenRouterBody>,
 ) -> HttpResponse {
+    // Validate the key against the authenticated `/key` endpoint rather than a
+    // real chat completion. This avoids spending credits and exercising a
+    // specific model just to confirm the key is valid.
+    // https://openrouter.ai/docs/api/api-reference/api-keys/get-current-key
     let client = reqwest::Client::new();
     let response = client
-        .post("https://openrouter.ai/api/v1/chat/completions")
+        .get("https://openrouter.ai/api/v1/key")
         .header("Authorization", format!("Bearer {}", body.api_key))
-        .header("Content-Type", "application/json")
-        .json(&serde_json::json!({
-            "model": "anthropic/claude-haiku-4.5",
-            "messages": [{"role": "user", "content": "Hi"}],
-            "max_tokens": 5
-        }))
         .send()
         .await;
 

--- a/src/components/atoms/AtomCard.tsx
+++ b/src/components/atoms/AtomCard.tsx
@@ -126,6 +126,7 @@ export const AtomCard = memo(function AtomCard({
   const remainingTags = atom.tags.length - maxVisibleTags;
 
   if (viewMode === 'list') {
+    const hasMetaRow = atom.tags.length > 0 || !!displaySource;
     return (
       <div
         onClick={handleClick}
@@ -138,41 +139,49 @@ export const AtomCard = memo(function AtomCard({
           onRetryTagging={handleRetryTagging}
         />
         <div className="flex-1 min-w-0">
-          <div className="flex items-baseline gap-2">
+          <div className="flex items-baseline gap-2 min-w-0">
             <span
-              className={`text-sm font-medium shrink-0 ${
+              className={`text-sm font-medium truncate min-w-0 ${
                 matchingChunkContent ? 'text-[var(--color-accent-light)]' : 'text-[var(--color-text-primary)]'
               }`}
             >
               {title || 'Untitled'}
             </span>
             {snippet && (
-              <span className="text-xs text-[var(--color-text-tertiary)] truncate">
+              <span className="hidden sm:inline text-xs text-[var(--color-text-tertiary)] truncate">
                 {snippet}
               </span>
             )}
           </div>
-          {atom.tags.length > 0 && (
-            <div className="flex items-center gap-1.5 mt-1">
-              {visibleTags.map((tag) => (
-                <TagChip key={tag.id} name={tag.name} size="sm" />
-              ))}
-              {remainingTags > 0 && (
-                <span className="text-xs text-[var(--color-text-tertiary)]">+{remainingTags}</span>
+          {hasMetaRow && (
+            <div className="flex items-center gap-1.5 mt-1 min-w-0">
+              {atom.tags.length > 0 && (
+                <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
+                  {visibleTags.map((tag) => (
+                    <TagChip key={tag.id} name={tag.name} size="sm" />
+                  ))}
+                  {remainingTags > 0 && (
+                    <span className="text-xs text-[var(--color-text-tertiary)] shrink-0">+{remainingTags}</span>
+                  )}
+                </div>
+              )}
+              {displaySource && (
+                <span
+                  className="ml-auto shrink-0 text-xs text-[var(--color-text-tertiary)] bg-[var(--color-bg-panel)] px-1.5 py-0.5 rounded truncate max-w-[100px] sm:max-w-[140px]"
+                  title={atom.source_url ?? displaySource}
+                >
+                  {displaySource}
+                </span>
               )}
             </div>
           )}
         </div>
-        <div className="flex items-center gap-2 shrink-0">
-          {displaySource && (
-            <span className="text-xs text-[var(--color-text-tertiary)] bg-[var(--color-bg-panel)] px-1.5 py-0.5 rounded truncate max-w-[120px]" title={atom.source_url ?? displaySource}>
-              {displaySource}
-            </span>
-          )}
-          <span className="text-xs text-[var(--color-text-tertiary)] whitespace-nowrap">
-            {formatRelativeDate(getDisplayDate(atom))}
-          </span>
-        </div>
+        <span
+          className="shrink-0 text-xs text-[var(--color-text-tertiary)] whitespace-nowrap"
+          title={formatRelativeDate(getDisplayDate(atom))}
+        >
+          {formatShortRelativeDate(getDisplayDate(atom))}
+        </span>
       </div>
     );
   }

--- a/src/components/dashboard/CaptureOptions.tsx
+++ b/src/components/dashboard/CaptureOptions.tsx
@@ -1,0 +1,505 @@
+import { useState } from 'react';
+import {
+  Check,
+  ChevronRight,
+  Copy,
+  FolderOpen,
+  Link2,
+  NotebookPen,
+  Plug,
+  Rss,
+} from 'lucide-react';
+import { Button } from '../ui/Button';
+import {
+  createApiToken,
+  createFeed,
+  getMcpHttpConfig,
+  getMcpStdioConfig,
+  ingestUrl,
+  type McpHttpConfig,
+  type McpStdioConfig,
+} from '../../lib/api';
+import { importMarkdownFolder } from '../../lib/import';
+import { AppleNotesImportError, importAppleNotes } from '../../lib/import-apple-notes';
+import {
+  getLocalServerConfig,
+  getMcpBridgePath,
+  getTransport,
+  isDesktopApp,
+  isLocalServer,
+} from '../../lib/transport';
+import { isMacOS, openExternalUrl, pickDirectory } from '../../lib/platform';
+import { copyToClipboard } from '../../lib/clipboard';
+import { useAtomsStore } from '../../stores/atoms';
+import { useTagsStore } from '../../stores/tags';
+import type { HttpTransport } from '../../lib/transport/http';
+
+type OptionId = 'url' | 'feed' | 'markdown' | 'apple-notes' | 'mcp';
+
+interface OptionMeta {
+  id: OptionId;
+  Icon: typeof Link2;
+  title: string;
+  subtitle: string;
+}
+
+export function CaptureOptions() {
+  const [openId, setOpenId] = useState<OptionId | null>(null);
+
+  const ids: OptionId[] = ['url', 'feed'];
+  if (isDesktopApp() && isLocalServer()) ids.push('markdown');
+  if (isDesktopApp() && isMacOS()) ids.push('apple-notes');
+  ids.push('mcp');
+
+  const META: Record<OptionId, OptionMeta> = {
+    url: {
+      id: 'url',
+      Icon: Link2,
+      title: 'Capture a URL',
+      subtitle: 'Save any web page as an atom',
+    },
+    feed: {
+      id: 'feed',
+      Icon: Rss,
+      title: 'Subscribe to an RSS feed',
+      subtitle: 'Poll a feed and capture new items in the background',
+    },
+    markdown: {
+      id: 'markdown',
+      Icon: FolderOpen,
+      title: 'Import a markdown folder',
+      subtitle: 'Load a folder of .md files as atoms',
+    },
+    'apple-notes': {
+      id: 'apple-notes',
+      Icon: NotebookPen,
+      title: 'Import from Apple Notes',
+      subtitle: 'Bring your Apple Notes library into Atomic',
+    },
+    mcp: {
+      id: 'mcp',
+      Icon: Plug,
+      title: 'Connect an MCP client',
+      subtitle: 'Use Atomic from Claude Desktop or any MCP client',
+    },
+  };
+
+  return (
+    <section className="mt-12">
+      <header className="flex items-center gap-3 mb-1 h-5">
+        <h3 className="text-[11px] leading-none font-medium uppercase tracking-[0.14em] text-[var(--color-text-tertiary)] whitespace-nowrap">
+          More ways to capture
+        </h3>
+        <div className="flex-1 h-px bg-[var(--color-border)]" />
+      </header>
+      <div>
+        {ids.map(id => (
+          <OptionRow
+            key={id}
+            meta={META[id]}
+            expanded={openId === id}
+            onToggle={() => setOpenId(openId === id ? null : id)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+interface OptionRowProps {
+  meta: OptionMeta;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function OptionRow({ meta, expanded, onToggle }: OptionRowProps) {
+  const { Icon } = meta;
+  return (
+    <div className="border-b border-[var(--color-border)]">
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-4 py-4 text-left group"
+      >
+        <div className="w-9 h-9 flex items-center justify-center rounded-md border border-[var(--color-border)] bg-[var(--color-bg-hover)]/30 shrink-0 transition-colors group-hover:border-[var(--color-text-tertiary)]">
+          <Icon className="w-4 h-4 text-[var(--color-text-secondary)]" strokeWidth={1.75} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-[var(--color-text-primary)]">{meta.title}</div>
+          <div className="text-[12px] text-[var(--color-text-tertiary)] mt-0.5">{meta.subtitle}</div>
+        </div>
+        <ChevronRight
+          className={`w-4 h-4 text-[var(--color-text-tertiary)] transition-transform ${expanded ? 'rotate-90' : ''}`}
+          strokeWidth={2}
+        />
+      </button>
+      {expanded && (
+        <div className="pr-1 pb-5" style={{ paddingLeft: '3.25rem' }}>
+          <OptionBody id={meta.id} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OptionBody({ id }: { id: OptionId }) {
+  switch (id) {
+    case 'url': return <UrlBody />;
+    case 'feed': return <FeedBody />;
+    case 'markdown': return <MarkdownBody />;
+    case 'apple-notes': return <AppleNotesBody />;
+    case 'mcp': return <McpBody />;
+  }
+}
+
+// ---------------------------------------------------------------- URL ----
+
+function UrlBody() {
+  const [url, setUrl] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<{ ok: true; title: string } | { ok: false; error: string } | null>(null);
+  const fetchAtoms = useAtomsStore(s => s.fetchAtoms);
+
+  const submit = async () => {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setResult(null);
+    try {
+      const res = await ingestUrl(trimmed);
+      setResult({ ok: true, title: res.title });
+      setUrl('');
+      void fetchAtoms();
+    } catch (e) {
+      setResult({ ok: false, error: String(e) });
+    }
+    setBusy(false);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        <input
+          type="url"
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') submit(); }}
+          placeholder="https://..."
+          className="flex-1 bg-[var(--color-bg-main)] border border-[var(--color-border)] rounded px-3 py-1.5 text-sm text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent)]"
+          autoFocus
+        />
+        <Button size="sm" onClick={submit} disabled={busy || !url.trim()}>
+          {busy ? 'Saving…' : 'Capture'}
+        </Button>
+      </div>
+      {result?.ok && (
+        <div className="text-[12px] text-emerald-400">Saved: {result.title || 'Untitled'}</div>
+      )}
+      {result && !result.ok && (
+        <div className="text-[12px] text-red-400">{result.error}</div>
+      )}
+    </div>
+  );
+}
+
+// --------------------------------------------------------------- Feed ----
+
+function FeedBody() {
+  const [url, setUrl] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<{ ok: true; title: string | null } | { ok: false; error: string } | null>(null);
+
+  const submit = async () => {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setResult(null);
+    try {
+      const feed = await createFeed(trimmed);
+      setResult({ ok: true, title: feed.title });
+      setUrl('');
+    } catch (e) {
+      setResult({ ok: false, error: String(e) });
+    }
+    setBusy(false);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        <input
+          type="url"
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') submit(); }}
+          placeholder="https://example.com/feed.xml"
+          className="flex-1 bg-[var(--color-bg-main)] border border-[var(--color-border)] rounded px-3 py-1.5 text-sm text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent)]"
+          autoFocus
+        />
+        <Button size="sm" onClick={submit} disabled={busy || !url.trim()}>
+          {busy ? 'Adding…' : 'Subscribe'}
+        </Button>
+      </div>
+      <p className="text-[12px] text-[var(--color-text-tertiary)]">
+        Polls hourly by default. Tune intervals and tags in Settings&nbsp;→&nbsp;Feeds.
+      </p>
+      {result?.ok && (
+        <div className="text-[12px] text-emerald-400">Subscribed{result.title ? `: ${result.title}` : ''}.</div>
+      )}
+      {result && !result.ok && (
+        <div className="text-[12px] text-red-400">{result.error}</div>
+      )}
+    </div>
+  );
+}
+
+// ------------------------------------------------------------ Markdown ----
+
+function MarkdownBody() {
+  const [importTags, setImportTags] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [progress, setProgress] = useState<{ processed: number; total: number } | null>(null);
+  const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const fetchAtoms = useAtomsStore(s => s.fetchAtoms);
+  const fetchTags = useTagsStore(s => s.fetchTags);
+
+  const choose = async () => {
+    setError(null);
+    setResult(null);
+    const dir = await pickDirectory('Select markdown folder');
+    if (!dir) return;
+    setBusy(true);
+    setProgress({ processed: 0, total: 0 });
+    try {
+      const res = await importMarkdownFolder(dir, {
+        importTags,
+        onProgress: p => setProgress({ processed: p.current, total: p.total }),
+      });
+      setResult({ imported: res.imported, skipped: res.skipped });
+      if (res.imported > 0) await Promise.all([fetchAtoms(), fetchTags()]);
+    } catch (e) {
+      setError(String(e));
+    }
+    setBusy(false);
+    setProgress(null);
+  };
+
+  return (
+    <div className="space-y-3">
+      <label className="flex items-center gap-2 text-[12px] text-[var(--color-text-secondary)] cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={importTags}
+          onChange={e => setImportTags(e.target.checked)}
+          className="accent-[var(--color-accent)]"
+        />
+        Turn folders and frontmatter into tags
+      </label>
+      <div>
+        <Button size="sm" variant="secondary" onClick={choose} disabled={busy}>
+          {busy ? 'Importing…' : 'Choose folder…'}
+        </Button>
+      </div>
+      {progress && progress.total > 0 && (
+        <div className="text-[12px] text-[var(--color-text-tertiary)] tabular-nums">
+          {progress.processed} / {progress.total}
+        </div>
+      )}
+      {result && (
+        <div className="text-[12px] text-emerald-400">
+          Imported {result.imported} atom{result.imported === 1 ? '' : 's'}
+          {result.skipped ? ` · skipped ${result.skipped}` : ''}.
+        </div>
+      )}
+      {error && <div className="text-[12px] text-red-400">{error}</div>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------- Apple Notes ----
+
+function AppleNotesBody() {
+  const [importTags, setImportTags] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [progress, setProgress] = useState<{ processed: number; total: number } | null>(null);
+  const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null);
+  const [error, setError] = useState<{ kind: AppleNotesImportError['kind'] | 'other'; message: string } | null>(null);
+  const fetchAtoms = useAtomsStore(s => s.fetchAtoms);
+  const fetchTags = useTagsStore(s => s.fetchTags);
+
+  const run = async () => {
+    setError(null);
+    setResult(null);
+    setBusy(true);
+    setProgress({ processed: 0, total: 0 });
+    try {
+      const res = await importAppleNotes({
+        importTags,
+        onProgress: p => setProgress({ processed: p.current, total: p.total }),
+      });
+      setResult({ imported: res.imported, skipped: res.skipped });
+      if (res.imported > 0) await Promise.all([fetchAtoms(), fetchTags()]);
+    } catch (e) {
+      if (e instanceof AppleNotesImportError) {
+        setError({ kind: e.kind, message: e.message });
+      } else {
+        setError({ kind: 'other', message: String(e) });
+      }
+    }
+    setBusy(false);
+    setProgress(null);
+  };
+
+  const openPrivacyPrefs = () =>
+    openExternalUrl(
+      'x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_AllFiles',
+    );
+
+  return (
+    <div className="space-y-3">
+      {error?.kind === 'permissionDenied' ? (
+        <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-[12px] text-amber-200 space-y-2">
+          <div>Atomic needs <strong>Full Disk Access</strong> to read the Apple Notes database.</div>
+          <div className="flex gap-2">
+            <Button size="sm" variant="secondary" onClick={openPrivacyPrefs}>
+              Open System Settings
+            </Button>
+            <Button size="sm" onClick={run} disabled={busy}>
+              Try again
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <label className="flex items-center gap-2 text-[12px] text-[var(--color-text-secondary)] cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={importTags}
+              onChange={e => setImportTags(e.target.checked)}
+              className="accent-[var(--color-accent)]"
+            />
+            Turn Apple Notes folders into tags
+          </label>
+          <div>
+            <Button size="sm" variant="secondary" onClick={run} disabled={busy}>
+              {busy ? 'Importing…' : 'Import notes'}
+            </Button>
+          </div>
+        </>
+      )}
+      {progress && progress.total > 0 && (
+        <div className="text-[12px] text-[var(--color-text-tertiary)] tabular-nums">
+          {progress.processed} / {progress.total}
+        </div>
+      )}
+      {result && (
+        <div className="text-[12px] text-emerald-400">
+          Imported {result.imported} note{result.imported === 1 ? '' : 's'}
+          {result.skipped ? ` · skipped ${result.skipped}` : ''}.
+        </div>
+      )}
+      {error && error.kind !== 'permissionDenied' && (
+        <div className="text-[12px] text-red-400">{error.message}</div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- MCP ----
+
+type McpConfigShape = McpStdioConfig | McpHttpConfig;
+
+function McpBody() {
+  const local = isDesktopApp() && isLocalServer();
+  const [config, setConfig] = useState<McpConfigShape | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const loadLocal = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const bridge = await getMcpBridgePath();
+      if (!bridge) throw new Error('MCP bridge binary not found.');
+      setConfig(getMcpStdioConfig(bridge));
+    } catch (e) {
+      setError(String(e));
+    }
+    setBusy(false);
+  };
+
+  const loadRemote = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const baseUrl = (() => {
+        const lc = getLocalServerConfig();
+        if (lc) return lc.baseUrl;
+        return (getTransport() as HttpTransport).getConfig().baseUrl;
+      })();
+      if (!baseUrl) throw new Error('Server URL is not available.');
+      const tokenResp = await createApiToken('mcp-integration');
+      setConfig(getMcpHttpConfig(baseUrl, tokenResp.token));
+    } catch (e) {
+      setError(String(e));
+    }
+    setBusy(false);
+  };
+
+  const copy = async () => {
+    if (!config) return;
+    try {
+      await copyToClipboard(JSON.stringify(config, null, 2));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {!config ? (
+        <>
+          <p className="text-[12px] text-[var(--color-text-tertiary)]">
+            {local
+              ? 'The MCP bridge is bundled with the desktop app — no token required.'
+              : 'Generate an API token so your MCP client can authenticate to this server.'}
+          </p>
+          <Button size="sm" variant="secondary" onClick={local ? loadLocal : loadRemote} disabled={busy}>
+            {busy ? 'Preparing…' : local ? 'Show config' : 'Generate config'}
+          </Button>
+          {error && <div className="text-[12px] text-red-400">{error}</div>}
+        </>
+      ) : (
+        <div className="space-y-2">
+          {!local && (
+            <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-200">
+              Copy this now — the token won&apos;t be shown again.
+            </div>
+          )}
+          <div className="relative">
+            <pre className="p-3 pr-10 bg-[var(--color-bg-main)] border border-[var(--color-border)] rounded-md text-[12px] text-[var(--color-text-primary)] overflow-x-auto">
+              {JSON.stringify(config, null, 2)}
+            </pre>
+            <button
+              onClick={copy}
+              className="absolute top-2 right-2 p-1.5 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors"
+              title="Copy to clipboard"
+            >
+              {copied ? (
+                <Check className="w-3.5 h-3.5 text-emerald-400" strokeWidth={2} />
+              ) : (
+                <Copy className="w-3.5 h-3.5" strokeWidth={2} />
+              )}
+            </button>
+          </div>
+          <p className="text-[11px] text-[var(--color-text-tertiary)]">
+            Paste into your MCP client config (e.g. Claude Desktop&nbsp;→&nbsp;Developer&nbsp;→&nbsp;Edit Config), then restart the client.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -1,9 +1,13 @@
 import { useEffect } from 'react';
 import { dashboardWidgets } from './registry';
 import { useWikiStore } from '../../stores/wiki';
+import { useAtomsStore } from '../../stores/atoms';
+import { WelcomeView } from './WelcomeView';
 
 export function DashboardView() {
   const fetchAllArticles = useWikiStore(s => s.fetchAllArticles);
+  const atomCount = useAtomsStore(s => s.atoms.length);
+  const initialLoadComplete = useAtomsStore(s => s.initialLoadComplete);
 
   useEffect(() => {
     // Kick off wiki data on dashboard mount. The call is idempotent — safe to
@@ -11,8 +15,16 @@ export function DashboardView() {
     fetchAllArticles();
   }, [fetchAllArticles]);
 
+  // Brand-new users land on an empty grid of widgets, which reads as broken.
+  // Defer to the welcome view until atoms exist. Gated on initialLoadComplete
+  // so we don't flash the welcome state during cold start before the first
+  // fetch settles.
+  if (initialLoadComplete && atomCount === 0) {
+    return <WelcomeView />;
+  }
+
   return (
-    <div className="h-full overflow-y-auto">
+    <div className="h-full overflow-y-auto scrollbar-auto-hide">
       <div className="mx-auto max-w-4xl px-6 pt-10 pb-16 md:px-10 md:pt-14 md:pb-20">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-10 gap-y-10 md:gap-y-12">
           {dashboardWidgets.map(({ id, span, Component }) => (

--- a/src/components/dashboard/WelcomeView.tsx
+++ b/src/components/dashboard/WelcomeView.tsx
@@ -1,0 +1,86 @@
+import { Plus } from 'lucide-react';
+import { useAtomsStore } from '../../stores/atoms';
+import { useUIStore } from '../../stores/ui';
+import { isDesktopApp } from '../../lib/transport';
+import { CaptureOptions } from './CaptureOptions';
+
+function greeting(date: Date): string {
+  const h = date.getHours();
+  if (h < 5) return 'Working late';
+  if (h < 12) return 'Good morning';
+  if (h < 18) return 'Good afternoon';
+  return 'Good evening';
+}
+
+function formatToday(date: Date): string {
+  return date
+    .toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' })
+    .toUpperCase();
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="px-1.5 py-0.5 rounded border border-[var(--color-border)] bg-[var(--color-bg-hover)]/60 text-[11px] font-mono text-[var(--color-text-secondary)]">
+      {children}
+    </kbd>
+  );
+}
+
+export function WelcomeView() {
+  const createAtom = useAtomsStore(s => s.createAtom);
+  const openReaderEditing = useUIStore(s => s.openReaderEditing);
+
+  const handleCreate = async () => {
+    try {
+      const atom = await createAtom('');
+      openReaderEditing(atom.id);
+    } catch (err) {
+      console.error('Failed to create atom:', err);
+    }
+  };
+
+  const now = new Date();
+  const modKey = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform) ? '⌘' : 'Ctrl';
+  // Only surface ⌘N in the desktop build — the browser reserves it for a
+  // new window and will swallow the keystroke before our listener sees it.
+  const showNewAtomShortcut = isDesktopApp();
+
+  return (
+    <div className="h-full overflow-y-auto scrollbar-auto-hide">
+      <div className="mx-auto max-w-4xl px-6 pt-10 pb-16 md:px-10 md:pt-14 md:pb-20">
+        <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--color-text-tertiary)] mb-3">
+          {formatToday(now)}
+        </div>
+
+        <h1 className="text-3xl md:text-4xl font-semibold text-[var(--color-text-primary)] tracking-tight mb-4">
+          {greeting(now)}.
+        </h1>
+
+        <p className="text-base md:text-lg text-[var(--color-text-secondary)] leading-relaxed max-w-2xl">
+          Atomic turns freeform notes into a semantically-connected knowledge graph. Capture
+          a thought — embeddings, tagging, and wiki synthesis happen behind the scenes.
+        </p>
+
+        <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-3">
+          <button
+            onClick={handleCreate}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-[var(--color-accent)] text-white text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors"
+          >
+            <Plus className="w-4 h-4" strokeWidth={2.5} />
+            Create your first atom
+          </button>
+          <span className="text-[13px] text-[var(--color-text-tertiary)]">
+            {showNewAtomShortcut && (
+              <>
+                or press <Kbd>{modKey}N</Kbd> ·{' '}
+              </>
+            )}
+            command palette <Kbd>{modKey}P</Kbd>
+          </span>
+        </div>
+
+        <CaptureOptions />
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/widgets/BriefingWidget.tsx
+++ b/src/components/dashboard/widgets/BriefingWidget.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Plus, RefreshCw } from 'lucide-react';
 import { SigmaCanvas } from '../../canvas/SigmaCanvas';
 import { CitationPopover } from '../../wiki/CitationPopover';
 import { BriefingContent } from './BriefingContent';
+import { CaptureOptions } from '../CaptureOptions';
 import { useIsMobile } from '../../../hooks';
 import { useAtomsStore } from '../../../stores/atoms';
 import { useWikiStore } from '../../../stores/wiki';
@@ -32,11 +33,22 @@ function formatToday(date: Date): string {
 
 export function BriefingWidget() {
   const atoms = useAtomsStore(s => s.atoms);
+  const createAtom = useAtomsStore(s => s.createAtom);
   const suggestedArticles = useWikiStore(s => s.suggestedArticles);
   const articles = useWikiStore(s => s.articles);
   const openReader = useUIStore(s => s.openReader);
+  const openReaderEditing = useUIStore(s => s.openReaderEditing);
   const setViewMode = useUIStore(s => s.setViewMode);
   const isMobile = useIsMobile();
+
+  const handleCreateAtom = async () => {
+    try {
+      const atom = await createAtom('');
+      openReaderEditing(atom.id);
+    } catch (err) {
+      console.error('Failed to create atom:', err);
+    }
+  };
 
   const active = useBriefingStore(s => s.active);
   const history = useBriefingStore(s => s.history);
@@ -84,22 +96,11 @@ export function BriefingWidget() {
   const stats = useMemo(() => {
     const newAtoms24h = atoms.filter(a => withinHours(a.created_at, 24)).length;
     const newAtoms7d = atoms.filter(a => withinHours(a.created_at, 24 * 7)).length;
-    const latestAtom = atoms[0] ?? null;
-    return { newAtoms24h, newAtoms7d, latestAtom, wikiCount: articles.length };
+    return { newAtoms24h, newAtoms7d, wikiCount: articles.length };
   }, [atoms, articles]);
 
   const now = new Date();
   const hello = greeting(now);
-
-  const fallbackSummary = useMemo(() => {
-    if (stats.newAtoms24h > 0) {
-      return `You captured ${stats.newAtoms24h} new atom${stats.newAtoms24h === 1 ? '' : 's'} in the last 24 hours. Your first briefing will generate automatically.`;
-    }
-    if (stats.newAtoms7d > 0) {
-      return `Quiet day. ${stats.newAtoms7d} atom${stats.newAtoms7d === 1 ? '' : 's'} added this week.`;
-    }
-    return 'Your knowledge base is quiet. Add an atom to get the flywheel turning.';
-  }, [stats]);
 
   const chips: string[] = [
     `${stats.newAtoms24h} new today`,
@@ -154,20 +155,21 @@ export function BriefingWidget() {
       </div>
 
       {/* Desktop: canvas floats right so the briefing copy wraps alongside it.
-          Rendered only on desktop to avoid mounting Sigma twice. */}
-      {!isMobile && (
+          Rendered only on desktop to avoid mounting Sigma twice. Skipped in the
+          no-briefing state — a near-empty graph reads as a broken widget. */}
+      {!isMobile && hasBriefing && (
         <div className="float-right ml-8 mb-2 w-80 aspect-[4/3]">
           <SigmaCanvas mode="preview" onPreviewClick={handleOpenCanvas} />
         </div>
       )}
 
       <h1 className="text-3xl md:text-4xl font-semibold text-[var(--color-text-primary)] tracking-tight mb-4">
-        {hasBriefing ? `${hello}.` : `${hello}.`}
+        {hello}.
       </h1>
 
       {/* Mobile: canvas stacks full-width between title and content so it
           never appears above the title. */}
-      {isMobile && (
+      {isMobile && hasBriefing && (
         <div className="my-4 w-full aspect-[16/10]">
           <SigmaCanvas mode="preview" onPreviewClick={handleOpenCanvas} />
         </div>
@@ -180,28 +182,19 @@ export function BriefingWidget() {
           onCitationClick={handleCitationClick}
         />
       ) : (
-        <p className="text-base md:text-lg text-[var(--color-text-secondary)] leading-relaxed">
-          {fallbackSummary}
-        </p>
+        <button
+          onClick={handleCreateAtom}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-[var(--color-accent)] text-white text-sm font-medium hover:bg-[var(--color-accent-hover)] transition-colors"
+        >
+          <Plus className="w-4 h-4" strokeWidth={2.5} />
+          Capture another atom
+        </button>
       )}
 
       {!hasBriefing && (
         <div className="mt-5 text-[13px] text-[var(--color-text-tertiary)] tabular-nums">
           {chips.join('  ·  ')}
         </div>
-      )}
-
-      {!hasBriefing && stats.latestAtom && (
-        <button
-          onClick={() => openReader(stats.latestAtom!.id)}
-          className="mt-4 inline-flex items-center gap-2 text-[13px] text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors group"
-        >
-          <span className="text-[var(--color-text-tertiary)]">Most recent</span>
-          <span className="text-[var(--color-text-secondary)] group-hover:text-[var(--color-accent-light)] truncate max-w-[16rem] md:max-w-sm">
-            {stats.latestAtom.title || 'Untitled'}
-          </span>
-          <ChevronRight className="w-3 h-3 opacity-60 group-hover:opacity-100 transition-opacity" strokeWidth={2} />
-        </button>
       )}
 
       {hasBriefing && (
@@ -212,6 +205,11 @@ export function BriefingWidget() {
 
       {/* Clear the float so any following sibling (layout-level gap) doesn't collide */}
       <div className="md:clear-right" />
+
+      {/* When there's no briefing yet, surface every capture/import path below
+          the primary CTA so a first-time user can pick whichever source best
+          fits their knowledge base. */}
+      {!hasBriefing && <CaptureOptions />}
 
       {/* Citation popover — shared with wiki, tolerates the BriefingCitation shape
           because CitationForPopover only requires {citation_index, atom_id, excerpt}. */}

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -51,8 +51,6 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     }
   })();
 
-  const isOptional = !currentStepDef.required;
-
   // Save AI provider settings before moving to step 3+
   const saveProviderSettings = async () => {
     try {
@@ -127,14 +125,6 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     }
   };
 
-  const handleSkip = () => {
-    if (isLastStep) {
-      onComplete();
-    } else {
-      dispatch({ type: 'NEXT_STEP' });
-    }
-  };
-
   const handleBack = () => {
     dispatch({ type: 'PREV_STEP' });
   };
@@ -171,7 +161,6 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
             </h1>
             <p className="text-xs text-[var(--color-text-secondary)] mt-0.5">
               Step {state.currentStep + 1} of {STEPS.length}: {currentStepDef.label}
-              {isOptional && ' (optional)'}
             </p>
           </div>
           <StepIndicator currentStep={state.currentStep} onStepClick={handleStepClick} />
@@ -192,11 +181,6 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
             )}
           </div>
           <div className="flex gap-2">
-            {isOptional && (
-              <Button variant="secondary" onClick={handleSkip}>
-                Skip
-              </Button>
-            )}
             <Button onClick={handleNext} disabled={!canProceed}>
               {isLastStep ? 'Finish' : 'Next'}
             </Button>

--- a/src/components/onboarding/steps/IntegrationsStep.tsx
+++ b/src/components/onboarding/steps/IntegrationsStep.tsx
@@ -288,7 +288,16 @@ function ExtensionContent() {
   return (
     <>
       <ol className="space-y-1.5 text-sm text-[var(--color-text-secondary)] list-decimal list-inside">
-        <li>Install the Atomic browser extension</li>
+        <li>
+          <a
+            href="https://chromewebstore.google.com/detail/atomic-web-clipper/bknijbafnefbaklndpglcmlhaglikccf"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-[var(--color-accent)] hover:underline"
+          >
+            Install the Atomic Web Clipper for Chrome
+          </a>
+        </li>
         <li>Click the extension icon and open settings</li>
         <li>Enter the server URL and auth token below</li>
       </ol>

--- a/src/components/onboarding/useOnboardingState.ts
+++ b/src/components/onboarding/useOnboardingState.ts
@@ -329,7 +329,7 @@ export function useOnboardingState() {
 export const STEPS: { id: StepId; label: string; required: boolean }[] = [
   { id: 'welcome', label: 'Welcome', required: true },
   { id: 'ai-provider', label: 'AI Provider', required: true },
-  { id: 'tag-categories', label: 'Tag Categories', required: false },
-  { id: 'integrations', label: 'Integrations', required: false },
-  { id: 'tutorial', label: 'Tutorial', required: false },
+  { id: 'tag-categories', label: 'Tag Categories', required: true },
+  { id: 'integrations', label: 'Integrations', required: true },
+  { id: 'tutorial', label: 'Tutorial', required: true },
 ];

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,24 @@
+/**
+ * Write `text` to the clipboard.
+ *
+ * Uses the async Clipboard API in secure contexts (HTTPS, Tauri) and falls
+ * back to a hidden textarea + `execCommand('copy')` for plain-HTTP localhost,
+ * where the Clipboard API is blocked.
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}

--- a/src/stores/atoms.ts
+++ b/src/stores/atoms.ts
@@ -115,6 +115,10 @@ interface AtomsStore {
   error: string | null;
   nextCursor: string | null;
   nextCursorId: string | null;
+  // Flips to true after the first successful fetch or cache hydrate. Lets
+  // consumers distinguish "truly empty" from "haven't loaded yet" without
+  // flashing empty-state UI during cold start.
+  initialLoadComplete: boolean;
 
   // Search state
   searchMode: SearchMode;
@@ -192,6 +196,7 @@ export const useAtomsStore = create<AtomsStore>((set, get) => ({
   error: null,
   nextCursor: null,
   nextCursorId: null,
+  initialLoadComplete: false,
 
   // Search state
   searchMode: 'hybrid' as SearchMode,
@@ -233,6 +238,7 @@ export const useAtomsStore = create<AtomsStore>((set, get) => ({
         isLoadingInitial: false,
         nextCursor: result.next_cursor ?? null,
         nextCursorId: result.next_cursor_id ?? null,
+        initialLoadComplete: true,
       });
       if (isDefaultQuery) {
         const dbId = useDatabasesStore.getState().activeId;
@@ -272,6 +278,7 @@ export const useAtomsStore = create<AtomsStore>((set, get) => ({
       hasMore: cached.data.atoms.length < cached.data.totalCount,
       nextCursor: cached.data.nextCursor,
       nextCursorId: cached.data.nextCursorId,
+      initialLoadComplete: true,
     });
   },
 
@@ -297,6 +304,7 @@ export const useAtomsStore = create<AtomsStore>((set, get) => ({
         isLoadingInitial: false,
         nextCursor: result.next_cursor ?? null,
         nextCursorId: result.next_cursor_id ?? null,
+        initialLoadComplete: true,
       });
     } catch (error) {
       set({ error: String(error), isLoadingInitial: false });
@@ -623,6 +631,7 @@ export const useAtomsStore = create<AtomsStore>((set, get) => ({
     error: null,
     nextCursor: null,
     nextCursorId: null,
+    initialLoadComplete: false,
     searchMode: 'hybrid',
     semanticSearchQuery: '',
     semanticSearchResults: null,

--- a/src/stores/briefing.ts
+++ b/src/stores/briefing.ts
@@ -58,7 +58,11 @@ export const useBriefingStore = create<BriefingStore>((set, get) => ({
     set({ isLoading: true, error: null });
     try {
       const transport = getTransport();
-      const history = await transport.invoke<Briefing[]>('list_briefings', { limit: HISTORY_LIMIT });
+      const raw = await transport.invoke<Briefing[]>('list_briefings', { limit: HISTORY_LIMIT });
+      // Filter out zero-atom stub briefings that older builds persisted when
+      // there was nothing new to report. The widget's fallback UI is a better
+      // experience than a briefing that just echoes "Nothing new since ...".
+      const history = raw.filter(b => b.atom_count > 0);
       if (history.length === 0) {
         set({ history: [], activeIndex: 0, active: null, isLoading: false });
         return;
@@ -93,11 +97,18 @@ export const useBriefingStore = create<BriefingStore>((set, get) => ({
     set({ isRunning: true, error: null });
     try {
       const transport = getTransport();
-      const active = await transport.invoke<BriefingWithCitations>('run_briefing_now');
-      // Refresh history so the new briefing is at index 0; keep the freshly-returned
-      // active object so we don't need a second round-trip.
-      const history = await transport.invoke<Briefing[]>('list_briefings', { limit: HISTORY_LIMIT });
-      set({ history, activeIndex: 0, active, isRunning: false });
+      // Server returns 204 (parsed as `undefined`) when there were no new atoms
+      // in the window — no briefing row is created in that case. Fall through
+      // to refreshing the history so the widget rests on its last real briefing
+      // (or the empty fallback if there is none).
+      const result = await transport.invoke<BriefingWithCitations | undefined>('run_briefing_now');
+      set({ isRunning: false });
+      if (result) {
+        const history = await transport.invoke<Briefing[]>('list_briefings', { limit: HISTORY_LIMIT });
+        set({ history: history.filter(b => b.atom_count > 0), activeIndex: 0, active: result });
+      } else {
+        await get().fetchLatest();
+      }
     } catch (error) {
       set({ error: String(error), isRunning: false });
     }


### PR DESCRIPTION
- Add WelcomeView + CaptureOptions panel (URL, RSS, markdown folder, Apple Notes, MCP) shown when the dashboard is empty or the briefing widget has no content yet
- Stop persisting zero-atom briefing stubs: backend returns Ok(None) / HTTP 204; frontend filters any legacy stub rows
- Hide the mini Sigma canvas and the redundant "Most recent" link until a real briefing exists; replace the automatic-briefing copy with a "Capture another atom" CTA
- Mark tag-categories / integrations / tutorial onboarding steps as required so the redundant Skip button goes away
- Link the Chrome Web Store listing for the browser-extension step
- Switch OpenRouter connection test to GET /key so it no longer burns credits on a real chat completion
- Fix atom list overflow on mobile (title truncation, source pill dropped into the tag row, snippet hidden below sm breakpoint)
- Shared clipboard helper with execCommand fallback for non-secure-context localhost