### PR TITLE
feat: custom system prompt overrides for chat, briefing, and tagging

### DIFF
--- a/crates/atomic-core/src/agent.rs
+++ b/crates/atomic-core/src/agent.rs
@@ -1530,7 +1530,16 @@ where
     };
 
     // Build message history for API
-    let mut api_messages = vec![Message::system(get_system_prompt(&scope_description))];
+    let custom_chat_prefix = settings_map
+        .get("chat_prompt")
+        .filter(|s| !s.is_empty())
+        .map(|s| s.as_str());
+    let base_system = get_system_prompt(&scope_description);
+    let system_prompt = match custom_chat_prefix {
+        Some(prefix) => format!("{prefix}\n\n{base_system}"),
+        None => base_system,
+    };
+    let mut api_messages = vec![Message::system(system_prompt)];
     api_messages.extend(messages);
 
     // Truncate to fit context window for providers with limited context
@@ -1734,7 +1743,15 @@ where
     };
 
     // Build message history for API, with canvas context appended to system prompt
-    let mut system_prompt = get_system_prompt(&scope_description);
+    let custom_chat_prefix = settings_map
+        .get("chat_prompt")
+        .filter(|s| !s.is_empty())
+        .map(|s| s.as_str());
+    let base_system = get_system_prompt(&scope_description);
+    let mut system_prompt = match custom_chat_prefix {
+        Some(prefix) => format!("{prefix}\n\n{base_system}"),
+        None => base_system,
+    };
     if page_context.is_some() {
         system_prompt.push_str(get_page_context_system_prompt());
     }

--- a/crates/atomic-core/src/briefing/agentic.rs
+++ b/crates/atomic-core/src/briefing/agentic.rs
@@ -320,7 +320,7 @@ struct AgentState {
     done_called: bool,
 }
 
-async fn resolve_model(core: &AtomicCore) -> Result<(ProviderConfig, String), String> {
+async fn resolve_model(core: &AtomicCore) -> Result<(ProviderConfig, String, Option<String>), String> {
     let settings = core
         .get_settings()
         .await
@@ -336,7 +336,11 @@ async fn resolve_model(core: &AtomicCore) -> Result<(ProviderConfig, String), St
             .cloned()
             .unwrap_or_else(|| "anthropic/claude-sonnet-4.6".to_string()),
     };
-    Ok((config, model))
+    let custom_prompt = settings
+        .get("briefing_prompt")
+        .filter(|s| !s.is_empty())
+        .cloned();
+    Ok((config, model, custom_prompt))
 }
 
 async fn run_research(
@@ -501,14 +505,15 @@ pub(crate) async fn generate(
     new_atoms: &[AtomWithTags],
     total_new: i32,
 ) -> Result<(String, Vec<(i32, String, String)>), String> {
-    let (provider_config, model) = resolve_model(core).await?;
+    let (provider_config, model, custom_system_prompt) = resolve_model(core).await?;
     tracing::info!(model = %model, atoms = new_atoms.len(), "[briefing/agentic] Running agent");
 
     let user_prompt = build_user_prompt(since, new_atoms, total_new);
 
+    let system = custom_system_prompt.as_deref().unwrap_or(SYSTEM_PROMPT);
     let mut state = AgentState {
         messages: vec![
-            Message::system(SYSTEM_PROMPT.to_string()),
+            Message::system(system.to_string()),
             Message::user(user_prompt),
         ],
         done_called: false,

--- a/crates/atomic-core/src/embedding.rs
+++ b/crates/atomic-core/src/embedding.rs
@@ -792,6 +792,10 @@ async fn process_tagging_only_inner(
         return Ok(TaggingOutcome::Skipped);
     }
 
+    let custom_tagging_prompt = settings_map
+        .get("tagging_prompt")
+        .filter(|s| !s.is_empty())
+        .map(|s| s.as_str());
     let tags = run_tagging_strategy(
         tagging_strategy,
         &provider_config,
@@ -799,6 +803,7 @@ async fn process_tagging_only_inner(
         &tag_tree_json,
         &tagging_model,
         supported_params,
+        custom_tagging_prompt,
     )
     .await?;
 
@@ -852,7 +857,6 @@ async fn process_tagging_only_inner(
         new_tags_created: all_new_tag_ids,
     })
 }
-
 async fn run_tagging_strategy(
     strategy: TaggingStrategy,
     provider_config: &ProviderConfig,
@@ -860,6 +864,7 @@ async fn run_tagging_strategy(
     tag_tree_json: &str,
     model: &str,
     supported_params: Option<Vec<String>>,
+    custom_system_prompt: Option<&str>,
 ) -> Result<Vec<crate::extraction::TagApplication>, String> {
     match strategy {
         TaggingStrategy::TruncatedFullContent => {
@@ -869,6 +874,7 @@ async fn run_tagging_strategy(
                 tag_tree_json,
                 model,
                 supported_params,
+                custom_system_prompt,
             )
             .await
         }
@@ -882,6 +888,7 @@ async fn run_tagging_strategy(
                 tag_tree_json,
                 model,
                 supported_params,
+                custom_system_prompt,
             )
             .await
         }

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -261,8 +261,8 @@ pub async fn extract_tags_from_content(
     tag_tree_json: &str,
     model: &str,
     supported_params: Option<Vec<String>>,
+    custom_system_prompt: Option<&str>,
 ) -> Result<Vec<TagApplication>, String> {
-    // Truncate based on provider's context length
     let max_chars = max_tagging_chars(provider_config, tag_tree_json, model);
     let text = if content.len() > max_chars {
         // Find the nearest char boundary at or before max_chars
@@ -280,7 +280,10 @@ pub async fn extract_tags_from_content(
         tag_tree_json, text
     );
 
-    let messages = vec![Message::system(SYSTEM_PROMPT), Message::user(user_content)];
+    let system = custom_system_prompt
+        .filter(|s| !s.is_empty())
+        .unwrap_or(SYSTEM_PROMPT);
+    let messages = vec![Message::system(system), Message::user(user_content)];
 
     let call = StructuredCall::<ExtractionResult>::new(
         provider_config,

--- a/crates/atomic-core/src/settings.rs
+++ b/crates/atomic-core/src/settings.rs
@@ -73,6 +73,9 @@ pub const DEFAULT_SETTINGS: &[(&str, &str)] = &[
     ("openai_compat_timeout_secs", "300"), // 5 minutes default for OpenAI-compatible servers
     ("wiki_generation_prompt", ""),
     ("wiki_update_prompt", ""),
+    ("briefing_prompt", ""),
+    ("chat_prompt", ""),
+    ("tagging_prompt", ""),
     // Scheduled tasks — see crate::scheduler::state for key format
     ("task.daily_briefing.enabled", "true"),
     ("task.daily_briefing.interval_hours", "24"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -13424,17 +13424,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -76,11 +76,12 @@ import { formatRelativeDate } from '../../lib/date';
 import { useDatabasesStore, type DatabaseInfo, type DatabaseStats } from '../../stores/databases';
 import { OverrideControls } from './OverrideControls';
 
-export type SettingsTab = 'general' | 'ai' | 'tag-categories' | 'connection' | 'integrations' | 'databases';
+export type SettingsTab = 'general' | 'ai' | 'tag-categories' | 'connection' | 'integrations' | 'databases' | 'prompts';
 
 const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: 'general', label: 'General' },
   { id: 'ai', label: 'AI Models' },
+  { id: 'prompts', label: 'Prompts' },
   { id: 'tag-categories', label: 'Tags' },
   { id: 'connection', label: 'Connection' },
   { id: 'integrations', label: 'Integrations' },
@@ -800,6 +801,9 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
   const [wikiStrategy, setWikiStrategy] = useState('centroid');
   const [wikiGenerationPrompt, setWikiGenerationPrompt] = useState('');
   const [wikiUpdatePrompt, setWikiUpdatePrompt] = useState('');
+  const [briefingPrompt, setBriefingPrompt] = useState('');
+  const [chatPrompt, setChatPrompt] = useState('');
+  const [taggingPrompt, setTaggingPrompt] = useState('');
   const [chatModel, setChatModel] = useState('anthropic/claude-sonnet-4.6');
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -1193,6 +1197,9 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
     setWikiStrategy(settings.wiki_strategy || 'centroid');
     setWikiGenerationPrompt(settings.wiki_generation_prompt || '');
     setWikiUpdatePrompt(settings.wiki_update_prompt || '');
+    setBriefingPrompt(settings.briefing_prompt || '');
+    setChatPrompt(settings.chat_prompt || '');
+    setTaggingPrompt(settings.tagging_prompt || '');
     setChatModel(settings.chat_model || 'anthropic/claude-sonnet-4.6');
     setOllamaHost(settings.ollama_host || 'http://127.0.0.1:11434');
     setOllamaEmbeddingModel(settings.ollama_embedding_model || 'nomic-embed-text');
@@ -1756,60 +1763,6 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                           <OverrideControls settingKey="wiki_strategy" />
                         </div>
 
-                        {/* Wiki Generation Prompt */}
-                        <div className="space-y-1">
-                          <label className="block text-sm font-medium text-[var(--color-text-primary)]">
-                            Wiki Generation Prompt
-                          </label>
-                          <p className="text-xs text-[var(--color-text-secondary)]">
-                            System prompt for generating new wiki articles. Leave empty to use the default.
-                          </p>
-                          <textarea
-                            value={wikiGenerationPrompt}
-                            onChange={(e) => setWikiGenerationPrompt(e.target.value)}
-                            onBlur={() => autoSave('wiki_generation_prompt', wikiGenerationPrompt)}
-                            placeholder={"You are synthesizing a wiki article based on the user's personal knowledge base. Write a well-structured, informative article that summarizes what is known about the topic.\n\nGuidelines:\n- Use markdown formatting with ## for main sections and ### for subsections\n- Every factual claim MUST have a citation using [N] notation\n- Place citations immediately after the relevant statement\n- If sources contain contradictions, note them\n- Structure logically: overview first, then thematic sections\n- Keep tone informative and neutral\n- Do not invent information not present in the sources\n- When mentioning topics that have their own articles in the knowledge base, use [[Topic Name]] wiki-link notation to cross-reference them\n- Only use [[wiki links]] for topics listed in the EXISTING WIKI ARTICLES section provided\n- Do not force wiki links where they don't fit naturally"}
-                            rows={8}
-                            className="w-full px-3 py-2 rounded-md bg-[var(--color-bg-main)] border border-[var(--color-border)] text-sm text-[var(--color-text-primary)] font-mono resize-y placeholder:text-[var(--color-text-secondary)]/40"
-                          />
-                          {wikiGenerationPrompt && (
-                            <button
-                              onClick={() => { setWikiGenerationPrompt(''); autoSave('wiki_generation_prompt', ''); }}
-                              className="text-xs text-[var(--color-accent)] hover:underline"
-                            >
-                              Reset to default
-                            </button>
-                          )}
-                          <OverrideControls settingKey="wiki_generation_prompt" />
-                        </div>
-
-                        {/* Wiki Update Prompt */}
-                        <div className="space-y-1">
-                          <label className="block text-sm font-medium text-[var(--color-text-primary)]">
-                            Wiki Update Prompt
-                          </label>
-                          <p className="text-xs text-[var(--color-text-secondary)]">
-                            Custom instructions prepended to the update prompt. Use this to control tone, style, or focus. Leave empty to use the default.
-                          </p>
-                          <textarea
-                            value={wikiUpdatePrompt}
-                            onChange={(e) => setWikiUpdatePrompt(e.target.value)}
-                            onBlur={() => autoSave('wiki_update_prompt', wikiUpdatePrompt)}
-                            placeholder={"e.g. Write in a casual, conversational tone. Focus on practical implications rather than theory."}
-                            rows={4}
-                            className="w-full px-3 py-2 rounded-md bg-[var(--color-bg-main)] border border-[var(--color-border)] text-sm text-[var(--color-text-primary)] font-mono resize-y placeholder:text-[var(--color-text-secondary)]/40"
-                          />
-                          {wikiUpdatePrompt && (
-                            <button
-                              onClick={() => { setWikiUpdatePrompt(''); autoSave('wiki_update_prompt', ''); }}
-                              className="text-xs text-[var(--color-accent)] hover:underline"
-                            >
-                              Reset to default
-                            </button>
-                          )}
-                          <OverrideControls settingKey="wiki_update_prompt" />
-                        </div>
-
                         {/* Chat Model */}
                         <div className="space-y-1">
                           <label className="block text-sm font-medium text-[var(--color-text-primary)]">
@@ -2193,6 +2146,148 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                 </>
               )}
 
+
+              {/* ===== PROMPTS TAB ===== */}
+              {activeTab === 'prompts' && (
+                <div className="space-y-6">
+
+                  {/* Wiki Generation Prompt */}
+                  <div className="space-y-1">
+                    <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                      Wiki Generation Prompt
+                    </label>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      System prompt for generating new wiki articles. Leave empty to use the default.
+                    </p>
+                    <textarea
+                      value={wikiGenerationPrompt}
+                      onChange={(e) => setWikiGenerationPrompt(e.target.value)}
+                      onBlur={() => autoSave('wiki_generation_prompt', wikiGenerationPrompt)}
+                      placeholder={"You are synthesizing a wiki article based on the user's personal knowledge base. Write a well-structured, informative article that summarizes what is known about the topic.\n\nGuidelines:\n- Use markdown formatting with ## for main sections and ### for subsections\n- Every factual claim MUST have a citation using [N] notation\n- Place citations immediately after the relevant statement\n- If sources contain contradictions, note them\n- Structure logically: overview first, then thematic sections\n- Keep tone informative and neutral\n- Do not invent information not present in the sources\n- When mentioning topics that have their own articles in the knowledge base, use [[Topic Name]] wiki-link notation to cross-reference them\n- Only use [[wiki links]] for topics listed in the EXISTING WIKI ARTICLES section provided\n- Do not force wiki links where they don't fit naturally"}
+                      rows={8}
+                      className="w-full px-3 py-2 rounded-md bg-[var(--color-bg-main)] border border-[var(--color-border)] text-sm text-[var(--color-text-primary)] font-mono resize-y placeholder:text-[var(--color-text-secondary)]/40"
+                    />
+                    {wikiGenerationPrompt && (
+                      <button
+                        onClick={() => { setWikiGenerationPrompt(''); autoSave('wiki_generation_prompt', ''); }}
+                        className="text-xs text-[var(--color-accent)] hover:underline"
+                      >
+                        Reset to default
+                      </button>
+                    )}
+                    <OverrideControls settingKey="wiki_generation_prompt" />
+                  </div>
+
+                  {/* Wiki Update Prompt */}
+                  <div className="space-y-1">
+                    <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                      Wiki Update Prompt
+                    </label>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      Custom instructions prepended to the update prompt. Controls tone, style, or focus. Leave empty to use the default.
+                    </p>
+                    <textarea
+                      value={wikiUpdatePrompt}
+                      onChange={(e) => setWikiUpdatePrompt(e.target.value)}
+                      onBlur={() => autoSave('wiki_update_prompt', wikiUpdatePrompt)}
+                      placeholder={"e.g. Write in a casual, conversational tone. Focus on practical implications rather than theory."}
+                      rows={4}
+                      className="w-full px-3 py-2 rounded-md bg-[var(--color-bg-main)] border border-[var(--color-border)] text-sm text-[var(--color-text-primary)] font-mono resize-y placeholder:text-[var(--color-text-secondary)]/40"
+                    />
+                    {wikiUpdatePrompt && (
+                      <button
+                        onClick={() => { setWikiUpdatePrompt(''); autoSave('wiki_update_prompt', ''); }}
+                        className="text-xs text-[var(--color-accent)] hover:underline"
+                      >
+                        Reset to default
+                      </button>
+                    )}
+                    <OverrideControls settingKey="wiki_update_prompt" />
+                  </div>
+
+                  {/* Briefing Prompt */}
+                  <div className="space-y-1">
+                    <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                      Briefing Prompt
+                    </label>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      System prompt for daily briefing generation. Leave empty to use the default.
+                    </p>
+                    <textarea
+                      value={briefingPrompt}
+                      onChange={(e) => setBriefingPrompt(e.target.value)}
+                      onBlur={() => autoSave('briefing_prompt', briefingPrompt)}
+                      placeholder={"You are writing a short daily briefing of newly captured notes for a personal knowledge base.\n\nGuidelines:\n- Keep the briefing to 2-3 short paragraphs. Do not write a long digest.\n- Write in the user's voice: concise, direct, mildly analytical, no filler.\n- Use [N] inline citation markers to cite specific new atoms."}
+                      rows={6}
+                      className="w-full px-3 py-2 rounded-md bg-[var(--color-bg-main)] border border-[var(--color-border)] text-sm text-[var(--color-text-primary)] font-mono resize-y placeholder:text-[var(--color-text-secondary)]/40"
+                    />
+                    {briefingPrompt && (
+                      <button
+                        onClick={() => { setBriefingPrompt(''); autoSave('briefing_prompt', ''); }}
+                        className="text-xs text-[var(--color-accent)] hover:underline"
+                      >
+                        Reset to default
+                      </button>
+                    )}
+                    <OverrideControls settingKey="briefing_prompt" />
+                  </div>
+
+                  {/* Chat Prompt */}
+                  <div className="space-y-1">
+                    <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                      Chat Prompt
+                    </label>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      Prepended to the chat assistant system prompt. Leave empty to use the default.
+                    </p>
+                    <textarea
+                      value={chatPrompt}
+                      onChange={(e) => setChatPrompt(e.target.value)}
+                      onBlur={() => autoSave('chat_prompt', chatPrompt)}
+                      placeholder={"You are a helpful AI assistant with access to the user's personal knowledge base.\n\nGuidelines:\n- Use search_atoms to find relevant information before answering\n- Cite sources using [N] notation\n- Be honest if you cannot find information\n- Keep responses concise but informative"}
+                      rows={6}
+                      className="w-full px-3 py-2 rounded-md bg-[var(--color-bg-main)] border border-[var(--color-border)] text-sm text-[var(--color-text-primary)] font-mono resize-y placeholder:text-[var(--color-text-secondary)]/40"
+                    />
+                    {chatPrompt && (
+                      <button
+                        onClick={() => { setChatPrompt(''); autoSave('chat_prompt', ''); }}
+                        className="text-xs text-[var(--color-accent)] hover:underline"
+                      >
+                        Reset to default
+                      </button>
+                    )}
+                    <OverrideControls settingKey="chat_prompt" />
+                  </div>
+
+                  {/* Tagging Prompt */}
+                  <div className="space-y-1">
+                    <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                      Tagging Prompt
+                    </label>
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      System prompt for auto-tagging. Leave empty to use the default.
+                    </p>
+                    <textarea
+                      value={taggingPrompt}
+                      onChange={(e) => setTaggingPrompt(e.target.value)}
+                      onBlur={() => autoSave('tagging_prompt', taggingPrompt)}
+                      placeholder={"You are a knowledge management assistant that categorizes text with tags.\n\nGuidelines:\n- Each tag MUST have a parent_name set to one of the existing top-level categories\n- Prefer broad tags rather than overly specific ones\n- If none of the categories feel like a natural fit, return an empty tag list"}
+                      rows={4}
+                      className="w-full px-3 py-2 rounded-md bg-[var(--color-bg-main)] border border-[var(--color-border)] text-sm text-[var(--color-text-primary)] font-mono resize-y placeholder:text-[var(--color-text-secondary)]/40"
+                    />
+                    {taggingPrompt && (
+                      <button
+                        onClick={() => { setTaggingPrompt(''); autoSave('tagging_prompt', ''); }}
+                        className="text-xs text-[var(--color-accent)] hover:underline"
+                      >
+                        Reset to default
+                      </button>
+                    )}
+                    <OverrideControls settingKey="tagging_prompt" />
+                  </div>
+
+                </div>
+              )}
               {/* ===== TAG CATEGORIES TAB ===== */}
               {activeTab === 'tag-categories' && (
                 <>


### PR DESCRIPTION
## Summary

Adds three new per-database settings that let users supply custom system prompts for the main AI features. All fields default to empty (existing behaviour is unchanged).

| Setting key | Feature | Behaviour |
|---|---|---|
| `chat_prompt` | Chat agent | Prepended before the base system prompt |
| `briefing_prompt` | Daily briefing | Replaces built-in `SYSTEM_PROMPT` when non-empty |
| `tagging_prompt` | Tag extraction | Replaces built-in `SYSTEM_PROMPT` when non-empty |

The existing wiki generation prompt override already worked; this PR moves it to a new dedicated **Prompts** tab in Settings alongside the three new fields, keeping the AI tab focused on provider/model config.

## Changes

**Backend**
- `settings.rs`: register the three keys as default (empty) settings
- `agent.rs`: read `chat_prompt` from settings, prepend to base system prompt when non-empty
- `briefing/agentic.rs`: read `briefing_prompt` from settings, use as system prompt when non-empty
- `extraction.rs`: accept `Option<&str> custom_system_prompt` param; apply when non-empty
- `embedding.rs`: read `tagging_prompt` from settings map, thread through `run_tagging_strategy` → `extract_tags_from_content`

**Frontend**
- `SettingsModal.tsx`: add Prompts tab; move wiki generation prompt there; add briefing, chat, tagging prompt text areas

## Testing

`cargo check -p atomic-core` — clean; `npx tsc --noEmit` — clean