### PR TITLE
Admin portal: plan overrides, comp tiers, account visibility

### DIFF
--- a/crates/atomic-cloud/frontend/src/App.tsx
+++ b/crates/atomic-cloud/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Signup } from './pages/Signup';
 import { Login } from './pages/Login';
 import { Legal } from './pages/Legal';
 import { NotFound } from './pages/NotFound';
+import { Admin } from './pages/Admin';
 import { AccountShell } from './pages/account/AccountShell';
 import { Overview } from './pages/account/Overview';
 import { Provider } from './pages/account/Provider';
@@ -42,6 +43,8 @@ function AppHostRoutes() {
       <Route path="/login" element={<Login />} />
       <Route path="/terms" element={<Legal kind="terms" />} />
       <Route path="/privacy" element={<Legal kind="privacy" />} />
+      {/* Operator portal — server-side 404 to non-admins; the page mirrors it. */}
+      <Route path="/admin" element={<Admin />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/crates/atomic-cloud/frontend/src/lib/api.ts
+++ b/crates/atomic-cloud/frontend/src/lib/api.ts
@@ -414,3 +414,105 @@ export function deleteAccount(
 
 /** Low-level escape hatch for any route without a typed helper. */
 export const api = { request };
+
+// --- Admin plane (app host, is_admin sessions; 404 to everyone else) ---------
+
+/** One row of `GET /admin/api/accounts`. */
+export interface AdminAccount {
+  id: string;
+  subdomain: string;
+  email: string;
+  status: string;
+  plan_id: string | null;
+  plan_pinned: boolean;
+  is_admin: boolean;
+  billing_state: string;
+  trial_ends_at: string | null;
+  created_at: string;
+  last_backup_at: string | null;
+}
+
+/** One `plans` catalogue row (`GET /admin/api/plans`) — the picker's source. */
+export interface AdminPlan {
+  id: string;
+  name: string;
+  monthly_price_cents: number;
+  atom_limit: number | null;
+  kb_limit: number | null;
+  storage_bytes_limit: number | null;
+  ai_credits_monthly_cents: number;
+}
+
+/** `GET /admin/api/accounts/{id}` — the detail drawer's read. */
+export interface AdminAccountDetail {
+  id: string;
+  subdomain: string;
+  email: string;
+  status: string;
+  plan_id: string | null;
+  plan_pinned: boolean;
+  billing_state: string;
+  recent_transitions: {
+    from: string | null;
+    to: string | null;
+    trigger: string;
+    at: string;
+  }[];
+}
+
+/**
+ * The admin plane answers 404 to non-admins by design — callers treat a 404
+ * as "this page does not exist for you", never as a data error, so none of
+ * these redirect on unauthorized.
+ */
+export function adminListAccounts(signal?: AbortSignal): Promise<AdminAccount[]> {
+  return request<AdminAccount[]>('/admin/api/accounts', {
+    method: 'GET',
+    redirectOnUnauthorized: false,
+    signal,
+  });
+}
+
+export function adminGetAccount(
+  id: string,
+  signal?: AbortSignal,
+): Promise<AdminAccountDetail> {
+  return request<AdminAccountDetail>(`/admin/api/accounts/${encodeURIComponent(id)}`, {
+    method: 'GET',
+    redirectOnUnauthorized: false,
+    signal,
+  });
+}
+
+export function adminListPlans(signal?: AbortSignal): Promise<AdminPlan[]> {
+  return request<AdminPlan[]>('/admin/api/plans', {
+    method: 'GET',
+    redirectOnUnauthorized: false,
+    signal,
+  });
+}
+
+export function adminSetPlan(
+  id: string,
+  planId: string,
+  pinned: boolean,
+): Promise<{ plan_id: string; pinned: boolean }> {
+  return request<{ plan_id: string; pinned: boolean }>(
+    `/admin/api/accounts/${encodeURIComponent(id)}/plan`,
+    {
+      method: 'PUT',
+      body: { plan_id: planId, pinned },
+      redirectOnUnauthorized: false,
+    },
+  );
+}
+
+export function adminEvict(id: string): Promise<{ evicted: boolean }> {
+  return request<{ evicted: boolean }>(
+    `/admin/api/accounts/${encodeURIComponent(id)}/evict`,
+    {
+      method: 'POST',
+      redirectOnUnauthorized: false,
+    },
+  );
+}

--- a/crates/atomic-cloud/frontend/src/pages/Admin.tsx
+++ b/crates/atomic-cloud/frontend/src/pages/Admin.tsx
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { PublicLayout } from '../layouts/PublicLayout';
+import { NotFound } from './NotFound';
+import { Banner } from '../components/ui/Banner';
+import { Button } from '../components/ui/Button';
+import { Card } from '../components/ui/Card';
+import { Spinner } from '../components/ui/Spinner';
+import { StatusPill } from '../components/ui/StatusPill';
+import {
+  adminEvict,
+  adminGetAccount,
+  adminListAccounts,
+  adminListPlans,
+  adminSetPlan,
+  ApiError,
+  type AdminAccount,
+  type AdminAccountDetail,
+  type AdminPlan,
+} from '../lib/api';
+
+/**
+ * The operator portal (app host, `/admin`). The server answers 404 to
+ * anything but an is_admin session, and this page mirrors that posture:
+ * a denied fetch renders the ordinary NotFound page, so the portal is
+ * indistinguishable from a dead link to everyone but an admin.
+ *
+ * The plan picker renders from the `plans` catalogue — a new (comp) tier
+ * added by migration appears here with no UI change.
+ */
+export function Admin() {
+  const [state, setState] = useState<
+    | { status: 'loading' }
+    | { status: 'denied' }
+    | { status: 'error'; message: string }
+    | { status: 'ready'; accounts: AdminAccount[]; plans: AdminPlan[] }
+  >({ status: 'loading' });
+  const [notice, setNotice] = useState<{ tone: 'success' | 'warning'; message: string } | null>(
+    null,
+  );
+
+  const load = useCallback(async () => {
+    try {
+      const [accounts, plans] = await Promise.all([adminListAccounts(), adminListPlans()]);
+      setState({ status: 'ready', accounts, plans });
+    } catch (e) {
+      if (e instanceof ApiError && (e.status === 404 || e.status === 401)) {
+        setState({ status: 'denied' });
+      } else {
+        setState({ status: 'error', message: String(e) });
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (state.status === 'denied') return <NotFound />;
+
+  return (
+    <PublicLayout>
+      <div className="max-w-5xl mx-auto px-6 py-16">
+        <header className="mb-8">
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">Operator</p>
+          <h1 className="mt-1 font-display text-3xl tracking-tight md:text-4xl">
+            Accounts<span className="italic">.</span>
+          </h1>
+        </header>
+
+        {notice && (
+          <div className="mb-6">
+            <Banner tone={notice.tone} title={notice.tone === 'success' ? 'Done' : 'Heads up'}>
+              {notice.message}
+            </Banner>
+          </div>
+        )}
+
+        {state.status === 'loading' && (
+          <Card>
+            <div className="flex items-center gap-3 text-text-secondary">
+              <Spinner className="h-5 w-5 text-accent" />
+              <span className="text-sm">Loading accounts…</span>
+            </div>
+          </Card>
+        )}
+
+        {state.status === 'error' && (
+          <Banner tone="warning" title="Couldn't load the portal">
+            {state.message}
+          </Banner>
+        )}
+
+        {state.status === 'ready' && (
+          <AccountsTable
+            accounts={state.accounts}
+            plans={state.plans}
+            onChanged={(message) => {
+              setNotice({ tone: 'success', message });
+              void load();
+            }}
+            onError={(message) => setNotice({ tone: 'warning', message })}
+          />
+        )}
+      </div>
+    </PublicLayout>
+  );
+}
+
+function AccountsTable({
+  accounts,
+  plans,
+  onChanged,
+  onError,
+}: {
+  accounts: AdminAccount[];
+  plans: AdminPlan[];
+  onChanged: (message: string) => void;
+  onError: (message: string) => void;
+}) {
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  return (
+    <div className="space-y-3">
+      {accounts.map((account) => (
+        <Card key={account.id}>
+          <button
+            type="button"
+            onClick={() => setOpenId(openId === account.id ? null : account.id)}
+            className="flex w-full flex-wrap items-center justify-between gap-3 text-left"
+          >
+            <div>
+              <p className="font-medium">
+                {account.subdomain}
+                {account.is_admin && (
+                  <span className="ml-2 text-xs uppercase tracking-wide text-accent">admin</span>
+                )}
+              </p>
+              <p className="text-sm text-text-muted">{account.email}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <StatusPill tone={account.billing_state === 'active' ? 'success' : 'warning'} dot>
+                {account.billing_state}
+              </StatusPill>
+              <StatusPill tone="neutral">
+                {account.plan_id ?? 'no plan'}
+                {account.plan_pinned ? ' · pinned' : ''}
+              </StatusPill>
+            </div>
+          </button>
+          <dl className="mt-3 grid gap-2 text-xs text-text-muted sm:grid-cols-3">
+            <div>Created {new Date(account.created_at).toLocaleDateString()}</div>
+            <div>
+              {account.last_backup_at
+                ? `Backed up ${new Date(account.last_backup_at).toLocaleString()}`
+                : 'Never backed up'}
+            </div>
+            <div>
+              {account.trial_ends_at
+                ? `Trial ends ${new Date(account.trial_ends_at).toLocaleDateString()}`
+                : ''}
+            </div>
+          </dl>
+          {openId === account.id && (
+            <AccountActions
+              account={account}
+              plans={plans}
+              onChanged={onChanged}
+              onError={onError}
+            />
+          )}
+        </Card>
+      ))}
+      {accounts.length === 0 && (
+        <Card>
+          <p className="text-sm text-text-secondary">No accounts yet.</p>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function AccountActions({
+  account,
+  plans,
+  onChanged,
+  onError,
+}: {
+  account: AdminAccount;
+  plans: AdminPlan[];
+  onChanged: (message: string) => void;
+  onError: (message: string) => void;
+}) {
+  const [detail, setDetail] = useState<AdminAccountDetail | null>(null);
+  const [planId, setPlanId] = useState(account.plan_id ?? 'free');
+  const [pinned, setPinned] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    adminGetAccount(account.id)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [account.id]);
+
+  const planLabel = useMemo(() => {
+    const fmt = (p: AdminPlan) => {
+      const atoms = p.atom_limit === null ? '∞ atoms' : `${p.atom_limit} atoms`;
+      const ai = `$${(p.ai_credits_monthly_cents / 100).toFixed(2)}/mo AI`;
+      return `${p.name} (${atoms}, ${ai})`;
+    };
+    return new Map(plans.map((p) => [p.id, fmt(p)]));
+  }, [plans]);
+
+  const savePlan = async () => {
+    setBusy(true);
+    try {
+      await adminSetPlan(account.id, planId, pinned);
+      onChanged(
+        `${account.subdomain} → ${planId}${pinned ? ' (pinned against automated downgrades)' : ''}`,
+      );
+    } catch (e) {
+      onError(e instanceof ApiError ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const evict = async () => {
+    setBusy(true);
+    try {
+      await adminEvict(account.id);
+      onChanged(`Evicted ${account.subdomain} from the serving cache.`);
+    } catch (e) {
+      onError(e instanceof ApiError ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-4 space-y-4 border-t border-border-light pt-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium text-text-muted">Plan</span>
+          <select
+            value={planId}
+            onChange={(e) => setPlanId(e.target.value)}
+            className="rounded-lg border border-border-light bg-bg-primary px-3 py-2 text-sm"
+          >
+            {plans.map((p) => (
+              <option key={p.id} value={p.id}>
+                {planLabel.get(p.id)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 pb-2 text-sm text-text-secondary">
+          <input
+            type="checkbox"
+            checked={pinned}
+            onChange={(e) => setPinned(e.target.checked)}
+          />
+          Pin (hold against trial expiry &amp; billing events)
+        </label>
+        <Button onClick={savePlan} disabled={busy}>
+          {busy ? 'Saving…' : 'Set plan'}
+        </Button>
+        <Button variant="secondary" onClick={evict} disabled={busy}>
+          Evict cache
+        </Button>
+      </div>
+      {detail && detail.recent_transitions.length > 0 && (
+        <div>
+          <p className="mb-1 text-xs font-medium uppercase tracking-wide text-text-muted">
+            Recent plan transitions
+          </p>
+          <ul className="space-y-1 text-xs text-text-secondary">
+            {detail.recent_transitions.map((t, i) => (
+              <li key={i}>
+                {new Date(t.at).toLocaleString()} — {t.from ?? '∅'} → {t.to ?? '∅'} (
+                {t.trigger})
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/crates/atomic-cloud/migrations/020_admin_portal.sql
+++ b/crates/atomic-cloud/migrations/020_admin_portal.sql
@@ -1,0 +1,37 @@
+-- Admin portal foundations (plan: admin portal slice 1).
+--
+--   * accounts.is_admin — gates the /admin plane. Bootstrapped via the CLI
+--     (`account promote`); never settable through a tenant-facing route.
+--   * accounts.plan_pinned — an admin-assigned plan holds against the
+--     automated writers: the trial-expiry sweep and the Stripe subscription
+--     projection skip pinned accounts. Without the pin, a comped account
+--     would be clawed back to free within one sweep interval.
+--   * admin_actions — the audit ledger every admin mutation writes.
+--   * The first comp tier: a catalogue row like any other (future comp
+--     tiers are additional rows — the admin UI renders its picker from the
+--     plans table, so no code changes). Unlimited atoms/KBs, pro-sized
+--     storage, premium models, a real but bounded $5/mo AI allowance.
+
+ALTER TABLE accounts ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE accounts ADD COLUMN plan_pinned BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE TABLE IF NOT EXISTS admin_actions (
+    id                BIGSERIAL PRIMARY KEY,
+    actor             TEXT NOT NULL,          -- account id, or 'cli'
+    action            TEXT NOT NULL,          -- 'set_plan' | 'evict' | 'delete_account' | 'promote' | ...
+    target_account_id TEXT,
+    detail            JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS admin_actions_target_idx
+    ON admin_actions (target_account_id, created_at);
+
+INSERT INTO plans
+    (id, name, monthly_price_cents, atom_limit, ai_credits_monthly_cents, kb_limit, storage_bytes_limit, feature_flags)
+VALUES
+    ('comp', 'Comp', 0, NULL, 500, NULL, 10737418240, '{"premium_models": true}'::jsonb)
+ON CONFLICT (id) DO NOTHING;
+
+-- Record this migration in the version table (the runner reads MAX(version)).
+INSERT INTO schema_version (version) VALUES (20);

--- a/crates/atomic-cloud/src/account_plane.rs
+++ b/crates/atomic-cloud/src/account_plane.rs
@@ -485,7 +485,7 @@ fn is_app_host(host: &str, base_domain: &str) -> bool {
 /// Route guard matching only app-host requests. Reads the same host source
 /// as `CloudAuth` (the `Host` header, falling back to the URI authority for
 /// HTTP/2 `:authority` requests); a request with neither matches nothing.
-fn app_host_guard(base_domain: String) -> impl Guard {
+pub(crate) fn app_host_guard(base_domain: String) -> impl Guard {
     guard::fn_guard(move |ctx: &GuardContext<'_>| {
         let head = ctx.head();
         head.headers()

--- a/crates/atomic-cloud/src/admin.rs
+++ b/crates/atomic-cloud/src/admin.rs
@@ -1,0 +1,494 @@
+//! The admin plane: operator routes on the **app host** (`/admin/api/*`)
+//! plus the plan-override machinery they and the CLI share.
+//!
+//! # Authorization
+//!
+//! Admin identity is `accounts.is_admin` (migration 020) — set only via the
+//! CLI (`account promote`), never through a tenant-facing route. Requests
+//! authenticate by the ordinary web session cookie (the admin logs in like
+//! any user); [`require_admin`] resolves the session **without** a subdomain
+//! (the app host names no account) and checks the flag. Everything short of
+//! a valid admin session answers **404, not 403** — the plane does not
+//! confirm its own existence to non-admins.
+//!
+//! # Plan overrides and the pin
+//!
+//! [`set_plan_override`] is the one writer for admin plan changes: it stamps
+//! `accounts.plan_id` + `plan_pinned`, records the existing
+//! `plan_transitions` ledger with `trigger='admin'`, re-sizes the managed
+//! OpenRouter key to the new plan's allowance (the same
+//! [`reconcile_managed_key_limit`] the billing transitions use), and writes
+//! the `admin_actions` audit row. The pin is honored by every automated
+//! plan writer (trial sweep, subscription projection/deletion — see
+//! [`crate::billing::dunning`]), so a comped account holds until an admin
+//! changes it back.
+//!
+//! Comp tiers are ordinary `plans` catalogue rows: the portal's picker
+//! renders from `GET /admin/api/plans`, so adding a tier is a migration,
+//! never a code change.
+
+use std::sync::Arc;
+
+use actix_web::{web, HttpRequest, HttpResponse};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::account_cache::AccountCache;
+use crate::account_plane::app_host_guard;
+use crate::auth::SESSION_COOKIE;
+use crate::billing::dunning::{current_plan, record_transition, reconcile_managed_key_limit};
+use crate::control_plane::ControlPlane;
+use crate::error::CloudError;
+use crate::managed_keys::ManagedKeys;
+use crate::tokens::resolve_session;
+
+/// The admin plane's composition state.
+#[derive(Clone)]
+pub struct AdminPlane {
+    control: ControlPlane,
+    cache: Arc<AccountCache>,
+    managed: ManagedKeys,
+    base_domain: String,
+}
+
+impl AdminPlane {
+    pub fn new(
+        control: ControlPlane,
+        cache: Arc<AccountCache>,
+        managed: ManagedKeys,
+        base_domain: &str,
+    ) -> Self {
+        Self {
+            control,
+            cache,
+            managed,
+            base_domain: base_domain.to_string(),
+        }
+    }
+
+    /// Register the admin routes, guarded to the **app host** — the admin
+    /// plane never exists on a tenant subdomain.
+    pub(crate) fn configure(&self, cfg: &mut web::ServiceConfig) {
+        let state = web::Data::new(self.clone());
+        cfg.service(
+            web::scope("/admin/api")
+                .guard(app_host_guard(self.base_domain.clone()))
+                .app_data(state)
+                .route("/accounts", web::get().to(list_accounts_route))
+                .route("/accounts/{id}", web::get().to(account_detail_route))
+                .route("/accounts/{id}/plan", web::put().to(set_plan_route))
+                .route("/accounts/{id}/evict", web::post().to(evict_route))
+                .route("/plans", web::get().to(list_plans_route)),
+        );
+    }
+}
+
+/// A verified admin caller.
+struct AdminActor {
+    account_id: String,
+}
+
+/// The uniform non-admin answer: the plane does not exist for you.
+fn admin_not_found() -> HttpResponse {
+    HttpResponse::NotFound().json(json!({ "error": "not_found" }))
+}
+
+/// Resolve the request's session cookie to an admin account, or the 404
+/// denial. Fail-closed: no cookie, dead session, unknown account, or a
+/// lookup error all read identically as not-found.
+async fn require_admin(
+    req: &HttpRequest,
+    control: &ControlPlane,
+) -> Result<AdminActor, HttpResponse> {
+    let Some(secret) = req.cookie(SESSION_COOKIE).map(|c| c.value().to_string()) else {
+        return Err(admin_not_found());
+    };
+    let session = match resolve_session(control, &secret).await {
+        Ok(Some(session)) => session,
+        Ok(None) => return Err(admin_not_found()),
+        Err(e) => {
+            tracing::error!(error = %e, "admin session resolution failed");
+            return Err(admin_not_found());
+        }
+    };
+    let is_admin: Option<bool> = sqlx::query_scalar(
+        "SELECT is_admin FROM accounts WHERE id = $1 AND deleted_at IS NULL",
+    )
+    .bind(&session.account_id)
+    .fetch_optional(control.pool())
+    .await
+    .unwrap_or_else(|e| {
+        tracing::error!(error = %e, "admin flag lookup failed");
+        None
+    });
+    if is_admin != Some(true) {
+        return Err(admin_not_found());
+    }
+    Ok(AdminActor {
+        account_id: session.account_id,
+    })
+}
+
+/// Write one `admin_actions` audit row. Best-effort by design: an audit
+/// failure is loud in the log but never blocks the action it describes.
+pub async fn audit(
+    control: &ControlPlane,
+    actor: &str,
+    action: &str,
+    target_account_id: Option<&str>,
+    detail: serde_json::Value,
+) {
+    let result = sqlx::query(
+        "INSERT INTO admin_actions (actor, action, target_account_id, detail) \
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(actor)
+    .bind(action)
+    .bind(target_account_id)
+    .bind(detail)
+    .execute(control.pool())
+    .await;
+    if let Err(e) = result {
+        tracing::error!(actor, action, error = %e, "writing admin audit row failed");
+    }
+}
+
+/// Set (or clear) an admin plan override: validate the plan against the
+/// catalogue, stamp `plan_id` + `plan_pinned`, ledger the transition as
+/// `trigger='admin'`, and re-size the managed key to the new allowance.
+/// The key resize is best-effort like every allowance reconcile — a
+/// provisioning-API hiccup logs and leaves the plan change standing.
+pub async fn set_plan_override(
+    control: &ControlPlane,
+    managed: &ManagedKeys,
+    actor: &str,
+    account_id: &str,
+    plan_id: &str,
+    pinned: bool,
+) -> Result<(), CloudError> {
+    let plan_exists: Option<i32> = sqlx::query_scalar("SELECT 1 FROM plans WHERE id = $1")
+        .bind(plan_id)
+        .fetch_optional(control.pool())
+        .await
+        .map_err(CloudError::db("validating plan id"))?;
+    if plan_exists.is_none() {
+        return Err(CloudError::Invariant(format!(
+            "unknown plan id {plan_id:?}"
+        )));
+    }
+
+    let mut conn = control
+        .pool()
+        .acquire()
+        .await
+        .map_err(CloudError::db("acquiring connection for plan override"))?;
+    let from_plan = current_plan(&mut conn, account_id).await?;
+    let updated = sqlx::query(
+        "UPDATE accounts SET plan_id = $2, plan_pinned = $3 \
+         WHERE id = $1 AND deleted_at IS NULL",
+    )
+    .bind(account_id)
+    .bind(plan_id)
+    .bind(pinned)
+    .execute(&mut *conn)
+    .await
+    .map_err(CloudError::db("applying plan override"))?;
+    if updated.rows_affected() == 0 {
+        return Err(CloudError::Invariant(format!(
+            "no active account {account_id:?}"
+        )));
+    }
+    record_transition(
+        &mut conn,
+        account_id,
+        from_plan.as_deref(),
+        Some(plan_id),
+        "admin",
+        Some(if pinned { "pinned" } else { "unpinned" }),
+    )
+    .await?;
+    drop(conn);
+
+    if let Err(e) = reconcile_managed_key_limit(control, managed, account_id).await {
+        tracing::warn!(
+            account_id,
+            plan_id,
+            error = %e,
+            "managed-key resize after admin plan override failed; \
+             plan change stands, allowance reconciles on the next transition"
+        );
+    }
+
+    audit(
+        control,
+        actor,
+        "set_plan",
+        Some(account_id),
+        json!({ "plan_id": plan_id, "pinned": pinned, "from": from_plan }),
+    )
+    .await;
+    Ok(())
+}
+
+/// Set or clear `accounts.is_admin` for a subdomain (CLI `account promote`).
+pub async fn set_admin_flag(
+    control: &ControlPlane,
+    subdomain: &str,
+    is_admin: bool,
+) -> Result<(), CloudError> {
+    let updated = sqlx::query(
+        "UPDATE accounts SET is_admin = $2 \
+         WHERE subdomain = $1 AND deleted_at IS NULL",
+    )
+    .bind(subdomain)
+    .bind(is_admin)
+    .execute(control.pool())
+    .await
+    .map_err(CloudError::db("setting admin flag"))?;
+    if updated.rows_affected() == 0 {
+        return Err(CloudError::Invariant(format!(
+            "no active account with subdomain {subdomain:?}"
+        )));
+    }
+    audit(
+        control,
+        "cli",
+        if is_admin { "promote" } else { "demote" },
+        None,
+        json!({ "subdomain": subdomain }),
+    )
+    .await;
+    Ok(())
+}
+
+// --- Route handlers ----------------------------------------------------------
+
+/// `GET /admin/api/accounts`: every active account with its plan, pin,
+/// billing state, and backup freshness — the portal's landing table.
+async fn list_accounts_route(req: HttpRequest, state: web::Data<AdminPlane>) -> HttpResponse {
+    if let Err(denial) = require_admin(&req, &state.control).await {
+        return denial;
+    }
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        id: String,
+        subdomain: String,
+        email: String,
+        status: String,
+        plan_id: Option<String>,
+        plan_pinned: bool,
+        is_admin: bool,
+        billing_state: String,
+        trial_ends_at: Option<chrono::DateTime<chrono::Utc>>,
+        created_at: chrono::DateTime<chrono::Utc>,
+        last_backup_at: Option<chrono::DateTime<chrono::Utc>>,
+    }
+    let rows: Result<Vec<Row>, _> = sqlx::query_as(
+        "SELECT a.id, a.subdomain, a.email, a.status, a.plan_id, a.plan_pinned, \
+                a.is_admin, a.billing_state, a.trial_ends_at, a.created_at, \
+                d.last_backup_at \
+         FROM accounts a \
+         LEFT JOIN account_databases d ON d.account_id = a.id \
+         WHERE a.deleted_at IS NULL \
+         ORDER BY a.created_at",
+    )
+    .fetch_all(state.control.pool())
+    .await;
+    match rows {
+        Ok(rows) => HttpResponse::Ok().json(
+            rows.into_iter()
+                .map(|r| {
+                    json!({
+                        "id": r.id,
+                        "subdomain": r.subdomain,
+                        "email": r.email,
+                        "status": r.status,
+                        "plan_id": r.plan_id,
+                        "plan_pinned": r.plan_pinned,
+                        "is_admin": r.is_admin,
+                        "billing_state": r.billing_state,
+                        "trial_ends_at": r.trial_ends_at.map(|t| t.to_rfc3339()),
+                        "created_at": r.created_at.to_rfc3339(),
+                        "last_backup_at": r.last_backup_at.map(|t| t.to_rfc3339()),
+                    })
+                })
+                .collect::<Vec<_>>(),
+        ),
+        Err(e) => {
+            tracing::error!(error = %e, "admin account listing failed");
+            HttpResponse::InternalServerError().json(json!({ "error": "internal_error" }))
+        }
+    }
+}
+
+/// `GET /admin/api/accounts/{id}`: one account plus its recent plan
+/// transitions and admin actions — the detail drawer's read.
+async fn account_detail_route(
+    req: HttpRequest,
+    state: web::Data<AdminPlane>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    if let Err(denial) = require_admin(&req, &state.control).await {
+        return denial;
+    }
+    let account_id = path.into_inner();
+    let account: Result<Option<serde_json::Value>, CloudError> = async {
+        let row: Option<(String, String, String, Option<String>, bool, String)> =
+            sqlx::query_as(
+                "SELECT subdomain, email, status, plan_id, plan_pinned, billing_state \
+                 FROM accounts WHERE id = $1 AND deleted_at IS NULL",
+            )
+            .bind(&account_id)
+            .fetch_optional(state.control.pool())
+            .await
+            .map_err(CloudError::db("reading account"))?;
+        let Some((subdomain, email, status, plan_id, plan_pinned, billing_state)) = row else {
+            return Ok(None);
+        };
+        let transitions: Vec<(Option<String>, Option<String>, String, chrono::DateTime<chrono::Utc>)> =
+            sqlx::query_as(
+                "SELECT from_plan_id, to_plan_id, trigger, created_at \
+                 FROM plan_transitions WHERE account_id = $1 \
+                 ORDER BY created_at DESC LIMIT 10",
+            )
+            .bind(&account_id)
+            .fetch_all(state.control.pool())
+            .await
+            .map_err(CloudError::db("reading plan transitions"))?;
+        Ok(Some(json!({
+            "id": account_id,
+            "subdomain": subdomain,
+            "email": email,
+            "status": status,
+            "plan_id": plan_id,
+            "plan_pinned": plan_pinned,
+            "billing_state": billing_state,
+            "recent_transitions": transitions.into_iter().map(|(from, to, trigger, at)| json!({
+                "from": from, "to": to, "trigger": trigger, "at": at.to_rfc3339(),
+            })).collect::<Vec<_>>(),
+        })))
+    }
+    .await;
+    match account {
+        Ok(Some(body)) => HttpResponse::Ok().json(body),
+        Ok(None) => HttpResponse::NotFound().json(json!({ "error": "not_found" })),
+        Err(e) => {
+            tracing::error!(error = %e, "admin account detail failed");
+            HttpResponse::InternalServerError().json(json!({ "error": "internal_error" }))
+        }
+    }
+}
+
+/// `GET /admin/api/plans`: the catalogue, for the portal's plan picker —
+/// new (comp) tiers appear here with zero UI changes.
+async fn list_plans_route(req: HttpRequest, state: web::Data<AdminPlane>) -> HttpResponse {
+    if let Err(denial) = require_admin(&req, &state.control).await {
+        return denial;
+    }
+    let rows: Result<
+        Vec<(String, String, i32, Option<i32>, Option<i32>, Option<i64>, i32)>,
+        _,
+    > = sqlx::query_as(
+        "SELECT id, name, monthly_price_cents, atom_limit, kb_limit, \
+                storage_bytes_limit, ai_credits_monthly_cents \
+         FROM plans ORDER BY monthly_price_cents, id",
+    )
+    .fetch_all(state.control.pool())
+    .await;
+    match rows {
+        Ok(rows) => HttpResponse::Ok().json(
+            rows.into_iter()
+                .map(|(id, name, price, atoms, kbs, storage, ai)| {
+                    json!({
+                        "id": id,
+                        "name": name,
+                        "monthly_price_cents": price,
+                        "atom_limit": atoms,
+                        "kb_limit": kbs,
+                        "storage_bytes_limit": storage,
+                        "ai_credits_monthly_cents": ai,
+                    })
+                })
+                .collect::<Vec<_>>(),
+        ),
+        Err(e) => {
+            tracing::error!(error = %e, "admin plan listing failed");
+            HttpResponse::InternalServerError().json(json!({ "error": "internal_error" }))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct SetPlanBody {
+    plan_id: String,
+    /// Pin the plan against the automated writers. Defaults to `true`: an
+    /// admin assigning a plan almost always means "and keep it there".
+    #[serde(default = "default_pin")]
+    pinned: bool,
+}
+
+fn default_pin() -> bool {
+    true
+}
+
+/// `PUT /admin/api/accounts/{id}/plan`: the plan override.
+async fn set_plan_route(
+    req: HttpRequest,
+    state: web::Data<AdminPlane>,
+    path: web::Path<String>,
+    body: web::Json<SetPlanBody>,
+) -> HttpResponse {
+    let actor = match require_admin(&req, &state.control).await {
+        Ok(actor) => actor,
+        Err(denial) => return denial,
+    };
+    let account_id = path.into_inner();
+    let body = body.into_inner();
+    match set_plan_override(
+        &state.control,
+        &state.managed,
+        &actor.account_id,
+        &account_id,
+        &body.plan_id,
+        body.pinned,
+    )
+    .await
+    {
+        Ok(()) => HttpResponse::Ok().json(json!({
+            "plan_id": body.plan_id,
+            "pinned": body.pinned,
+        })),
+        Err(CloudError::Invariant(msg)) => {
+            HttpResponse::BadRequest().json(json!({ "error": "invalid_request", "message": msg }))
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "admin plan override failed");
+            HttpResponse::InternalServerError().json(json!({ "error": "internal_error" }))
+        }
+    }
+}
+
+/// `POST /admin/api/accounts/{id}/evict`: drop the account's serving-cache
+/// entry — the restore runbook's step 3, finally reachable without a pod
+/// restart.
+async fn evict_route(
+    req: HttpRequest,
+    state: web::Data<AdminPlane>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let actor = match require_admin(&req, &state.control).await {
+        Ok(actor) => actor,
+        Err(denial) => return denial,
+    };
+    let account_id = path.into_inner();
+    state.cache.evict(&account_id).await;
+    audit(
+        &state.control,
+        &actor.account_id,
+        "evict",
+        Some(&account_id),
+        json!({}),
+    )
+    .await;
+    HttpResponse::Ok().json(json!({ "evicted": true }))
+}

--- a/crates/atomic-cloud/src/auth.rs
+++ b/crates/atomic-cloud/src/auth.rs
@@ -252,6 +252,19 @@ impl CloudAuth {
     pub(crate) fn public_scheme(&self) -> &str {
         &self.ctx.public_scheme
     }
+
+    /// The control plane this middleware verifies against — like
+    /// [`base_domain`](Self::base_domain), an accessor so sibling planes
+    /// (admin) compose from the same inputs without new
+    /// `configure_cloud_app` arguments.
+    pub(crate) fn control(&self) -> ControlPlane {
+        self.ctx.control.clone()
+    }
+
+    /// The serving cache — see [`control`](Self::control).
+    pub(crate) fn cache(&self) -> Arc<AccountCache> {
+        self.ctx.cache.clone()
+    }
 }
 
 impl<S, B> Transform<S, ServiceRequest> for CloudAuth

--- a/crates/atomic-cloud/src/billing/dunning.rs
+++ b/crates/atomic-cloud/src/billing/dunning.rs
@@ -156,7 +156,7 @@ pub fn billing_state_from_column(value: &str) -> BillingState {
 /// Runs on whatever connection the caller threads — the webhook's apply path
 /// passes the same transaction the claim rode, so the audit row commits (or
 /// rolls back) atomically with the rest of the event's effects.
-async fn record_transition(
+pub(crate) async fn record_transition(
     conn: &mut PgConnection,
     account_id: &str,
     from_plan: Option<&str>,
@@ -358,31 +358,20 @@ pub async fn apply_subscription_event_on_conn(
     account_id: &str,
     state: &SubscriptionState,
 ) -> Result<(), CloudError> {
-    // Persist the subscription projection.
-    sqlx::query(
-        "INSERT INTO stripe_subscriptions \
-             (account_id, stripe_subscription_id, plan_id, status, \
-              current_period_start, current_period_end, cancel_at_period_end, updated_at) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW()) \
-         ON CONFLICT (account_id) DO UPDATE SET \
-             stripe_subscription_id = EXCLUDED.stripe_subscription_id, \
-             plan_id = EXCLUDED.plan_id, \
-             status = EXCLUDED.status, \
-             current_period_start = EXCLUDED.current_period_start, \
-             current_period_end = EXCLUDED.current_period_end, \
-             cancel_at_period_end = EXCLUDED.cancel_at_period_end, \
-             updated_at = NOW()",
-    )
-    .bind(account_id)
-    .bind(&state.stripe_subscription_id)
-    .bind(&state.plan_id)
-    .bind(&state.status)
-    .bind(state.current_period_start)
-    .bind(state.current_period_end)
-    .bind(state.cancel_at_period_end)
-    .execute(&mut *conn)
-    .await
-    .map_err(CloudError::db("persisting Stripe subscription"))?;
+    // An admin-pinned plan holds against the projection: comped accounts
+    // must not be re-planned by a stray/legacy subscription event. The
+    // subscription row itself is still persisted below (billing history
+    // stays truthful) — only the plan/billing-state stamps are skipped.
+    if plan_pinned(conn, account_id).await? {
+        tracing::warn!(
+            account_id,
+            status = %state.status,
+            "subscription event for an admin-pinned account; \
+             persisting the subscription row but leaving the pinned plan untouched"
+        );
+        return persist_subscription_row(conn, account_id, state).await;
+    }
+    persist_subscription_row(conn, account_id, state).await?;
 
     let from_plan = current_plan(conn, account_id).await?;
 
@@ -427,6 +416,56 @@ pub async fn apply_subscription_event_on_conn(
     Ok(())
 }
 
+/// Persist the subscription projection row — the billing-history half of
+/// [`apply_subscription_event_on_conn`], shared with the admin-pinned early
+/// return (which records the event but never re-plans the account).
+async fn persist_subscription_row(
+    conn: &mut PgConnection,
+    account_id: &str,
+    state: &SubscriptionState,
+) -> Result<(), CloudError> {
+    sqlx::query(
+        "INSERT INTO stripe_subscriptions \
+             (account_id, stripe_subscription_id, plan_id, status, \
+              current_period_start, current_period_end, cancel_at_period_end, updated_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW()) \
+         ON CONFLICT (account_id) DO UPDATE SET \
+             stripe_subscription_id = EXCLUDED.stripe_subscription_id, \
+             plan_id = EXCLUDED.plan_id, \
+             status = EXCLUDED.status, \
+             current_period_start = EXCLUDED.current_period_start, \
+             current_period_end = EXCLUDED.current_period_end, \
+             cancel_at_period_end = EXCLUDED.cancel_at_period_end, \
+             updated_at = NOW()",
+    )
+    .bind(account_id)
+    .bind(&state.stripe_subscription_id)
+    .bind(&state.plan_id)
+    .bind(&state.status)
+    .bind(state.current_period_start)
+    .bind(state.current_period_end)
+    .bind(state.cancel_at_period_end)
+    .execute(&mut *conn)
+    .await
+    .map_err(CloudError::db("persisting Stripe subscription"))?;
+    Ok(())
+}
+
+/// Whether the account's plan is admin-pinned (see migration 020): pinned
+/// plans hold against every automated writer — the trial-expiry sweep and
+/// the Stripe subscription projection.
+pub(crate) async fn plan_pinned(
+    conn: &mut PgConnection,
+    account_id: &str,
+) -> Result<bool, CloudError> {
+    sqlx::query_scalar("SELECT plan_pinned FROM accounts WHERE id = $1")
+        .bind(account_id)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(CloudError::db("reading plan pin"))
+        .map(|row| row.unwrap_or(false))
+}
+
 /// `customer.subscription.deleted`: drop the account to the free plan and
 /// clear the subscription row. Over-limit data is **retained** — the quota
 /// guard blocks new writes until the user is back under the free limits (no
@@ -448,6 +487,22 @@ pub async fn apply_subscription_deleted_on_conn(
     conn: &mut PgConnection,
     account_id: &str,
 ) -> Result<(), CloudError> {
+    // Admin-pinned plans hold here too: the subscription row is cleared
+    // (billing history stays truthful) but a comped account is never
+    // dropped to free by its old subscription winding down.
+    if plan_pinned(conn, account_id).await? {
+        tracing::warn!(
+            account_id,
+            "subscription deleted for an admin-pinned account; \
+             clearing the subscription row, keeping the pinned plan"
+        );
+        sqlx::query("DELETE FROM stripe_subscriptions WHERE account_id = $1")
+            .bind(account_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(CloudError::db("clearing deleted subscription"))?;
+        return Ok(());
+    }
     let from_plan = current_plan(conn, account_id).await?;
     set_plan(conn, account_id, DEFAULT_PLAN_ID).await?;
     clear_billing_state(conn, account_id).await?;
@@ -546,7 +601,7 @@ pub async fn apply_payment_failed_on_conn(
 /// webhook transaction commits, via [`reconcile_managed_key_limit`] (the
 /// reconcile issues an outbound provider call that must not ride inside the
 /// claim+apply transaction — see its docs).
-async fn set_plan(
+pub(crate) async fn set_plan(
     conn: &mut PgConnection,
     account_id: &str,
     plan_id: &str,
@@ -610,7 +665,7 @@ pub async fn reconcile_managed_key_limit(
 }
 
 /// The account's current `plan_id`, for the audit-log `from_plan` field.
-async fn current_plan(
+pub(crate) async fn current_plan(
     conn: &mut PgConnection,
     account_id: &str,
 ) -> Result<Option<String>, CloudError> {
@@ -824,11 +879,14 @@ pub async fn expired_trials(
     control: &ControlPlane,
     now: DateTime<Utc>,
 ) -> Result<Vec<String>, CloudError> {
+    // `NOT plan_pinned`: an admin-pinned plan holds — the sweep never even
+    // considers a comped account, so no downgrade and no key resize.
     sqlx::query_scalar(
         "SELECT id FROM accounts \
           WHERE billing_state = 'trialing' \
             AND trial_ends_at IS NOT NULL \
-            AND trial_ends_at <= $1",
+            AND trial_ends_at <= $1 \
+            AND NOT plan_pinned",
     )
     .bind(now)
     .fetch_all(control.pool())

--- a/crates/atomic-cloud/src/control_plane.rs
+++ b/crates/atomic-cloud/src/control_plane.rs
@@ -87,6 +87,7 @@ const MIGRATIONS: &[(i32, &str)] = &[
         19,
         include_str!("../migrations/019_cloud_token_prefix.sql"),
     ),
+    (20, include_str!("../migrations/020_admin_portal.sql")),
 ];
 
 /// Advisory lock key serializing control-plane migrations. Advisory locks

--- a/crates/atomic-cloud/src/lib.rs
+++ b/crates/atomic-cloud/src/lib.rs
@@ -25,6 +25,7 @@
 
 pub mod account_cache;
 pub mod account_plane;
+pub mod admin;
 pub mod auth;
 pub mod backpressure;
 pub mod backup;

--- a/crates/atomic-cloud/src/main.rs
+++ b/crates/atomic-cloud/src/main.rs
@@ -1171,6 +1171,37 @@ enum AccountAction {
         #[arg(long)]
         subdomain: String,
     },
+
+    /// Grant (or with --revoke, remove) admin-portal access for an account.
+    /// Admin is a control-plane flag, settable only here — never through a
+    /// tenant-facing route.
+    Promote {
+        /// Subdomain of the account.
+        #[arg(long)]
+        subdomain: String,
+
+        /// Remove admin access instead of granting it.
+        #[arg(long)]
+        revoke: bool,
+    },
+
+    /// Override an account's plan (and pin it against the automated plan
+    /// writers — the trial sweep and Stripe projection). The operator-side
+    /// twin of the admin portal's plan action; audits to `admin_actions`.
+    SetPlan {
+        /// Subdomain of the account.
+        #[arg(long)]
+        subdomain: String,
+
+        /// Plan id from the `plans` catalogue (e.g. free, pro, comp).
+        #[arg(long)]
+        plan: String,
+
+        /// Pin the plan (default true). --pin false re-exposes the account
+        /// to the automated writers.
+        #[arg(long, default_value_t = true)]
+        pin: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1632,6 +1663,45 @@ async fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 )
                 .await?;
                 println!("deleted account {account_id} ({subdomain})");
+                Ok(())
+            }
+
+            AccountAction::Promote { subdomain, revoke } => {
+                atomic_cloud::admin::set_admin_flag(&control, &subdomain, !revoke).await?;
+                println!(
+                    "{} admin access for {subdomain}",
+                    if revoke { "revoked" } else { "granted" }
+                );
+                Ok(())
+            }
+
+            AccountAction::SetPlan {
+                subdomain,
+                plan,
+                pin,
+            } => {
+                let account_id = control
+                    .account_id_by_subdomain(&subdomain)
+                    .await?
+                    .ok_or_else(|| format!("no account with subdomain {subdomain:?}"))?;
+                // Managed keys are disabled on CLI hosts (no provisioning
+                // key), so the allowance resize inside set_plan_override is
+                // a logged no-op here; it reconciles on the next transition
+                // a serve pod drives, or immediately when run through the
+                // admin portal instead.
+                atomic_cloud::admin::set_plan_override(
+                    &control,
+                    &ManagedKeys::Disabled,
+                    "cli",
+                    &account_id,
+                    &plan,
+                    pin,
+                )
+                .await?;
+                println!(
+                    "set {subdomain} to plan {plan} ({})",
+                    if pin { "pinned" } else { "unpinned" }
+                );
                 Ok(())
             }
         },

--- a/crates/atomic-cloud/src/server.rs
+++ b/crates/atomic-cloud/src/server.rs
@@ -475,6 +475,16 @@ pub fn configure_cloud_app(
                     .route(web::get().to(ready)),
             );
         account_plane.configure(cfg);
+        // The admin plane (app host only, is_admin sessions only — 404 to
+        // everyone else). Composed from the same inputs the auth middleware
+        // and tenant plane already carry — no new assembly arguments.
+        crate::admin::AdminPlane::new(
+            auth.control(),
+            auth.cache(),
+            tenant_plane.managed(),
+            auth.base_domain(),
+        )
+        .configure(cfg);
         // The signed Stripe webhook on the app host (unauthenticated — the
         // signature is the auth; guarded to the app host like the account
         // plane). Registered with the app plane, never on tenant subdomains.

--- a/crates/atomic-cloud/src/tenant_plane.rs
+++ b/crates/atomic-cloud/src/tenant_plane.rs
@@ -357,6 +357,14 @@ pub struct TenantPlane {
 }
 
 impl TenantPlane {
+    /// The managed-key lifecycle handle — an accessor (like
+    /// [`CloudAuth::base_domain`](crate::auth::CloudAuth)) so the admin
+    /// plane composes from the same inputs without a new
+    /// `configure_cloud_app` argument.
+    pub(crate) fn managed(&self) -> ManagedKeys {
+        self.state.managed.clone()
+    }
+
     /// Build the plane over the same control plane, cluster, vault, and
     /// cache the rest of the composition serves from.
     pub fn new(

--- a/crates/atomic-cloud/src/tokens.rs
+++ b/crates/atomic-cloud/src/tokens.rs
@@ -283,6 +283,24 @@ pub async fn verify_token(
     row.map(TokenRecord::try_from).transpose()
 }
 
+/// Resolve a session plaintext to its live row WITHOUT knowing the account —
+/// the app-host case, where no subdomain names one (the admin plane; logout
+/// takes the even simpler delete-by-hash path). The hash lookup is the
+/// credential check: a 32-random-byte preimage is the only way to produce it.
+pub async fn resolve_session(
+    control: &ControlPlane,
+    plaintext: &str,
+) -> Result<Option<SessionRecord>, CloudError> {
+    sqlx::query_as(
+        "SELECT hash, account_id, created_at, expires_at, ip_first_seen, ua_first_seen \
+         FROM sessions WHERE hash = $1 AND expires_at > NOW()",
+    )
+    .bind(sha256_hex(plaintext))
+    .fetch_optional(control.pool())
+    .await
+    .map_err(CloudError::db("resolving session"))
+}
+
 /// Create a web session for `account_id`, expiring after `ttl`, and return
 /// its plaintext (the value the cookie will carry). Only the SHA-256 hash
 /// is stored. `ip_first_seen` / `ua_first_seen` are forensic breadcrumbs;

--- a/crates/atomic-cloud/tests/e2e_cloud.rs
+++ b/crates/atomic-cloud/tests/e2e_cloud.rs
@@ -1993,3 +1993,207 @@ async fn tenant_token_management_plane() {
     })
     .await;
 }
+
+/// The admin plane: existence-hidden to everyone but an is_admin session,
+/// and the plan-override path end to end — catalogue-validated, ledgered
+/// as trigger='admin', audited, and pinned against the trial sweep.
+#[actix_web::test]
+async fn admin_plane_gates_and_plan_override() {
+    with_control_db("admin_plane_gates_and_plan_override", |url| async move {
+        let h = CloudHarness::spawn(&url, AccountCacheConfig::default()).await;
+        let alpha = h.provision("alpha").await;
+        let bravo = h.provision("bravo").await;
+
+        let app_host = format!("app.{BASE_DOMAIN}");
+        let admin_get = |path: &str, cookie: Option<String>| {
+            let mut req = h
+                .client
+                .get(format!("{}{path}", h.base_url))
+                .header(HOST, app_host.as_str());
+            if let Some(cookie) = cookie {
+                req = req.header("Cookie", format!("{SESSION_COOKIE}={cookie}"));
+            }
+            req
+        };
+
+        // No cookie, a bogus cookie, and a real-but-not-admin session all
+        // read identically: the plane does not exist for you.
+        let alpha_session = create_session(
+            &h.control,
+            &alpha.account_id,
+            Duration::from_secs(3600),
+            None,
+            None,
+        )
+        .await
+        .expect("alpha session");
+        for cookie in [
+            None,
+            Some("ats_bogus".to_string()),
+            Some(alpha_session.clone()),
+        ] {
+            let resp = admin_get("/admin/api/accounts", cookie)
+                .send()
+                .await
+                .expect("send");
+            assert_eq!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "non-admin must read the admin plane as not-found"
+            );
+        }
+
+        // Promote alpha (the CLI path) — the same session now reads the plane.
+        atomic_cloud::admin::set_admin_flag(&h.control, "alpha", true)
+            .await
+            .expect("promote alpha");
+        let resp = admin_get("/admin/api/accounts", Some(alpha_session.clone()))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let listing: Value = resp.json().await.expect("listing json");
+        assert!(
+            listing
+                .as_array()
+                .expect("array")
+                .iter()
+                .any(|a| a["subdomain"] == "bravo"),
+            "admin listing shows every account: {listing}"
+        );
+
+        // The plan picker's source of truth: the catalogue, comp included.
+        let resp = admin_get("/admin/api/plans", Some(alpha_session.clone()))
+            .send()
+            .await
+            .expect("send");
+        let plans: Value = resp.json().await.expect("plans json");
+        assert!(
+            plans
+                .as_array()
+                .expect("array")
+                .iter()
+                .any(|p| p["id"] == "comp"),
+            "comp tier seeded and listed: {plans}"
+        );
+
+        // Comp bravo through the route (defaults to pinned).
+        let resp = h
+            .client
+            .put(format!(
+                "{}/admin/api/accounts/{}/plan",
+                h.base_url, bravo.account_id
+            ))
+            .header(HOST, app_host.as_str())
+            .header("Cookie", format!("{SESSION_COOKIE}={alpha_session}"))
+            .json(&json!({ "plan_id": "comp" }))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut conn = PgConnection::connect(&url).await.expect("connect");
+        let (plan_id, pinned): (Option<String>, bool) = sqlx::query_as(
+            "SELECT plan_id, plan_pinned FROM accounts WHERE id = $1",
+        )
+        .bind(&bravo.account_id)
+        .fetch_one(&mut conn)
+        .await
+        .expect("read account");
+        assert_eq!(plan_id.as_deref(), Some("comp"));
+        assert!(pinned, "admin plan override pins by default");
+        let ledgered: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM plan_transitions \
+             WHERE account_id = $1 AND trigger = 'admin' AND to_plan_id = 'comp'",
+        )
+        .bind(&bravo.account_id)
+        .fetch_one(&mut conn)
+        .await
+        .expect("count transitions");
+        assert_eq!(ledgered, 1, "override rides the plan_transitions ledger");
+        let audited: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM admin_actions \
+             WHERE action = 'set_plan' AND target_account_id = $1 AND actor = $2",
+        )
+        .bind(&bravo.account_id)
+        .bind(&alpha.account_id)
+        .fetch_one(&mut conn)
+        .await
+        .expect("count audits");
+        assert_eq!(audited, 1, "override writes the admin audit ledger");
+
+        // The pin holds against the trial sweep: manufacture an expired
+        // trial on the comped account and run the sweep — the plan stays.
+        sqlx::query(
+            "UPDATE accounts SET billing_state = 'trialing', \
+             trial_ends_at = NOW() - interval '1 day' WHERE id = $1",
+        )
+        .bind(&bravo.account_id)
+        .execute(&mut conn)
+        .await
+        .expect("manufacture expired trial");
+        atomic_cloud::billing::dunning::advance_expired_trials(
+            &h.control,
+            &ManagedKeys::Disabled,
+            chrono::Utc::now(),
+            |_| async { Ok(false) },
+        )
+        .await
+        .expect("sweep");
+        let plan_after: Option<String> =
+            sqlx::query_scalar("SELECT plan_id FROM accounts WHERE id = $1")
+                .bind(&bravo.account_id)
+                .fetch_one(&mut conn)
+                .await
+                .expect("read plan after sweep");
+        assert_eq!(
+            plan_after.as_deref(),
+            Some("comp"),
+            "a pinned plan holds against the trial-expiry sweep"
+        );
+
+        // An unknown plan id is a structured 400, and nothing changes.
+        let resp = h
+            .client
+            .put(format!(
+                "{}/admin/api/accounts/{}/plan",
+                h.base_url, bravo.account_id
+            ))
+            .header(HOST, app_host.as_str())
+            .header("Cookie", format!("{SESSION_COOKIE}={alpha_session}"))
+            .json(&json!({ "plan_id": "platinum-sparkle" }))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // The admin plane never exists on a tenant subdomain, even for the
+        // admin's own session: the host guard excludes it from the route
+        // table, so the path falls through to the SPA fallback like any
+        // unknown tenant path — an HTML shell, never JSON, never data.
+        let resp = h
+            .api(Method::GET, &alpha.subdomain, "/admin/api/accounts")
+            .header("Cookie", format!("{SESSION_COOKIE}={alpha_session}"))
+            .send()
+            .await
+            .expect("send");
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            content_type.contains("text/html"),
+            "tenant-host /admin/api/* is the SPA shell, not the admin plane: {content_type}"
+        );
+        let body = resp.text().await.expect("body");
+        assert!(
+            !body.contains(&bravo.account_id) && !body.contains("bravo"),
+            "no admin data on a tenant host"
+        );
+
+        h.stop().await;
+    })
+    .await;
+}


### PR DESCRIPTION
## Summary

Operator portal for Atomic Cloud, planned around the headline need: **override individual users' plans (comp accounts) in a way the automated billing machinery can't claw back**, with future comp tiers as catalogue rows from day one.

- **Comp tier = a `plans` row** (migration 020). NULL limits already mean unlimited; premium models is a feature flag; the AI allowance drives the managed-key resize. New tiers are future migrations — the portal picker renders from `GET /admin/api/plans`.
- **`plan_pinned`**: the trial-expiry sweep and Stripe projection/deletion arms honor the pin (billing history still persists; plan stamps skip, warn-logged). Pinned in e2e against a manufactured expired trial.
- **One admin writer** (`admin::set_plan_override`): catalogue-validated → plan+pin stamp → `plan_transitions` ledger (`trigger='admin'`) → managed-key resize (same reconcile as billing) → `admin_actions` audit row.
- **Admin plane** on the app host: accounts list/detail, plans, plan override, cache evict (closes the restore runbook's step-3 gap). Auth = `accounts.is_admin` (CLI `account promote` only) over the session cookie; **everything short of an admin session reads as 404** — the plane never confirms its existence. Zero `configure_cloud_app` signature churn (composed via CloudAuth/TenantPlane accessors, the AccountGate precedent).
- **Portal UI** at `app.<base>/admin` in the dashboard SPA, mirroring the 404 posture (denied → the ordinary NotFound page).
- **CLI twins**: `account promote`, `account set-plan` (bootstrap + emergency path).

## Testing

- New e2e `admin_plane_gates_and_plan_override` (gating × 3, listing, catalogue, override side-effects ×3, pin-vs-sweep, invalid plan 400, tenant-host shell fallback)
- Full atomic-cloud suite vs Postgres: **426 passed, 0 failed**; SPA build/lint/vitest green

## After merge

Deploy applies migration 020 at boot. Bootstrap: `account promote --subdomain kenny`, then `app.atomicapp.ai/admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)