### PR TITLE
fix: prevent duplicate embedding runs from pipeline scheduler

### DIFF
--- a/crates/atomic-core/src/pipeline_task.rs
+++ b/crates/atomic-core/src/pipeline_task.rs
@@ -57,17 +57,9 @@ impl ScheduledTask for DraftPipelineTask {
             let cb = Arc::clone(&ctx.embedding_event_cb);
             move |event| cb(event)
         };
-        let on_event_tag = {
-            let cb = Arc::clone(&ctx.embedding_event_cb);
-            move |event| cb(event)
-        };
 
-        let embedding_count = core
+        let queued_count = core
             .process_pending_embeddings_due(cutoff, on_event)
-            .await
-            .map_err(TaskError::from)?;
-        let tagging_count = core
-            .process_pending_tagging_due(cutoff, on_event_tag)
             .await
             .map_err(TaskError::from)?;
 
@@ -78,8 +70,7 @@ impl ScheduledTask for DraftPipelineTask {
         tracing::info!(
             db_id = %db_id,
             quiet_minutes,
-            embedding_queued = embedding_count,
-            tagging_queued = tagging_count,
+            queued_count,
             "[draft_pipeline] scheduler tick complete"
         );
 

--- a/crates/atomic-core/src/storage/sqlite/chunks.rs
+++ b/crates/atomic-core/src/storage/sqlite/chunks.rs
@@ -905,8 +905,20 @@ impl SqliteStorage {
                 tag_requested = MAX(atom_pipeline_jobs.tag_requested, excluded.tag_requested),
                 reason = excluded.reason,
                 not_before = MIN(atom_pipeline_jobs.not_before, excluded.not_before),
-                state = 'pending',
-                lease_until = NULL,
+                state = CASE
+                    WHEN atom_pipeline_jobs.state = 'processing'
+                         AND atom_pipeline_jobs.lease_until IS NOT NULL
+                         AND atom_pipeline_jobs.lease_until > excluded.updated_at
+                    THEN atom_pipeline_jobs.state
+                    ELSE 'pending'
+                END,
+                lease_until = CASE
+                    WHEN atom_pipeline_jobs.state = 'processing'
+                         AND atom_pipeline_jobs.lease_until IS NOT NULL
+                         AND atom_pipeline_jobs.lease_until > excluded.updated_at
+                    THEN atom_pipeline_jobs.lease_until
+                    ELSE NULL
+                END,
                 atom_updated_at = excluded.atom_updated_at,
                 last_error = NULL,
                 updated_at = excluded.updated_at"
@@ -936,8 +948,20 @@ impl SqliteStorage {
                 tag_requested = MAX(atom_pipeline_jobs.tag_requested, excluded.tag_requested),
                 reason = excluded.reason,
                 not_before = MIN(atom_pipeline_jobs.not_before, excluded.not_before),
-                state = 'pending',
-                lease_until = NULL,
+                state = CASE
+                    WHEN atom_pipeline_jobs.state = 'processing'
+                         AND atom_pipeline_jobs.lease_until IS NOT NULL
+                         AND atom_pipeline_jobs.lease_until > excluded.updated_at
+                    THEN atom_pipeline_jobs.state
+                    ELSE 'pending'
+                END,
+                lease_until = CASE
+                    WHEN atom_pipeline_jobs.state = 'processing'
+                         AND atom_pipeline_jobs.lease_until IS NOT NULL
+                         AND atom_pipeline_jobs.lease_until > excluded.updated_at
+                    THEN atom_pipeline_jobs.lease_until
+                    ELSE NULL
+                END,
                 atom_updated_at = excluded.atom_updated_at,
                 last_error = NULL,
                 updated_at = excluded.updated_at"


### PR DESCRIPTION
## Problem

Two bugs caused atoms to be embedded twice on every scheduler tick:

**Bug 1 — redundant scheduler calls ()**

The `DraftPipelineTask` scheduler called both `process_pending_embeddings_due` and `process_pending_tagging_due` in the same tick. Both functions execute the exact same `enqueue_pipeline_jobs_from_statuses_sync` SQL followed by `process_queued_pipeline_jobs`. The second call's `ON CONFLICT` reset jobs already claimed by the first call back to `state='pending'`, so those atoms were claimed and processed a second time.

`process_pending_embeddings_due` already covers atoms with `(embedding_status='complete' AND tagging_status='pending')` — the tagging call was purely redundant.

**Bug 2 — ON CONFLICT clobbers active leases (`sqlite/chunks.rs`)**

`enqueue_pipeline_jobs_from_statuses_sync` used `ON CONFLICT … DO UPDATE SET state='pending', lease_until=NULL` unconditionally. Any concurrent or racing enqueue — scheduler overlap, rapid saves, retry calls — could interrupt an actively-leased processing job by clearing its lease, causing it to be re-claimed and processed again.

## Fix

- Remove the redundant `process_pending_tagging_due` call from the scheduler tick
- Update the `ON CONFLICT` clause in both SQL variants to preserve `state='processing'` and `lease_until` when the existing job has a non-expired lease

## Testing

- `cargo test -p atomic-core pipeline` — existing `full_pipeline_sqlite` passes
- `cargo check -p atomic-core` — clean (pre-existing warnings only)