### PR TITLE
fix(pwa): exclude OAuth/MCP paths from service-worker navigation fallback

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,9 +31,20 @@ export default defineConfig({
               // fall back to index.html for every navigation so deep-links
               // like /atoms/:id work when the server is a static host.
               navigateFallback: '/index.html',
-              // API and WS calls must NEVER be intercepted. Skip anything that
-              // looks like a server endpoint the app talks to.
-              navigateFallbackDenylist: [/^\/api\//, /^\/health/, /^\/ws/],
+              // Server endpoints must NEVER be intercepted and rewritten to
+              // index.html. /oauth/ and /.well-known/ are hit by top-level
+              // browser navigations (MCP remote-auth flow from claude.ai),
+              // so without this denylist the SPA shell takes over the URL
+              // and the user lands on the dashboard with OAuth params in
+              // the querystring instead of the consent page.
+              navigateFallbackDenylist: [
+                /^\/api\//,
+                /^\/health/,
+                /^\/ws/,
+                /^\/oauth\//,
+                /^\/\.well-known\//,
+                /^\/mcp(\/|$)/,
+              ],
               runtimeCaching: [
                 {
                   // Google Fonts stylesheets — cache for a day.


### PR DESCRIPTION
## Summary

- The PWA service worker's `NavigationRoute` rewrites every top-level navigation to `/index.html`. The `navigateFallbackDenylist` only excluded `/api/`, `/health`, and `/ws`, so top-level browser navigations to `/oauth/authorize`, `/.well-known/oauth-*`, and `/mcp` were intercepted once the SPA had been loaded once.
- Concrete symptom: connecting a remote MCP server in claude.ai → Claude redirects the browser to `https://<host>/oauth/authorize?client_id=…&redirect_uri=https://claude.ai/api/mcp/auth_callback&…`. Instead of atomic-server's purple consent page, the cached SPA shell takes over, the React router doesn't recognize `/oauth/authorize`, and the user lands on the dashboard with the OAuth query params still in the URL.
- Background `fetch()` calls to `/api/*` and `/ws` weren't affected because they're not navigations; only top-level navigations triggered the bug, which is why it only shows up in the MCP remote-auth flow.
- Regression was introduced when `VitePWA` was enabled in `vite.config.ts` (commit 8504e77, "Prep frontend for mobile").

Fix: add `/oauth/`, `/.well-known/`, and `/mcp` to `navigateFallbackDenylist` so the browser lets those requests reach atomic-server.

## Test plan

- [x] `curl https://<host>/.well-known/oauth-authorization-server` returns correct metadata (confirms server side was never broken)
- [x] `curl https://<host>/oauth/authorize?...` returns the consent HTML (confirms server-side routing is fine)
- [x] Reproduced the SPA interception in Edge: paste the OAuth URL while the cached SW is active → lands on dashboard. Unregister SW + clear site data → lands on consent page.
- [x] After rebuilding web assets with this fix, InPrivate / fresh browser navigating to `/oauth/authorize?...` reaches the consent page via the SW (denylist bypass)
- [x] Claude.ai "Connect" against a deployed server with the new build completes OAuth and issues a bearer token (will verify post-deploy)

Note: users with the buggy SW already cached will need to refresh once for the new SW (which uses `skipWaiting()` + `clientsClaim()`) to take over — no manual unregister needed.