### PR TITLE
Cloud tenant API token management

### DIFF
--- a/crates/atomic-cloud/migrations/019_cloud_token_prefix.sql
+++ b/crates/atomic-cloud/migrations/019_cloud_token_prefix.sql
@@ -1,0 +1,9 @@
+-- Cloud tokens gain a display prefix (the first 10 chars of the plaintext,
+-- e.g. 'atm_4yegax'), stored at mint time: hash-only storage can't recover
+-- it, and the tenant token-management UI renders it so users can tell their
+-- tokens apart (and detect "you're revoking the token you're using"). Rows
+-- minted before this migration stay NULL and render without a prefix.
+ALTER TABLE cloud_tokens ADD COLUMN token_prefix TEXT;
+
+-- Record this migration in the version table (the runner reads MAX(version)).
+INSERT INTO schema_version (version) VALUES (19);

--- a/crates/atomic-cloud/src/control_plane.rs
+++ b/crates/atomic-cloud/src/control_plane.rs
@@ -83,6 +83,10 @@ const MIGRATIONS: &[(i32, &str)] = &[
         18,
         include_str!("../migrations/018_premium_models_flag.sql"),
     ),
+    (
+        19,
+        include_str!("../migrations/019_cloud_token_prefix.sql"),
+    ),
 ];
 
 /// Advisory lock key serializing control-plane migrations. Advisory locks

--- a/crates/atomic-cloud/src/server.rs
+++ b/crates/atomic-cloud/src/server.rs
@@ -272,7 +272,15 @@ pub const DEFAULT_MCP_SSE_KEEP_ALIVE: Duration = Duration::from_secs(30);
 ///   tenant's export by id.
 /// - `/api/logs` — the process-wide log ring buffer (`state.log_buffer`).
 fn fallback_bound_plane(path: &str) -> bool {
-    if path.starts_with("/api/auth/") || path.starts_with("/api/exports/") || path == "/api/logs" {
+    if path.starts_with("/api/auth/") {
+        // The token subtree has a cloud-owned, per-tenant implementation
+        // (tenant_plane's `/api/auth/tokens*`, backed by `cloud_tokens`)
+        // registered ahead of `api_scope` — those requests must pass this
+        // guard. Everything else under the self-hosted auth plane stays
+        // unrouted.
+        return !(path == "/api/auth/tokens" || path.starts_with("/api/auth/tokens/"));
+    }
+    if path.starts_with("/api/exports/") || path == "/api/logs" {
         return true;
     }
     // `/api/databases/{id}/exports/...` — the export-start route lives under
@@ -598,8 +606,10 @@ mod tests {
     #[test]
     fn fallback_bound_planes_are_matched() {
         for unrouted in [
-            "/api/auth/tokens",
-            "/api/auth/tokens/some-id",
+            // The rest of the self-hosted auth plane stays fallback-bound —
+            // only the token subtree is cloud-owned (tenant_plane).
+            "/api/auth/setup",
+            "/api/auth/whoami",
             "/api/exports/job-1",
             "/api/exports/job-1/download",
             "/api/databases/default/exports/markdown",
@@ -615,6 +625,9 @@ mod tests {
         for routed in [
             "/api/atoms",
             "/api/databases",
+            // The token subtree is cloud-owned now (tenant_plane serves it).
+            "/api/auth/tokens",
+            "/api/auth/tokens/some-id",
             "/api/databases/default/stats",
             "/api/databases/default/activate",
             // Only the exact /api/logs path is the log plane.

--- a/crates/atomic-cloud/src/tenant_plane.rs
+++ b/crates/atomic-cloud/src/tenant_plane.rs
@@ -505,6 +505,27 @@ impl TenantPlane {
                 .app_data(self.state.clone())
                 .route(web::put().to(update_models_route))
                 .wrap(from_fn(cloud_plane_guard))
+                .wrap(auth.clone()),
+        );
+        // The tenant token-management plane, at the SAME paths as
+        // atomic-server's self-hosted token routes so the product app's
+        // existing settings UI works unchanged. Registered here (ahead of
+        // `api_scope`) these exact-path resources win the match; the
+        // self-hosted handlers behind them stay unreachable, and the rest
+        // of `/api/auth/*` stays unrouted by `fallback_bound_plane`.
+        cfg.service(
+            web::resource("/api/auth/tokens")
+                .app_data(self.state.clone())
+                .route(web::get().to(list_tokens_route))
+                .route(web::post().to(create_token_route))
+                .wrap(from_fn(cloud_plane_guard))
+                .wrap(auth.clone()),
+        );
+        cfg.service(
+            web::resource("/api/auth/tokens/{id}")
+                .app_data(self.state.clone())
+                .route(web::delete().to(revoke_token_route))
+                .wrap(from_fn(cloud_plane_guard))
                 .wrap(auth),
         );
     }
@@ -1527,6 +1548,140 @@ async fn rearm_provider_held_work(state: &PlaneState, account_id: &str) {
 /// authorization posture). CloudAuth installs the extension on every
 /// request it passes; like `cloud_plane_guard`, its absence is a
 /// composition bug and fails closed rather than guessing at an identity.
+// --- Tenant token management (`/api/auth/tokens*`) ---------------------------
+//
+// Cloud's per-tenant implementation of the self-hosted token plane: same
+// paths, same response shapes (the product settings UI consumes both), but
+// backed by the account's control-plane `cloud_tokens` rows — the store
+// CloudAuth actually verifies against. Account-scope only, like every route
+// in this module: a db-pinned or MCP-scoped credential minting an
+// account-scope token would be privilege escalation.
+
+/// Body of `POST /api/auth/tokens` — mirrors atomic-server's `CreateTokenBody`.
+#[derive(Deserialize)]
+struct CreateCloudTokenBody {
+    name: String,
+}
+
+/// `POST /api/auth/tokens`: mint an account-scope token, returning its
+/// plaintext exactly once (only the hash is stored). Response shape matches
+/// the self-hosted route: `{id, name, token, prefix, created_at}`.
+async fn create_token_route(
+    req: HttpRequest,
+    state: web::Data<PlaneState>,
+    body: web::Json<CreateCloudTokenBody>,
+) -> HttpResponse {
+    let tenant = match require_account_scope(&req) {
+        Ok(tenant) => tenant,
+        Err(denial) => return denial,
+    };
+    let name = body.into_inner().name;
+    let name = name.trim();
+    if name.is_empty() || name.len() > 100 {
+        return bad_request(
+            "invalid_token_name",
+            "Token name must be 1-100 characters.",
+        );
+    }
+
+    match crate::tokens::issue_token(
+        &state.control,
+        &tenant.principal.account_id,
+        TokenScope::Account,
+        None,
+        name,
+    )
+    .await
+    {
+        Ok(plaintext) => HttpResponse::Created().json(json!({
+            "id": crate::tokens::sha256_hex(&plaintext),
+            "name": name,
+            "token": plaintext,
+            "prefix": crate::tokens::display_prefix(&plaintext),
+            "created_at": chrono::Utc::now().to_rfc3339(),
+            "scope": "account",
+        })),
+        Err(e) => {
+            tracing::error!(error = %e, "minting tenant token failed");
+            HttpResponse::InternalServerError().json(json!({
+                "error": "token_create_failed",
+                "message": "Could not create the token.",
+            }))
+        }
+    }
+}
+
+/// `GET /api/auth/tokens`: the account's live tokens, metadata only —
+/// shaped like atomic-core's `ApiTokenInfo` so the settings UI renders it
+/// unchanged. Includes OAuth-minted MCP tokens: listing (and revoking) them
+/// is how a user audits and severs MCP-client access.
+async fn list_tokens_route(req: HttpRequest, state: web::Data<PlaneState>) -> HttpResponse {
+    let tenant = match require_account_scope(&req) {
+        Ok(tenant) => tenant,
+        Err(denial) => return denial,
+    };
+    match crate::tokens::list_account_tokens(&state.control, &tenant.principal.account_id).await {
+        Ok(tokens) => HttpResponse::Ok().json(
+            tokens
+                .into_iter()
+                .map(|t| {
+                    json!({
+                        "id": t.id,
+                        "name": t.name,
+                        "token_prefix": t.token_prefix.unwrap_or_default(),
+                        "created_at": t.created_at.to_rfc3339(),
+                        "last_used_at": t.last_used_at.map(|ts| ts.to_rfc3339()),
+                        "is_revoked": false,
+                        "scope": t.scope,
+                    })
+                })
+                .collect::<Vec<_>>(),
+        ),
+        Err(e) => {
+            tracing::error!(error = %e, "listing tenant tokens failed");
+            HttpResponse::InternalServerError().json(json!({
+                "error": "token_list_failed",
+                "message": "Could not list tokens.",
+            }))
+        }
+    }
+}
+
+/// `DELETE /api/auth/tokens/{id}`: revoke one of the account's tokens.
+/// The id is the stored hash; the account scoping inside the UPDATE is the
+/// cross-tenant chokepoint, so an id from another tenant reads as 404.
+async fn revoke_token_route(
+    req: HttpRequest,
+    state: web::Data<PlaneState>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let tenant = match require_account_scope(&req) {
+        Ok(tenant) => tenant,
+        Err(denial) => return denial,
+    };
+    let token_id = path.into_inner();
+    match crate::tokens::revoke_account_token(
+        &state.control,
+        &tenant.principal.account_id,
+        &token_id,
+    )
+    .await
+    {
+        Ok(true) => HttpResponse::Ok().json(json!({ "revoked": true })),
+        Ok(false) => HttpResponse::NotFound().json(json!({
+            "error": "not_found",
+            "message": "No such token.",
+        })),
+        Err(e) => {
+            tracing::error!(error = %e, "revoking tenant token failed");
+            HttpResponse::InternalServerError().json(json!({
+                "error": "token_revoke_failed",
+                "message": "Could not revoke the token.",
+            }))
+        }
+    }
+}
+
 fn require_account_scope(req: &HttpRequest) -> Result<ResolvedTenant, HttpResponse> {
     let Some(tenant) = req.extensions().get::<ResolvedTenant>().cloned() else {
         tracing::error!(

--- a/crates/atomic-cloud/src/tokens.rs
+++ b/crates/atomic-cloud/src/tokens.rs
@@ -176,18 +176,84 @@ pub async fn issue_token(
 ) -> Result<String, CloudError> {
     let (plaintext, hash) = generate_secret(TOKEN_PREFIX);
     sqlx::query(
-        "INSERT INTO cloud_tokens (hash, account_id, scope, allowed_db_id, name) \
-         VALUES ($1, $2, $3, $4, $5)",
+        "INSERT INTO cloud_tokens (hash, account_id, scope, allowed_db_id, name, token_prefix) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
     )
     .bind(&hash)
     .bind(account_id)
     .bind(scope.as_str())
     .bind(allowed_db_id)
     .bind(name)
+    .bind(display_prefix(&plaintext))
     .execute(control.pool())
     .await
     .map_err(CloudError::db("inserting cloud token"))?;
     Ok(plaintext)
+}
+
+/// The stored display prefix: the plaintext's first 10 chars
+/// (`atm_` + 6). Enough to tell tokens apart in a list — and to match the
+/// self-hosted UI's "is this the token I'm using?" comparison — without
+/// meaningfully narrowing the 32-random-byte search space.
+pub(crate) fn display_prefix(plaintext: &str) -> &str {
+    &plaintext[..10.min(plaintext.len())]
+}
+
+/// Token metadata for the tenant token-management surface: everything a
+/// list view needs, never the hash's preimage. `id` is the hash itself —
+/// it identifies the row for revocation and is useless for authentication
+/// (verifying requires the plaintext preimage).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TokenMeta {
+    #[sqlx(rename = "hash")]
+    pub id: String,
+    pub name: String,
+    pub scope: String,
+    pub token_prefix: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub last_used_at: Option<DateTime<Utc>>,
+}
+
+/// The account's live tokens (not revoked, not expired), oldest first.
+/// Includes OAuth-minted MCP tokens — surfacing them is how a user audits
+/// and severs MCP-client access.
+pub async fn list_account_tokens(
+    control: &ControlPlane,
+    account_id: &str,
+) -> Result<Vec<TokenMeta>, CloudError> {
+    sqlx::query_as(
+        "SELECT hash, name, scope, token_prefix, created_at, last_used_at \
+         FROM cloud_tokens \
+         WHERE account_id = $1 \
+           AND revoked_at IS NULL \
+           AND (expires_at IS NULL OR expires_at > NOW()) \
+         ORDER BY created_at",
+    )
+    .bind(account_id)
+    .fetch_all(control.pool())
+    .await
+    .map_err(CloudError::db("listing cloud tokens"))
+}
+
+/// Revoke one of the account's tokens by id (the hash). Returns `false`
+/// when the id names no live token of THIS account — the account scoping
+/// is the same cross-tenant chokepoint as verification, so one tenant's
+/// revoke can never touch another's row.
+pub async fn revoke_account_token(
+    control: &ControlPlane,
+    account_id: &str,
+    token_id: &str,
+) -> Result<bool, CloudError> {
+    let result = sqlx::query(
+        "UPDATE cloud_tokens SET revoked_at = NOW() \
+         WHERE account_id = $1 AND hash = $2 AND revoked_at IS NULL",
+    )
+    .bind(account_id)
+    .bind(token_id)
+    .execute(control.pool())
+    .await
+    .map_err(CloudError::db("revoking cloud token"))?;
+    Ok(result.rows_affected() > 0)
 }
 
 /// Verify a token plaintext against `account_id`.

--- a/crates/atomic-cloud/tests/e2e_cloud.rs
+++ b/crates/atomic-cloud/tests/e2e_cloud.rs
@@ -644,8 +644,11 @@ async fn unknown_subdomain_and_unauthenticated_requests() {
                 .expect("send");
             assert_eq!(resp.status(), StatusCode::OK);
 
-            // The self-hosted token plane is unrouted in cloud, even for an
-            // authenticated tenant: cloud tokens live in the control plane.
+            // The token subtree is cloud-owned now (tenant_plane serves it
+            // against control-plane cloud_tokens; see
+            // tenant_token_management_plane), but the REST of the
+            // self-hosted auth plane stays unrouted even for an
+            // authenticated tenant.
             let resp = h
                 .api(Method::GET, &alpha.subdomain, "/api/auth/tokens")
                 .bearer_auth(&alpha.token)
@@ -654,8 +657,19 @@ async fn unknown_subdomain_and_unauthenticated_requests() {
                 .expect("send");
             assert_eq!(
                 resp.status(),
+                StatusCode::OK,
+                "the token subtree is cloud-owned and routed"
+            );
+            let resp = h
+                .api(Method::GET, &alpha.subdomain, "/api/auth/setup")
+                .bearer_auth(&alpha.token)
+                .send()
+                .await
+                .expect("send");
+            assert_eq!(
+                resp.status(),
                 StatusCode::NOT_FOUND,
-                "self-hosted token plane must be unrouted"
+                "the rest of the self-hosted auth plane must stay unrouted"
             );
 
             h.stop().await;
@@ -1233,9 +1247,21 @@ async fn fallback_state_fails_closed_without_tenant_extension() {
     .await;
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
-    // And the guard's other rule: the self-hosted token plane — the one
-    // /api family whose handlers bind the composition-time AppState manager
-    // (the fallback) directly — is unrouted.
+    // And the guard's other rule: the self-hosted auth plane — handlers
+    // that bind the composition-time AppState manager (the fallback)
+    // directly — is unrouted…
+    let resp = actix_test::call_service(
+        &app,
+        actix_test::TestRequest::get()
+            .uri("/api/auth/setup")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // …except the token subtree, which is cloud-owned (tenant_plane) and
+    // carved out of the unrouting — so with no resolved tenant it
+    // fail-closes through the guard's missing-extension rule instead.
     let resp = actix_test::call_service(
         &app,
         actix_test::TestRequest::get()
@@ -1243,7 +1269,7 @@ async fn fallback_state_fails_closed_without_tenant_extension() {
             .to_request(),
     )
     .await;
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
 /// The data plane writes dispatch hints (plan: "Worker fairness & job

--- a/crates/atomic-cloud/tests/e2e_cloud.rs
+++ b/crates/atomic-cloud/tests/e2e_cloud.rs
@@ -1808,3 +1808,162 @@ async fn tenant_migration_import_end_to_end() {
     })
     .await;
 }
+
+/// The tenant token-management plane (`/api/auth/tokens*`): mint → list →
+/// use → revoke → dead, with the scope-escalation and cross-tenant
+/// chokepoints asserted along the way. This is the surface the product
+/// app's settings UI drives, and the token source for the desktop
+/// "Migrate to Cloud" flow.
+#[actix_web::test]
+async fn tenant_token_management_plane() {
+    with_control_db("tenant_token_management_plane", |url| async move {
+        let h = CloudHarness::spawn(&url, AccountCacheConfig::default()).await;
+        let alpha = h.provision("alpha").await;
+        let bravo = h.provision("bravo").await;
+
+        // Mint through the route; the plaintext appears exactly once.
+        let resp = h
+            .api(Method::POST, &alpha.subdomain, "/api/auth/tokens")
+            .bearer_auth(&alpha.token)
+            .json(&json!({ "name": "migration-laptop" }))
+            .send()
+            .await
+            .expect("create token");
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let created: Value = resp.json().await.expect("created json");
+        let minted = created["token"].as_str().expect("plaintext").to_string();
+        let minted_id = created["id"].as_str().expect("id").to_string();
+        assert!(minted.starts_with("atm_"), "cloud token prefix");
+        assert_eq!(
+            created["prefix"].as_str().expect("prefix"),
+            &minted[..10],
+            "display prefix is the plaintext's first 10 chars"
+        );
+
+        // It lists — metadata only, prefix present, never the plaintext.
+        let resp = h
+            .api(Method::GET, &alpha.subdomain, "/api/auth/tokens")
+            .bearer_auth(&alpha.token)
+            .send()
+            .await
+            .expect("list tokens");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let listing: Value = resp.json().await.expect("list json");
+        let entries = listing.as_array().expect("array");
+        assert!(
+            entries.iter().any(|t| t["name"] == "migration-laptop"
+                && t["token_prefix"] == created["prefix"]
+                && t["is_revoked"] == false),
+            "minted token appears with its metadata: {listing}"
+        );
+        assert!(
+            !listing.to_string().contains(&minted),
+            "the plaintext must never appear in a listing"
+        );
+
+        // The minted token is a working data-plane credential.
+        let resp = h
+            .api(Method::GET, &alpha.subdomain, "/api/atoms")
+            .bearer_auth(&minted)
+            .send()
+            .await
+            .expect("use minted token");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Escalation chokepoint: a db-pinned credential may not mint an
+        // account-scope token (nor list or revoke).
+        let pinned = issue_token(
+            &h.control,
+            &alpha.account_id,
+            TokenScope::Database,
+            Some("default"),
+            "kb-pinned",
+        )
+        .await
+        .expect("issue pinned token");
+        for (method, path) in [
+            (Method::POST, "/api/auth/tokens".to_string()),
+            (Method::GET, "/api/auth/tokens".to_string()),
+            (Method::DELETE, format!("/api/auth/tokens/{minted_id}")),
+        ] {
+            let mut req = h.api(method.clone(), &alpha.subdomain, &path).bearer_auth(&pinned);
+            if method == Method::POST {
+                req = req.json(&json!({ "name": "escalation" }));
+            }
+            let resp = req.send().await.expect("scoped request");
+            assert_eq!(
+                resp.status(),
+                StatusCode::FORBIDDEN,
+                "{method} {path} must 403 for a db-pinned credential"
+            );
+        }
+
+        // Cross-tenant chokepoint: bravo can neither see nor revoke alpha's
+        // token — the foreign id reads as not-found.
+        let resp = h
+            .api(
+                Method::DELETE,
+                &bravo.subdomain,
+                &format!("/api/auth/tokens/{minted_id}"),
+            )
+            .bearer_auth(&bravo.token)
+            .send()
+            .await
+            .expect("cross-tenant revoke");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let resp = h
+            .api(Method::GET, &bravo.subdomain, "/api/auth/tokens")
+            .bearer_auth(&bravo.token)
+            .send()
+            .await
+            .expect("bravo list");
+        let bravo_listing: Value = resp.json().await.expect("bravo json");
+        assert!(
+            bravo_listing
+                .as_array()
+                .expect("array")
+                .iter()
+                .all(|t| t["name"] != "migration-laptop"),
+            "alpha's token must never appear in bravo's listing"
+        );
+
+        // Revoke for real: the route confirms, the credential dies, and the
+        // listing no longer shows it.
+        let resp = h
+            .api(
+                Method::DELETE,
+                &alpha.subdomain,
+                &format!("/api/auth/tokens/{minted_id}"),
+            )
+            .bearer_auth(&alpha.token)
+            .send()
+            .await
+            .expect("revoke");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp = h
+            .api(Method::GET, &alpha.subdomain, "/api/atoms")
+            .bearer_auth(&minted)
+            .send()
+            .await
+            .expect("use revoked token");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let resp = h
+            .api(Method::GET, &alpha.subdomain, "/api/auth/tokens")
+            .bearer_auth(&alpha.token)
+            .send()
+            .await
+            .expect("list after revoke");
+        let after: Value = resp.json().await.expect("json");
+        assert!(
+            after
+                .as_array()
+                .expect("array")
+                .iter()
+                .all(|t| t["id"] != minted_id.as_str()),
+            "revoked token must leave the listing"
+        );
+
+        h.stop().await;
+    })
+    .await;
+}

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -80,7 +80,7 @@ import { getBrowserTimeZone, getSupportedTimeZones } from '../../lib/tz';
 import { useDatabasesStore, type DatabaseInfo, type DatabaseStats } from '../../stores/databases';
 import { OverrideControls } from './OverrideControls';
 
-export type SettingsTab = 'general' | 'ai' | 'tag-categories' | 'connection' | 'integrations' | 'databases' | 'prompts' | 'migrate';
+export type SettingsTab = 'general' | 'ai' | 'tag-categories' | 'connection' | 'integrations' | 'databases' | 'prompts' | 'migrate' | 'tokens';
 
 const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: 'general', label: 'General' },
@@ -1053,15 +1053,23 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
   const localServerConfig = isDesktopApp() ? getLocalServerConfig() : null;
 
   // On Atomic Cloud the provider/models and the connection itself are owned by
-  // the control plane (managed key or dashboard BYOK; fixed cookie-auth origin;
-  // account-scoped tokens live in the dashboard). Those tabs would only mislead
-  // — and their fetches (provider models, /api/auth/tokens) 404 — so a cloud
-  // tenant never sees them.
+  // the control plane (managed key or dashboard BYOK; fixed cookie-auth
+  // origin), and "Migrate to Cloud" is where you already are. Those tabs
+  // would only mislead, so a cloud tenant never sees them. Token management
+  // IS tenant-facing on cloud (the tenant-plane serves /api/auth/tokens
+  // against the account's control-plane tokens), but it lives inside the
+  // hidden Connection tab — so cloud gets a dedicated API Tokens tab that
+  // renders the same section.
   const isCloud = isCloudTenant();
   const visibleTabs = useMemo(
     () =>
       isCloud
-        ? SETTINGS_TABS.filter(tab => tab.id !== 'ai' && tab.id !== 'connection')
+        ? [
+            ...SETTINGS_TABS.filter(
+              tab => tab.id !== 'ai' && tab.id !== 'connection' && tab.id !== 'migrate',
+            ),
+            { id: 'tokens' as SettingsTab, label: 'API Tokens' },
+          ]
         : SETTINGS_TABS,
     [isCloud],
   );
@@ -1173,6 +1181,15 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
   };
 
   // Revoke an API token
+  // The dedicated API Tokens tab (cloud) renders the section expanded and
+  // freshly loaded; the Connection tab keeps its collapsed-by-default state.
+  useEffect(() => {
+    if (isOpen && activeTab === 'tokens') {
+      setShowTokenSection(true);
+      loadApiTokens();
+    }
+  }, [isOpen, activeTab, loadApiTokens]);
+
   const handleRevokeToken = async (tokenId: string) => {
     // Check if revoking the current token
     const currentPrefix = serverToken.substring(0, 10);
@@ -1365,9 +1382,9 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
         }
       }
       // Load API tokens when connected to a non-local server. Cloud tenants
-      // manage account-scoped tokens in the dashboard, not here (the data-plane
-      // /api/auth/tokens route is not exposed), so skip it.
-      if (!isLocalServer() && !isCloud && transport.isConnected()) {
+      // included: the tenant plane serves /api/auth/tokens against the
+      // account's control-plane tokens.
+      if (!isLocalServer() && transport.isConnected()) {
         loadApiTokens();
       }
       // Reset token creation state
@@ -1699,6 +1716,154 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
   const ollamaLlmModels: AvailableModel[] = ollamaModels
     .filter(m => !m.is_embedding)
     .map(m => ({ id: m.id, name: m.name }));
+
+  // The API-token management section, rendered in two places: inside the
+  // Connection tab (self-hosted remote/web mode) and as the cloud tenants'
+  // dedicated API Tokens tab. All state/handlers live at component scope.
+  const apiTokensSection = (
+    <div className="space-y-3 pt-4 border-t border-[var(--color-border)]">
+      <button
+        type="button"
+        onClick={() => setShowTokenSection(!showTokenSection)}
+        className="flex items-center gap-2 text-sm font-medium text-[var(--color-text-primary)] hover:text-white transition-colors w-full"
+      >
+        <ChevronRight
+          className={`w-4 h-4 transition-transform ${showTokenSection ? 'rotate-90' : ''}`}
+          strokeWidth={2}
+        />
+        API Tokens
+        {apiTokens.filter(t => !t.is_revoked).length > 0 && (
+          <span className="text-xs text-[var(--color-text-secondary)]">
+            ({apiTokens.filter(t => !t.is_revoked).length} active)
+          </span>
+        )}
+      </button>
+
+      {showTokenSection && (
+        <div className="space-y-4 pl-6 border-l-2 border-[var(--color-border)]">
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            Manage API tokens for accessing this server. Each device or integration should use its own token.
+          </p>
+
+          {/* Token list */}
+          {isLoadingTokens ? (
+            <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+              <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
+              Loading tokens...
+            </div>
+          ) : apiTokens.length === 0 ? (
+            <div className="text-sm text-[var(--color-text-secondary)]">No tokens found.</div>
+          ) : (
+            <div className="space-y-2">
+              {apiTokens.filter(t => !t.is_revoked).map((token) => {
+                // Guarded on both sides: cloud (cookie-auth) has no
+                // serverToken, and legacy cloud tokens minted before the
+                // prefix column have an empty prefix — neither may match.
+                const isCurrentToken =
+                  serverToken.length > 0 &&
+                  token.token_prefix.length > 0 &&
+                  token.token_prefix === serverToken.substring(0, 10);
+                return (
+                  <div
+                    key={token.id}
+                    className={`p-3 bg-[var(--color-bg-card)] border rounded-md text-sm ${
+                      isCurrentToken ? 'border-green-500/50' : 'border-[var(--color-border)]'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-[var(--color-text-primary)]">{token.name}</span>
+                        {isCurrentToken && (
+                          <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">current</span>
+                        )}
+                      </div>
+                      {confirmRevokeId === token.id ? (
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-amber-400">
+                            {isCurrentToken ? 'This will log you out!' : 'Revoke?'}
+                          </span>
+                          <button
+                            onClick={() => handleRevokeToken(token.id)}
+                            className="text-xs px-2 py-1 rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
+                          >
+                            Confirm
+                          </button>
+                          <button
+                            onClick={() => setConfirmRevokeId(null)}
+                            className="text-xs px-2 py-1 rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setConfirmRevokeId(token.id)}
+                          className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                        >
+                          Revoke
+                        </button>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3 mt-1 text-xs text-[var(--color-text-secondary)]">
+                      {token.token_prefix && <span className="font-mono">{token.token_prefix}...</span>}
+                      <span>Created {new Date(token.created_at).toLocaleDateString()}</span>
+                      {token.last_used_at && (
+                        <span>Last used {new Date(token.last_used_at).toLocaleDateString()}</span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Created token display (shown once after creation) */}
+          {createdToken && (
+            <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-md space-y-2">
+              <div className="text-sm font-medium text-amber-400">
+                Token created — save it now, it won't be shown again
+              </div>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 text-xs font-mono bg-[var(--color-bg-main)] px-2 py-1.5 rounded border border-[var(--color-border)] text-[var(--color-text-primary)] break-all select-all">
+                  {createdToken.token}
+                </code>
+                <button
+                  onClick={handleCopyToken}
+                  className="p-1.5 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors flex-shrink-0"
+                  title="Copy to clipboard"
+                >
+                  {tokenCopied ? (
+                    <Check className="w-4 h-4 text-green-500" strokeWidth={2} />
+                  ) : (
+                    <Copy className="w-4 h-4" strokeWidth={2} />
+                  )}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Create new token */}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={newTokenName}
+              onChange={(e) => setNewTokenName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleCreateToken(); }}
+              placeholder="Token name (e.g. laptop, phone)"
+              className="flex-1 px-3 py-2 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-md text-[var(--color-text-primary)] placeholder-[var(--color-text-secondary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:border-transparent transition-colors duration-150 text-sm"
+            />
+            <Button
+              variant="secondary"
+              onClick={handleCreateToken}
+              disabled={!newTokenName.trim() || isCreatingToken}
+            >
+              {isCreatingToken ? 'Creating...' : 'Create'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 
   if (!isOpen) return null;
 
@@ -2712,146 +2877,22 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                   )}
 
                   {/* API Tokens Section — remote/web only (auto-managed for local sidecar) */}
-                  {!isLocalServer() && getTransport().isConnected() && (
-                    <div className="space-y-3 pt-4 border-t border-[var(--color-border)]">
-                      <button
-                        type="button"
-                        onClick={() => setShowTokenSection(!showTokenSection)}
-                        className="flex items-center gap-2 text-sm font-medium text-[var(--color-text-primary)] hover:text-white transition-colors w-full"
-                      >
-                        <ChevronRight
-                          className={`w-4 h-4 transition-transform ${showTokenSection ? 'rotate-90' : ''}`}
-                          strokeWidth={2}
-                        />
-                        API Tokens
-                        {apiTokens.filter(t => !t.is_revoked).length > 0 && (
-                          <span className="text-xs text-[var(--color-text-secondary)]">
-                            ({apiTokens.filter(t => !t.is_revoked).length} active)
-                          </span>
-                        )}
-                      </button>
-
-                      {showTokenSection && (
-                        <div className="space-y-4 pl-6 border-l-2 border-[var(--color-border)]">
-                          <p className="text-xs text-[var(--color-text-secondary)]">
-                            Manage API tokens for accessing this server. Each device or integration should use its own token.
-                          </p>
-
-                          {/* Token list */}
-                          {isLoadingTokens ? (
-                            <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-                              <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
-                              Loading tokens...
-                            </div>
-                          ) : apiTokens.length === 0 ? (
-                            <div className="text-sm text-[var(--color-text-secondary)]">No tokens found.</div>
-                          ) : (
-                            <div className="space-y-2">
-                              {apiTokens.filter(t => !t.is_revoked).map((token) => {
-                                const isCurrentToken = token.token_prefix === serverToken.substring(0, 10);
-                                return (
-                                  <div
-                                    key={token.id}
-                                    className={`p-3 bg-[var(--color-bg-card)] border rounded-md text-sm ${
-                                      isCurrentToken ? 'border-green-500/50' : 'border-[var(--color-border)]'
-                                    }`}
-                                  >
-                                    <div className="flex items-center justify-between">
-                                      <div className="flex items-center gap-2">
-                                        <span className="font-medium text-[var(--color-text-primary)]">{token.name}</span>
-                                        {isCurrentToken && (
-                                          <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">current</span>
-                                        )}
-                                      </div>
-                                      {confirmRevokeId === token.id ? (
-                                        <div className="flex items-center gap-2">
-                                          <span className="text-xs text-amber-400">
-                                            {isCurrentToken ? 'This will log you out!' : 'Revoke?'}
-                                          </span>
-                                          <button
-                                            onClick={() => handleRevokeToken(token.id)}
-                                            className="text-xs px-2 py-1 rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
-                                          >
-                                            Confirm
-                                          </button>
-                                          <button
-                                            onClick={() => setConfirmRevokeId(null)}
-                                            className="text-xs px-2 py-1 rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
-                                          >
-                                            Cancel
-                                          </button>
-                                        </div>
-                                      ) : (
-                                        <button
-                                          onClick={() => setConfirmRevokeId(token.id)}
-                                          className="text-xs text-red-400 hover:text-red-300 transition-colors"
-                                        >
-                                          Revoke
-                                        </button>
-                                      )}
-                                    </div>
-                                    <div className="flex items-center gap-3 mt-1 text-xs text-[var(--color-text-secondary)]">
-                                      <span className="font-mono">{token.token_prefix}...</span>
-                                      <span>Created {new Date(token.created_at).toLocaleDateString()}</span>
-                                      {token.last_used_at && (
-                                        <span>Last used {new Date(token.last_used_at).toLocaleDateString()}</span>
-                                      )}
-                                    </div>
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          )}
-
-                          {/* Created token display (shown once after creation) */}
-                          {createdToken && (
-                            <div className="p-3 bg-amber-500/10 border border-amber-500/30 rounded-md space-y-2">
-                              <div className="text-sm font-medium text-amber-400">
-                                Token created — save it now, it won't be shown again
-                              </div>
-                              <div className="flex items-center gap-2">
-                                <code className="flex-1 text-xs font-mono bg-[var(--color-bg-main)] px-2 py-1.5 rounded border border-[var(--color-border)] text-[var(--color-text-primary)] break-all select-all">
-                                  {createdToken.token}
-                                </code>
-                                <button
-                                  onClick={handleCopyToken}
-                                  className="p-1.5 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors flex-shrink-0"
-                                  title="Copy to clipboard"
-                                >
-                                  {tokenCopied ? (
-                                    <Check className="w-4 h-4 text-green-500" strokeWidth={2} />
-                                  ) : (
-                                    <Copy className="w-4 h-4" strokeWidth={2} />
-                                  )}
-                                </button>
-                              </div>
-                            </div>
-                          )}
-
-                          {/* Create new token */}
-                          <div className="flex gap-2">
-                            <input
-                              type="text"
-                              value={newTokenName}
-                              onChange={(e) => setNewTokenName(e.target.value)}
-                              onKeyDown={(e) => { if (e.key === 'Enter') handleCreateToken(); }}
-                              placeholder="Token name (e.g. laptop, phone)"
-                              className="flex-1 px-3 py-2 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-md text-[var(--color-text-primary)] placeholder-[var(--color-text-secondary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:border-transparent transition-colors duration-150 text-sm"
-                            />
-                            <Button
-                              variant="secondary"
-                              onClick={handleCreateToken}
-                              disabled={!newTokenName.trim() || isCreatingToken}
-                            >
-                              {isCreatingToken ? 'Creating...' : 'Create'}
-                            </Button>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
+                  {!isLocalServer() && getTransport().isConnected() && apiTokensSection}
 
                 </>
+              )}
+
+              {/* ===== API TOKENS TAB (cloud tenants; same section, own tab) ===== */}
+              {activeTab === 'tokens' && (
+                <div className="space-y-4">
+                  <p className="text-sm text-[var(--color-text-secondary)]">
+                    Tokens grant full API access to your account — for the desktop
+                    app&apos;s &quot;Migrate to Cloud&quot; flow, scripts, and other
+                    integrations. Treat them like passwords: each one is shown once
+                    at creation and can be revoked here at any time.
+                  </p>
+                  {apiTokensSection}
+                </div>
               )}
 
               {/* ===== INTEGRATIONS TAB ===== */}


### PR DESCRIPTION
## Summary

A regular cloud user had no way to mint the account-scope token the desktop **Migrate to Cloud** flow asks for — the only mint path was the operator CLI over SSH. This reuses the self-hosted token plane end to end:

- **tenant_plane** serves `POST/GET /api/auth/tokens` + `DELETE /api/auth/tokens/{id}` at the same paths and response shapes as atomic-server's routes, backed by the account's control-plane `cloud_tokens` (the store CloudAuth actually verifies). Account-scope credentials only — a db-pinned/MCP token minting an account token would be escalation. `fallback_bound_plane` carves out only the token subtree; the rest of `/api/auth/*` stays unrouted.
- **tokens.rs** grows list/revoke (soft `revoked_at`; `account_id` in every WHERE is the cross-tenant chokepoint) and stores a 10-char display prefix at mint (**migration 019**). OAuth-minted MCP tokens appear in the listing — that's how a user audits and severs MCP-client access.
- **Product settings UI**: the existing token section (previously inside the cloud-hidden Connection tab) becomes a dedicated **API Tokens** tab for cloud tenants. Cloud also stops showing the Migrate-to-Cloud tab (you're already there).

## Testing

- New e2e `tenant_token_management_plane`: mint → list (plaintext never listed) → use on the data plane → revoke → 401; db-pinned 403 on all three routes; cross-tenant revoke reads not-found; listings never leak across accounts.
- Full atomic-cloud suite vs Postgres: **425 passed, 0 failed**. Frontend: tsc clean, vitest 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)