### PR TITLE
Fix/local graph webgl crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <link rel="apple-touch-icon" href="/icons/icon-256.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#1e1e1e" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Atomic" />

--- a/src/components/canvas/LocalGraphView.tsx
+++ b/src/components/canvas/LocalGraphView.tsx
@@ -12,6 +12,27 @@ const SIZE_CENTER = 18;
 const SIZE_DEPTH_1 = 11;
 const SIZE_DEPTH_2 = 7;
 
+/**
+ * Kill a Sigma instance and proactively release its WebGL contexts.
+ *
+ * `sigma.kill()` detaches its canvases but the browser may hold the underlying
+ * WebGL contexts until GC. Browsers cap concurrent contexts per tab (~16 on
+ * Chrome, ~8 on Safari), and rapid re-centers of the local graph can exhaust
+ * the pool — the next `new Sigma` then gets a canvas whose `getContext`
+ * returns null and crashes on its first GL call (e.g. `gl.blendFunc`).
+ * `WEBGL_lose_context.loseContext()` frees the slot immediately.
+ */
+function releaseSigma(sigma: Sigma, container: HTMLElement) {
+  const canvases = Array.from(container.querySelectorAll('canvas'));
+  sigma.kill();
+  for (const canvas of canvases) {
+    const gl =
+      (canvas.getContext('webgl2') as WebGL2RenderingContext | null) ??
+      (canvas.getContext('webgl') as WebGLRenderingContext | null);
+    gl?.getExtension('WEBGL_lose_context')?.loseContext();
+  }
+}
+
 /** Brighten/dim an [r,g,b] triple by a 0..1 factor. */
 function modulateRgb(rgb: [number, number, number], factor: number): string {
   return `rgb(${Math.round(rgb[0] * factor)},${Math.round(rgb[1] * factor)},${Math.round(rgb[2] * factor)})`;
@@ -233,7 +254,7 @@ export function LocalGraphView() {
     if (!container || !graph || graph.atoms.length === 0) return;
 
     if (sigmaRef.current) {
-      sigmaRef.current.kill();
+      releaseSigma(sigmaRef.current, container);
       sigmaRef.current = null;
     }
 
@@ -329,56 +350,67 @@ export function LocalGraphView() {
     }
     neighborsRef.current = neighbors;
 
-    const sigma = new Sigma(g, container, {
-      // Labels are rendered by our overlay canvas (always-on with collision avoidance).
-      renderLabels: false,
-      defaultEdgeColor: '#333',
-      defaultNodeColor: '#555',
-      defaultEdgeType: 'curved',
-      zIndex: true,
-      edgeProgramClasses: {
-        curved: EdgeCurveProgram,
-      },
-      minCameraRatio: 0.2,
-      maxCameraRatio: 4,
-      stagePadding: 80,
-      defaultDrawNodeHover: () => {}, // Hover ring/pill drawn on overlay
-      nodeReducer: (node, attrs) => {
-        const hovered = hoveredNodeRef.current;
-        if (!hovered) return attrs;
-        if (node === hovered) return { ...attrs, zIndex: 2 };
-        const isNeighbor = neighborsRef.current.get(hovered)?.has(node);
-        if (isNeighbor) return { ...attrs, zIndex: 1 };
-        // Non-neighbors fade toward gray. Sizes stay put — in a small ego-network shrinking
-        // most of the nodes at once reads as "the whole graph just got smaller", which is
-        // disorienting. Color fade is enough to direct attention.
-        const dim = hoverAnimRef.current;
-        const rgb = parseRgbColor(attrs.color as string);
-        const color = rgb
-          ? `rgb(${Math.round(rgb[0] + (60 - rgb[0]) * dim)},${Math.round(rgb[1] + (60 - rgb[1]) * dim)},${Math.round(rgb[2] + (60 - rgb[2]) * dim)})`
-          : attrs.color;
-        return { ...attrs, color };
-      },
-      edgeReducer: (edge, attrs) => {
-        const hovered = hoveredNodeRef.current;
-        if (!hovered) return attrs;
-        const src = g.source(edge);
-        const dst = g.target(edge);
-        const incident = src === hovered || dst === hovered;
-        const dim = hoverAnimRef.current;
-        if (incident) {
-          // Brighten incident edges via color (no size pump — same reason as nodeReducer).
-          return { ...attrs, zIndex: 1 };
-        }
-        // Fade non-incident edges toward the background (color only).
-        const rgb = parseRgbColor(attrs.color as string);
-        const bg = parseRgbColor(themeRef.current.background) ?? [30, 30, 30];
-        const color = rgb
-          ? `rgb(${Math.round(rgb[0] + (bg[0] - rgb[0]) * dim * 0.85)},${Math.round(rgb[1] + (bg[1] - rgb[1]) * dim * 0.85)},${Math.round(rgb[2] + (bg[2] - rgb[2]) * dim * 0.85)})`
-          : attrs.color;
-        return { ...attrs, color };
-      },
-    });
+    let sigma: Sigma;
+    try {
+      sigma = new Sigma(g, container, {
+        // Labels are rendered by our overlay canvas (always-on with collision avoidance).
+        renderLabels: false,
+        defaultEdgeColor: '#333',
+        defaultNodeColor: '#555',
+        defaultEdgeType: 'curved',
+        zIndex: true,
+        edgeProgramClasses: {
+          curved: EdgeCurveProgram,
+        },
+        minCameraRatio: 0.2,
+        maxCameraRatio: 4,
+        stagePadding: 80,
+        defaultDrawNodeHover: () => {}, // Hover ring/pill drawn on overlay
+        nodeReducer: (node, attrs) => {
+          const hovered = hoveredNodeRef.current;
+          if (!hovered) return attrs;
+          if (node === hovered) return { ...attrs, zIndex: 2 };
+          const isNeighbor = neighborsRef.current.get(hovered)?.has(node);
+          if (isNeighbor) return { ...attrs, zIndex: 1 };
+          // Non-neighbors fade toward gray. Sizes stay put — in a small ego-network shrinking
+          // most of the nodes at once reads as "the whole graph just got smaller", which is
+          // disorienting. Color fade is enough to direct attention.
+          const dim = hoverAnimRef.current;
+          const rgb = parseRgbColor(attrs.color as string);
+          const color = rgb
+            ? `rgb(${Math.round(rgb[0] + (60 - rgb[0]) * dim)},${Math.round(rgb[1] + (60 - rgb[1]) * dim)},${Math.round(rgb[2] + (60 - rgb[2]) * dim)})`
+            : attrs.color;
+          return { ...attrs, color };
+        },
+        edgeReducer: (edge, attrs) => {
+          const hovered = hoveredNodeRef.current;
+          if (!hovered) return attrs;
+          const src = g.source(edge);
+          const dst = g.target(edge);
+          const incident = src === hovered || dst === hovered;
+          const dim = hoverAnimRef.current;
+          if (incident) {
+            // Brighten incident edges via color (no size pump — same reason as nodeReducer).
+            return { ...attrs, zIndex: 1 };
+          }
+          // Fade non-incident edges toward the background (color only).
+          const rgb = parseRgbColor(attrs.color as string);
+          const bg = parseRgbColor(themeRef.current.background) ?? [30, 30, 30];
+          const color = rgb
+            ? `rgb(${Math.round(rgb[0] + (bg[0] - rgb[0]) * dim * 0.85)},${Math.round(rgb[1] + (bg[1] - rgb[1]) * dim * 0.85)},${Math.round(rgb[2] + (bg[2] - rgb[2]) * dim * 0.85)})`
+            : attrs.color;
+          return { ...attrs, color };
+        },
+      });
+    } catch (err) {
+      // WebGL context unavailable — typically the browser has hit its per-tab
+      // context limit. Surface a graceful error instead of letting the crash
+      // bubble up to the route-level Error Boundary and blank the page.
+      console.error('LocalGraphView: failed to initialize graph renderer', err);
+      setError('Could not initialize the graph renderer. Try closing other tabs that use graph or 3D views, or reload the page.');
+      graphRef.current = null;
+      return;
+    }
 
     sigmaRef.current = sigma;
 
@@ -591,7 +623,7 @@ export function LocalGraphView() {
 
     return () => {
       if (hoverRaf !== null) cancelAnimationFrame(hoverRaf);
-      sigma.kill();
+      releaseSigma(sigma, container);
       labelCanvas.remove();
       sigmaRef.current = null;
       graphRef.current = null;


### PR DESCRIPTION
## Summary

- `LocalGraphView` no longer crashes the page when the browser refuses a WebGL context.
- The first-load console warning about `apple-mobile-web-app-capable` deprecation goes away.

## What was happening

Hosting a fresh instance and opening the local graph (`/graph?tag=…`) bubbled up to the route-level Error Boundary:

```
TypeError: Cannot read properties of null (reading 'blendFunc')
    at new Sigma (…)
    at LocalGraphView (…)
```

`gl.blendFunc(...)` is one of the first calls Sigma makes in its constructor. The trace means `canvas.getContext('webgl2' | 'webgl')` returned `null` — i.e. the browser refused to allocate a context.

The trigger is the browser's per-tab WebGL context cap (~16 on Chromium, ~8 on Safari). `sigma.kill()` detaches its canvases but the GL contexts linger until GC, so rapid re-centers of the local graph (or coexistence with the main `SigmaCanvas`) can exhaust the pool. The next `new Sigma(...)` then gets a context-less canvas and crashes on its first state call.

## Fix

1. **`releaseSigma(sigma, container)`** helper — calls `sigma.kill()` and then `WEBGL_lose_context.loseContext()` on each canvas in the container, freeing the GL slot immediately rather than waiting on GC. Used from both the in-effect "previous Sigma" cleanup and the effect's return cleanup.
2. **`try { new Sigma(...) } catch`** — if a context still can't be acquired we now `setError(...)` instead of letting the route's Error Boundary blank the whole page.
3. **`<meta name="mobile-web-app-capable">`** added alongside the Apple-prefixed one to silence the Chrome 102+ deprecation warning.

## Test plan

- [ ] Open local graph; verify it renders.
- [ ] Re-center the local graph rapidly across many atoms — previously surfaced the crash within ~10 navigations on Chrome; should now stay stable.
- [ ] Force a context failure (Chrome devtools → Rendering → "Disable WebGL") and confirm the friendly error message replaces the Error Boundary blank page.
- [ ] Verify the `apple-mobile-web-app-capable` deprecation warning is gone from the console on initial load.