### PR TITLE
PWA: make deploys actually reach open clients

### DIFF
--- a/crates/atomic-cloud/src/spa.rs
+++ b/crates/atomic-cloud/src/spa.rs
@@ -529,11 +529,17 @@ fn asset_response(path: &Path, bytes: Vec<u8>) -> HttpResponse {
         builder.insert_header((CONTENT_TYPE, content_type));
     }
     // Files under `assets/` carry a content hash in their name → immutable,
-    // cache hard. Everything else (favicon, logos) gets a short cache.
+    // cache hard. The service-worker machinery must never be cached: the
+    // browser's update check fetches `sw.js` by its fixed name, and any
+    // stale copy delays every client on the previous deploy (see
+    // `src/lib/pwa.ts` for the client half of the update flow). Everything
+    // else (favicon, logos) gets a short cache.
     let is_hashed_asset = path
         .components()
         .any(|c| matches!(c, Component::Normal(part) if part == "assets"));
-    if is_hashed_asset {
+    if is_service_worker_file(path) {
+        builder.insert_header(CacheControl(vec![CacheDirective::NoCache]));
+    } else if is_hashed_asset {
         builder.insert_header(CacheControl(vec![
             CacheDirective::Public,
             CacheDirective::MaxAge(ASSET_MAX_AGE_SECS),
@@ -546,6 +552,15 @@ fn asset_response(path: &Path, bytes: Vec<u8>) -> HttpResponse {
         ]));
     }
     builder.body(bytes)
+}
+
+/// Whether this build file is part of the PWA update machinery — served by a
+/// fixed name (no content hash), so its bytes change under the same URL on
+/// every deploy and it must be revalidated, never cached.
+fn is_service_worker_file(path: &Path) -> bool {
+    path.file_name().and_then(|n| n.to_str()).is_some_and(|name| {
+        matches!(name, "sw.js" | "registerSW.js" | "manifest.webmanifest")
+    })
 }
 
 /// The SPA shell (`index.html`) response: 200, HTML, explicitly **not**
@@ -609,6 +624,31 @@ mod tests {
             resolve_asset_path(root, "/favicon.svg"),
             Some(PathBuf::from("/srv/dist/favicon.svg"))
         );
+    }
+
+    #[test]
+    fn cache_headers_by_file_kind() {
+        use actix_web::http::header::CACHE_CONTROL;
+
+        let header = |path: &str| {
+            let resp = asset_response(Path::new(path), b"x".to_vec());
+            resp.headers()
+                .get(CACHE_CONTROL)
+                .expect("cache-control set")
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
+
+        // The SW update machinery is fetched by fixed name → never cached.
+        assert_eq!(header("/srv/dist/sw.js"), "no-cache");
+        assert_eq!(header("/srv/dist/manifest.webmanifest"), "no-cache");
+        // Hashed assets cache hard; other root files get the short cache.
+        assert!(header("/srv/dist/assets/index-abc123.js").contains("max-age=31536000"));
+        assert!(header("/srv/dist/favicon.svg").contains("max-age=3600"));
+        // A hashed asset that *contains* "sw.js" in its name is still an
+        // asset — only the exact fixed names are special.
+        assert!(header("/srv/dist/assets/sw.js-legacy-abc.js").contains("max-age=31536000"));
     }
 
     #[test]

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -1,0 +1,76 @@
+import { registerSW } from 'virtual:pwa-register';
+import { toast } from 'sonner';
+
+/**
+ * PWA update lifecycle for the web build.
+ *
+ * The service worker precaches the whole app (including the shell), so
+ * without this module a deployed update never reaches an open tab: the
+ * browser only checks for a new worker on navigation, and even when one
+ * installs, nothing tells the user the page they're looking at is stale.
+ * That's how clients end up "stuck" until someone unregisters the worker.
+ *
+ * Three legs, matching the vite-plugin-pwa `prompt` flow:
+ *
+ * 1. Register immediately (not on window load) so the update check races
+ *    the app boot instead of waiting behind it.
+ * 2. Re-check hourly, and when a hidden tab becomes visible again — the
+ *    knowledge-base tab people keep pinned for days would otherwise never
+ *    look for updates between navigations.
+ * 3. When a new worker is installed and waiting, show a persistent toast.
+ *    The update applies only when the user clicks Refresh: an automatic
+ *    reload could eat an unsaved note, so activation stays user-driven.
+ *    (Closing every tab also activates it, the normal SW lifecycle.)
+ *
+ * In Tauri this module resolves to a stub (see `stubs/pwa-register.ts`) —
+ * the desktop app has no service worker.
+ */
+
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+/** Minimum gap between a scheduled check and a visibility-triggered one. */
+const VISIBILITY_CHECK_MIN_GAP_MS = 10 * 60 * 1000;
+
+export function setupPwaUpdates(): void {
+  if (!('serviceWorker' in navigator)) return;
+
+  const updateSW = registerSW({
+    immediate: true,
+    onNeedRefresh() {
+      toast('A new version of Atomic is ready', {
+        id: 'pwa-update',
+        duration: Infinity,
+        action: {
+          label: 'Refresh',
+          onClick: () => {
+            void updateSW(true);
+          },
+        },
+      });
+    },
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return;
+      let lastCheck = Date.now();
+      const check = () => {
+        if (registration.installing || !navigator.onLine) return;
+        lastCheck = Date.now();
+        registration.update().catch(() => {
+          // Server unreachable — the next tick will try again.
+        });
+      };
+      setInterval(check, UPDATE_CHECK_INTERVAL_MS);
+      document.addEventListener('visibilitychange', () => {
+        if (
+          document.visibilityState === 'visible' &&
+          Date.now() - lastCheck > VISIBILITY_CHECK_MIN_GAP_MS
+        ) {
+          check();
+        }
+      });
+    },
+    onRegisterError(err) {
+      // Non-fatal: the app works without a SW (e.g. Capacitor webviews,
+      // where custom schemes reject registration).
+      console.warn('Service worker registration failed:', err);
+    },
+  });
+}

--- a/src/lib/stubs/pwa-register.ts
+++ b/src/lib/stubs/pwa-register.ts
@@ -1,0 +1,9 @@
+/**
+ * Stub for `virtual:pwa-register` in non-web builds (Tauri desktop). The
+ * VitePWA plugin — and therefore the real virtual module — only exists when
+ * VITE_BUILD_TARGET=web; this mirrors its surface as a no-op, the same
+ * pattern as the `@tauri-apps/*` stubs used in the opposite direction.
+ */
+export function registerSW(_options?: unknown): (reloadPage?: boolean) => Promise<void> {
+  return async () => {};
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,9 @@ import App from './App'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
 import './index.css'
 import { initTransport } from './lib/transport'
+import { setupPwaUpdates } from './lib/pwa'
+
+setupPwaUpdates()
 
 initTransport()
   .catch((err) => console.error('Transport init failed:', err))

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -77,8 +77,19 @@ export default defineConfig({
     ...(isWebBuild
       ? [
           VitePWA({
-            registerType: 'autoUpdate',
-            injectRegister: 'auto',
+            // `prompt`: a new worker installs in the background and *waits*;
+            // `src/lib/pwa.ts` surfaces a "Refresh" toast and applies it on
+            // click. Deliberately not `autoUpdate` — that mode activates the
+            // new worker mid-session, which both leaves the running page
+            // stale (nothing reloads it) and purges the old precache out
+            // from under it, so a lazy chunk request can 404 until the user
+            // happens to reload. Prompt keeps the old app fully consistent
+            // until the user opts into the update.
+            registerType: 'prompt',
+            // Registration is hand-wired in src/lib/pwa.ts (it needs the
+            // update-check loop and the refresh toast), so the plugin must
+            // not inject its own bare register call.
+            injectRegister: false,
             // We author the manifest in `public/manifest.webmanifest` so it's
             // readable without a build step. Tell the plugin not to generate
             // its own copy.
@@ -183,7 +194,14 @@ export default defineConfig({
             '@tauri-apps/plugin-fs': path.resolve(__dirname, 'src/lib/stubs/tauri-fs.ts'),
           },
         }
-      : {}),
+      : {
+          alias: {
+            // The VitePWA plugin (and its virtual module) only exists in web
+            // builds; Tauri gets a no-op stub, mirroring the tauri-api stubs
+            // used in the opposite direction above.
+            'virtual:pwa-register': path.resolve(__dirname, 'src/lib/stubs/pwa-register.ts'),
+          },
+        }),
   },
   build: {
     rollupOptions: {


### PR DESCRIPTION
## Problem

After a deploy, tenants kept seeing the previous build until they manually unregistered the service worker (observed: the new API-tokens tab was invisible until an unregister). Root cause: the web build used `registerType: 'autoUpdate'` with the plugin's bare fallback registration — just `navigator.serviceWorker.register('/sw.js')`. So:

- A long-lived tab **never checked for updates** (checks only happen on navigation).
- When an update *was* discovered, autoUpdate activated it silently mid-session: the visible page stayed stale, nothing prompted a reload, and the old precache was purged under the running app (lazy chunks could 404 until reload).
- `sw.js` was served with `max-age=3600`.

## Fix

**Client** (`src/lib/pwa.ts`, new): switch to the `prompt` flow.
- Register immediately at boot.
- Re-check for a new worker hourly, and when a hidden tab becomes visible again (≥10 min since last check).
- When a new worker is installed and waiting, show a persistent sonner toast — **"A new version of Atomic is ready → Refresh"**. Clicking applies the update and reloads. Deliberately user-driven: an automatic reload could eat an unsaved note. (Closing all tabs also activates it, per the normal SW lifecycle.)

**Build** (`vite.config.ts`): `registerType: 'prompt'`, `injectRegister: false` (registration is now app code). Tauri builds alias `virtual:pwa-register` to a no-op stub — same pattern as the `@tauri-apps/*` stubs.

**Server** (`crates/atomic-cloud/src/spa.rs`): `sw.js` / `registerSW.js` / `manifest.webmanifest` are fetched by fixed name and change bytes every deploy → served `no-cache`. Hashed assets keep the 1-year immutable header.

## Rollout note

Clients currently holding the old worker will pick this up through the ordinary update path (the old worker still checks `sw.js` on navigation, and the old registration + autoUpdate worker will adopt the new prompt-mode worker on their next visit) — no manual unregister needed ever again after this one lands.

## Verified

- `cargo test -p atomic-cloud --lib spa::tests::` — 8/8 including the new cache-header test
- `npm run build:web` — prompt-mode `sw.js` (SKIP_WAITING listener only, no unconditional `skipWaiting()`), toast code in bundle, no `registerSW.js` emitted
- `npx vite build` (Tauri target) — stub resolves
- `npx tsc --noEmit`, root vitest 33/33

🤖 Generated with [Claude Code](https://claude.com/claude-code)