### PR TITLE
feat(extension): configurable database per request

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -76,10 +76,10 @@ async function captureContent(tabId, mode) {
 
 // Send to desktop app via HTTP
 async function sendToDesktop(capture) {
-  const { serverUrl, apiToken } = await getConfig();
+  const { serverUrl, apiToken, database } = await getConfig();
   const response = await fetch(`${serverUrl}/api/atoms`, {
     method: 'POST',
-    headers: authHeaders(apiToken),
+    headers: authHeaders(apiToken, database),
     body: JSON.stringify({
       content: capture.content,
       source_url: capture.url,
@@ -114,11 +114,11 @@ async function getQueue() {
 
 // Check connection and sync queue
 async function syncQueue() {
-  const { serverUrl, apiToken } = await getConfig();
+  const { serverUrl, apiToken, database } = await getConfig();
   try {
     // Health check
     const response = await fetch(`${serverUrl}/health`, {
-      headers: authHeaders(apiToken)
+      headers: authHeaders(apiToken, database)
     });
     if (!response.ok) throw new Error('Unhealthy');
 
@@ -165,9 +165,9 @@ async function updateBadge() {
     chrome.action.setBadgeBackgroundColor({ color: '#f59e0b' });
   } else {
     // Clear badge when queue is empty, show connection status dot
-    const { serverUrl, apiToken } = await getConfig();
+    const { serverUrl, apiToken, database } = await getConfig();
     const response = await fetch(`${serverUrl}/health`, {
-      headers: authHeaders(apiToken)
+      headers: authHeaders(apiToken, database)
     }).catch(() => null);
     if (response && response.ok) {
       chrome.action.setBadgeBackgroundColor({ color: '#22c55e' });

--- a/extension/lib/config.js
+++ b/extension/lib/config.js
@@ -3,11 +3,12 @@ const DEFAULT_URL = 'http://localhost:44380';
 
 export async function getConfig() {
   const result = await chrome.storage.local.get(CONFIG_KEY);
-  return result[CONFIG_KEY] || { serverUrl: DEFAULT_URL, apiToken: '' };
+  return result[CONFIG_KEY] || { serverUrl: DEFAULT_URL, apiToken: '', database: '' };
 }
 
-export function authHeaders(apiToken) {
+export function authHeaders(apiToken, database) {
   const headers = { 'Content-Type': 'application/json' };
   if (apiToken) headers['Authorization'] = `Bearer ${apiToken}`;
+  if (database) headers['X-Atomic-Database'] = database;
   return headers;
 }

--- a/extension/lib/config.js
+++ b/extension/lib/config.js
@@ -6,6 +6,10 @@ export async function getConfig() {
   return result[CONFIG_KEY] || { serverUrl: DEFAULT_URL, apiToken: '', database: '' };
 }
 
+export async function setConfig(config) {
+  await chrome.storage.local.set({ [CONFIG_KEY]: config });
+}
+
 export function authHeaders(apiToken, database) {
   const headers = { 'Content-Type': 'application/json' };
   if (apiToken) headers['Authorization'] = `Bearer ${apiToken}`;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,6 +13,14 @@
     "alarms"
   ],
 
+  "host_permissions": [
+    "http://localhost/*",
+    "http://127.0.0.1/*",
+    "https://localhost/*",
+    "https://127.0.0.1/*",
+    "https://*/*"
+  ],
+
   "options_page": "options/options.html",
 
   "background": {

--- a/extension/options/options.css
+++ b/extension/options/options.css
@@ -72,6 +72,44 @@ h1 {
   color: var(--text-secondary);
 }
 
+.form-group select {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.form-group select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.db-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.db-row select {
+  flex: 1;
+}
+
+.db-row .btn-secondary {
+  flex: 0 0 auto;
+  padding: 0 14px;
+}
+
+.hint {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
 .button-row {
   display: flex;
   gap: 8px;

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -20,6 +20,17 @@
       <input type="password" id="api-token" placeholder="Enter your API token">
     </div>
 
+    <div class="form-group">
+      <label for="database">Database</label>
+      <div class="db-row">
+        <select id="database">
+          <option value="">(server default)</option>
+        </select>
+        <button class="btn-secondary" id="refresh-dbs" type="button">Refresh</button>
+      </div>
+      <p class="hint" id="db-hint">Click Refresh after setting server URL + token.</p>
+    </div>
+
     <div class="button-row">
       <button class="btn-primary" id="save">Save</button>
       <button class="btn-secondary" id="test">Test Connection</button>

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -1,6 +1,4 @@
-import { getConfig, authHeaders } from '../lib/config.js';
-
-const CONFIG_KEY = 'serverConfig';
+import { getConfig, setConfig, authHeaders } from '../lib/config.js';
 
 const urlInput = document.getElementById('server-url');
 const tokenInput = document.getElementById('api-token');
@@ -11,88 +9,14 @@ const saveBtn = document.getElementById('save');
 const testBtn = document.getElementById('test');
 const messageEl = document.getElementById('message');
 
-let lastLoadedDatabases = [];
-
-// Load saved config
-async function loadConfig() {
-  const config = await getConfig();
-  urlInput.value = config.serverUrl;
-  tokenInput.value = config.apiToken;
-
-  // Seed the select with the saved value so it persists even before refresh
-  if (config.database) {
-    const opt = document.createElement('option');
-    opt.value = config.database;
-    opt.textContent = `${config.database} (saved)`;
-    opt.selected = true;
-    databaseSelect.appendChild(opt);
-  }
-
-  // Attempt to load databases list on open
-  refreshDatabases({ silent: true });
+function readForm() {
+  return {
+    serverUrl: urlInput.value.trim().replace(/\/+$/, ''),
+    apiToken: tokenInput.value.trim(),
+    database: databaseSelect.value.trim(),
+  };
 }
 
-// Populate the select with databases fetched from the server
-function renderDatabases(databases, selectedId) {
-  lastLoadedDatabases = databases;
-  databaseSelect.innerHTML = '';
-
-  const defaultOpt = document.createElement('option');
-  defaultOpt.value = '';
-  defaultOpt.textContent = '(server default)';
-  databaseSelect.appendChild(defaultOpt);
-
-  for (const db of databases) {
-    const opt = document.createElement('option');
-    opt.value = db.id;
-    opt.textContent = `${db.name} — ${db.id}${db.is_default ? ' [default]' : ''}`;
-    if (db.id === selectedId) opt.selected = true;
-    databaseSelect.appendChild(opt);
-  }
-
-  // If the saved id isn't in the list, preserve it as an extra option
-  if (selectedId && !databases.some((d) => d.id === selectedId)) {
-    const opt = document.createElement('option');
-    opt.value = selectedId;
-    opt.textContent = `${selectedId} (not found on server)`;
-    opt.selected = true;
-    databaseSelect.appendChild(opt);
-  }
-}
-
-async function refreshDatabases({ silent = false } = {}) {
-  const serverUrl = urlInput.value.trim().replace(/\/+$/, '');
-  const apiToken = tokenInput.value.trim();
-
-  if (!serverUrl) {
-    if (!silent) showMessage('Server URL is required', 'error');
-    return;
-  }
-
-  refreshDbsBtn.disabled = true;
-  const prev = refreshDbsBtn.textContent;
-  refreshDbsBtn.textContent = '…';
-
-  try {
-    const res = await fetch(`${serverUrl}/api/databases`, {
-      headers: authHeaders(apiToken)
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    const databases = data.databases || [];
-    const config = await getConfig();
-    renderDatabases(databases, config.database || '');
-    dbHint.textContent = `Loaded ${databases.length} database(s).`;
-  } catch (err) {
-    if (!silent) showMessage(`Could not load databases: ${err.message}`, 'error');
-    dbHint.textContent = `Could not reach server (${err.message}). Save to persist current selection anyway.`;
-  } finally {
-    refreshDbsBtn.disabled = false;
-    refreshDbsBtn.textContent = prev;
-  }
-}
-
-// Show status message
 function showMessage(text, type) {
   messageEl.textContent = text;
   messageEl.className = `message ${type}`;
@@ -100,30 +24,61 @@ function showMessage(text, type) {
   setTimeout(() => { messageEl.style.display = 'none'; }, 3000);
 }
 
-// Save config
-saveBtn.addEventListener('click', async () => {
-  const serverUrl = urlInput.value.trim().replace(/\/+$/, '');
-  const apiToken = tokenInput.value.trim();
-  const database = databaseSelect.value.trim();
+function renderDatabases(databases, selectedId) {
+  databaseSelect.innerHTML = '';
+  databaseSelect.appendChild(new Option('(server default)', ''));
+  for (const db of databases) {
+    const label = `${db.name} — ${db.id}${db.is_default ? ' [default]' : ''}`;
+    databaseSelect.appendChild(new Option(label, db.id));
+  }
+  if (selectedId && !databases.some((d) => d.id === selectedId)) {
+    databaseSelect.appendChild(new Option(`${selectedId} (not found on server)`, selectedId));
+  }
+  databaseSelect.value = selectedId || '';
+}
 
+async function refreshDatabases({ silent = false } = {}) {
+  const { serverUrl, apiToken, database } = readForm();
   if (!serverUrl) {
-    showMessage('Server URL is required', 'error');
+    if (!silent) showMessage('Server URL is required', 'error');
     return;
   }
 
-  await chrome.storage.local.set({
-    [CONFIG_KEY]: { serverUrl, apiToken, database }
-  });
+  refreshDbsBtn.disabled = true;
+  try {
+    const res = await fetch(`${serverUrl}/api/databases`, { headers: authHeaders(apiToken) });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const { databases = [] } = await res.json();
+    renderDatabases(databases, database);
+    dbHint.textContent = `Loaded ${databases.length} database(s).`;
+  } catch (err) {
+    if (!silent) showMessage(`Could not load databases: ${err.message}`, 'error');
+    dbHint.textContent = `Could not reach server (${err.message}). Save to persist current selection anyway.`;
+  } finally {
+    refreshDbsBtn.disabled = false;
+  }
+}
 
+async function loadConfig() {
+  const config = await getConfig();
+  urlInput.value = config.serverUrl;
+  tokenInput.value = config.apiToken;
+  renderDatabases([], config.database);
+  refreshDatabases({ silent: true });
+}
+
+saveBtn.addEventListener('click', async () => {
+  const form = readForm();
+  if (!form.serverUrl) {
+    showMessage('Server URL is required', 'error');
+    return;
+  }
+  await setConfig(form);
   showMessage('Settings saved', 'success');
 });
 
-// Test connection
 testBtn.addEventListener('click', async () => {
-  const serverUrl = urlInput.value.trim().replace(/\/+$/, '');
-  const apiToken = tokenInput.value.trim();
-  const database = databaseSelect.value.trim();
-
+  const { serverUrl, apiToken, database } = readForm();
   if (!serverUrl) {
     showMessage('Server URL is required', 'error');
     return;
@@ -131,25 +86,21 @@ testBtn.addEventListener('click', async () => {
 
   testBtn.disabled = true;
   testBtn.textContent = 'Testing...';
-
   try {
-    // Hit an authenticated endpoint to verify connectivity, token, and DB routing
-    const response = await fetch(`${serverUrl}/api/atoms?limit=1`, {
+    const res = await fetch(`${serverUrl}/api/atoms?limit=1`, {
       headers: authHeaders(apiToken, database)
     });
-
-    if (response.ok) {
-      const dbLabel = database || '(server default)';
-      showMessage(`Connection successful — using database: ${dbLabel}`, 'success');
-    } else if (response.status === 401) {
-      showMessage('Connected but token is invalid — check your API token', 'error');
-    } else if (response.status === 400) {
+    if (res.ok) {
+      showMessage(`Connection successful — using database: ${database || '(server default)'}`, 'success');
+    } else if (res.status === 401) {
+      showMessage('Connected but token is invalid', 'error');
+    } else if (res.status === 400) {
       showMessage('Connected but database not found — pick one from the list', 'error');
     } else {
-      showMessage(`Connection failed: HTTP ${response.status}`, 'error');
+      showMessage(`Connection failed: HTTP ${res.status}`, 'error');
     }
-  } catch (error) {
-    showMessage(`Connection failed: ${error.message}`, 'error');
+  } catch (err) {
+    showMessage(`Connection failed: ${err.message}`, 'error');
   } finally {
     testBtn.disabled = false;
     testBtn.textContent = 'Test Connection';

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -4,15 +4,92 @@ const CONFIG_KEY = 'serverConfig';
 
 const urlInput = document.getElementById('server-url');
 const tokenInput = document.getElementById('api-token');
+const databaseSelect = document.getElementById('database');
+const refreshDbsBtn = document.getElementById('refresh-dbs');
+const dbHint = document.getElementById('db-hint');
 const saveBtn = document.getElementById('save');
 const testBtn = document.getElementById('test');
 const messageEl = document.getElementById('message');
+
+let lastLoadedDatabases = [];
 
 // Load saved config
 async function loadConfig() {
   const config = await getConfig();
   urlInput.value = config.serverUrl;
   tokenInput.value = config.apiToken;
+
+  // Seed the select with the saved value so it persists even before refresh
+  if (config.database) {
+    const opt = document.createElement('option');
+    opt.value = config.database;
+    opt.textContent = `${config.database} (saved)`;
+    opt.selected = true;
+    databaseSelect.appendChild(opt);
+  }
+
+  // Attempt to load databases list on open
+  refreshDatabases({ silent: true });
+}
+
+// Populate the select with databases fetched from the server
+function renderDatabases(databases, selectedId) {
+  lastLoadedDatabases = databases;
+  databaseSelect.innerHTML = '';
+
+  const defaultOpt = document.createElement('option');
+  defaultOpt.value = '';
+  defaultOpt.textContent = '(server default)';
+  databaseSelect.appendChild(defaultOpt);
+
+  for (const db of databases) {
+    const opt = document.createElement('option');
+    opt.value = db.id;
+    opt.textContent = `${db.name} — ${db.id}${db.is_default ? ' [default]' : ''}`;
+    if (db.id === selectedId) opt.selected = true;
+    databaseSelect.appendChild(opt);
+  }
+
+  // If the saved id isn't in the list, preserve it as an extra option
+  if (selectedId && !databases.some((d) => d.id === selectedId)) {
+    const opt = document.createElement('option');
+    opt.value = selectedId;
+    opt.textContent = `${selectedId} (not found on server)`;
+    opt.selected = true;
+    databaseSelect.appendChild(opt);
+  }
+}
+
+async function refreshDatabases({ silent = false } = {}) {
+  const serverUrl = urlInput.value.trim().replace(/\/+$/, '');
+  const apiToken = tokenInput.value.trim();
+
+  if (!serverUrl) {
+    if (!silent) showMessage('Server URL is required', 'error');
+    return;
+  }
+
+  refreshDbsBtn.disabled = true;
+  const prev = refreshDbsBtn.textContent;
+  refreshDbsBtn.textContent = '…';
+
+  try {
+    const res = await fetch(`${serverUrl}/api/databases`, {
+      headers: authHeaders(apiToken)
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const databases = data.databases || [];
+    const config = await getConfig();
+    renderDatabases(databases, config.database || '');
+    dbHint.textContent = `Loaded ${databases.length} database(s).`;
+  } catch (err) {
+    if (!silent) showMessage(`Could not load databases: ${err.message}`, 'error');
+    dbHint.textContent = `Could not reach server (${err.message}). Save to persist current selection anyway.`;
+  } finally {
+    refreshDbsBtn.disabled = false;
+    refreshDbsBtn.textContent = prev;
+  }
 }
 
 // Show status message
@@ -27,6 +104,7 @@ function showMessage(text, type) {
 saveBtn.addEventListener('click', async () => {
   const serverUrl = urlInput.value.trim().replace(/\/+$/, '');
   const apiToken = tokenInput.value.trim();
+  const database = databaseSelect.value.trim();
 
   if (!serverUrl) {
     showMessage('Server URL is required', 'error');
@@ -34,7 +112,7 @@ saveBtn.addEventListener('click', async () => {
   }
 
   await chrome.storage.local.set({
-    [CONFIG_KEY]: { serverUrl, apiToken }
+    [CONFIG_KEY]: { serverUrl, apiToken, database }
   });
 
   showMessage('Settings saved', 'success');
@@ -44,6 +122,7 @@ saveBtn.addEventListener('click', async () => {
 testBtn.addEventListener('click', async () => {
   const serverUrl = urlInput.value.trim().replace(/\/+$/, '');
   const apiToken = tokenInput.value.trim();
+  const database = databaseSelect.value.trim();
 
   if (!serverUrl) {
     showMessage('Server URL is required', 'error');
@@ -54,15 +133,18 @@ testBtn.addEventListener('click', async () => {
   testBtn.textContent = 'Testing...';
 
   try {
-    // Hit an authenticated endpoint to verify both connectivity and token
+    // Hit an authenticated endpoint to verify connectivity, token, and DB routing
     const response = await fetch(`${serverUrl}/api/atoms?limit=1`, {
-      headers: authHeaders(apiToken)
+      headers: authHeaders(apiToken, database)
     });
 
     if (response.ok) {
-      showMessage('Connection successful — token is valid', 'success');
+      const dbLabel = database || '(server default)';
+      showMessage(`Connection successful — using database: ${dbLabel}`, 'success');
     } else if (response.status === 401) {
       showMessage('Connected but token is invalid — check your API token', 'error');
+    } else if (response.status === 400) {
+      showMessage('Connected but database not found — pick one from the list', 'error');
     } else {
       showMessage(`Connection failed: HTTP ${response.status}`, 'error');
     }
@@ -73,5 +155,7 @@ testBtn.addEventListener('click', async () => {
     testBtn.textContent = 'Test Connection';
   }
 });
+
+refreshDbsBtn.addEventListener('click', () => refreshDatabases());
 
 loadConfig();

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -36,11 +36,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 async function updateStatus() {
   const statusEl = document.getElementById('status');
   const labelEl = document.getElementById('status-label');
-  const { serverUrl, apiToken } = await getConfig();
+  const { serverUrl, apiToken, database } = await getConfig();
 
   try {
     const response = await fetch(`${serverUrl}/health`, {
-      headers: authHeaders(apiToken)
+      headers: authHeaders(apiToken, database)
     });
     if (response.ok) {
       statusEl.classList.remove('offline');
@@ -93,7 +93,7 @@ async function extractFromTab(tabId, mode) {
 // Capture from current tab
 async function captureCurrentTab(mode) {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const { serverUrl, apiToken } = await getConfig();
+  const { serverUrl, apiToken, database } = await getConfig();
 
   try {
     const result = await extractFromTab(tab.id, mode);
@@ -101,7 +101,7 @@ async function captureCurrentTab(mode) {
     if (result && result.content) {
       const response = await fetch(`${serverUrl}/api/atoms`, {
         method: 'POST',
-        headers: authHeaders(apiToken),
+        headers: authHeaders(apiToken, database),
         body: JSON.stringify({
           content: result.content,
           source_url: result.url,


### PR DESCRIPTION
## Summary
- Adds a **Database** field to the browser extension's options page, populated via `GET /api/databases`.
- Sends the selected id on every API request as `X-Atomic-Database`, so clipped atoms land in the chosen database instead of the server's default.
- Declares `host_permissions` in `manifest.json` so MV3 bypasses CORS for the configured atomic-server host.

## Test plan
- [ ] Load unpacked extension, open Options
- [ ] Set server URL + API token, click **Refresh** → databases list populates
- [ ] Select a non-default database, **Save**, **Test Connection** reports the selected database
- [ ] Capture a page — atom appears in the selected database
- [ ] Leave database blank → atoms still land in the server's active database (no regression)
- [ ] With wrong server URL/token, Refresh shows a friendly hint; saved id still persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)