### PR TITLE
fix: preserve parent tag expanded state on child create/delete (#142)

### DIFF
--- a/src/components/tags/TagTree.tsx
+++ b/src/components/tags/TagTree.tsx
@@ -60,6 +60,7 @@ export function TagTree({ onOpenTagSettings }: TagTreeProps = {}) {
   const setSelectedTag = useUIStore(s => s.setSelectedTag);
   const openSearchPalette = useUIStore(s => s.openSearchPalette);
   const expandedTagIds = useUIStore(s => s.expandedTagIds);
+  const expandTagPath = useUIStore(s => s.expandTagPath);
   const fetchAtoms = useAtomsStore(s => s.fetchAtoms);
   const fetchAtomsByTag = useAtomsStore(s => s.fetchAtomsByTag);
 
@@ -155,7 +156,11 @@ export function TagTree({ onOpenTagSettings }: TagTreeProps = {}) {
 
   const handleCreateTag = async () => {
     if (newTagModal.name.trim()) {
-      await createTag(newTagModal.name.trim(), newTagModal.parentId || undefined);
+      const parentId = newTagModal.parentId;
+      await createTag(newTagModal.name.trim(), parentId || undefined);
+      if (parentId) {
+        expandTagPath([parentId]);
+      }
       setNewTagModal({ isOpen: false, parentId: null, name: '' });
     }
   };

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -519,6 +519,7 @@ export const useUIStore = create<UIStore>()(
         chatSidebarOpen: state.chatSidebarOpen,
         chatSidebarWidth: state.chatSidebarWidth,
         chatSidebarConversationId: state.chatSidebarConversationId,
+        expandedTagIds: state.expandedTagIds,
       }),
       // v0 → v1: 'grid' and 'list' were top-level ViewMode values. They're now
       // collapsed into a single 'atoms' view with a separate atomsLayout field.


### PR DESCRIPTION
Replace w.atom_count (stored at wiki generation time) with a live subquery counting current atoms from atom_tags. This ensures the wiki list view always shows the correct source count matching the actual tagged atoms.