### PR TITLE
fix(ui): anchor new-atom FAB inside main so chat sidebar pushes it

### DIFF
--- a/src/components/ui/FAB.tsx
+++ b/src/components/ui/FAB.tsx
@@ -8,7 +8,7 @@ interface FABProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 export function FAB({ icon, className = '', ...props }: FABProps) {
   return (
     <button
-      className={`fixed bottom-6 right-6 mb-[env(safe-area-inset-bottom)] mr-[env(safe-area-inset-right)] w-14 h-14 bg-[var(--color-accent)] hover:bg-[var(--color-accent-hover)] text-white rounded-full shadow-lg flex items-center justify-center transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-main)] ${className}`}
+      className={`absolute bottom-6 right-6 mb-[env(safe-area-inset-bottom)] mr-[env(safe-area-inset-right)] w-14 h-14 bg-[var(--color-accent)] hover:bg-[var(--color-accent-hover)] text-white rounded-full shadow-lg flex items-center justify-center transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-main)] ${className}`}
       {...props}
     >
       {icon || (


### PR DESCRIPTION
Switch the FAB from fixed to absolute positioning. Its parent <main> is already relative, so when the chat sidebar opens and flexes main smaller, the button now slides left with the content instead of staying pinned to the viewport and getting covered.