### PR TITLE
editor: read mode by default, edit on demand (atomic-editor 0.6.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@atomic-editor/editor": "^0.3.0",
+        "@atomic-editor/editor": "^0.6.0",
         "@capacitor/android": "^8.3.1",
         "@capacitor/core": "^8.3.0",
         "@capacitor/ios": "^8.3.0",
@@ -188,9 +188,9 @@
       "license": "ISC"
     },
     "node_modules/@atomic-editor/editor": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@atomic-editor/editor/-/editor-0.3.0.tgz",
-      "integrity": "sha512-+d3HXmz1um/QB+rcCC/G5JogywFKaagLeG/Zx1qnvPFEsk/nNt6zf3ai2YgyClMca/x7OPndMZEaA5qFE5zbYw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@atomic-editor/editor/-/editor-0.6.0.tgz",
+      "integrity": "sha512-kVZUPzYPkoaHrxZ1wOjF8hMZTnk6lp4/g/NNAQSGATZycxnmd6cWNpGlH9vD4BryGjIMP6vKH234vDUBSiTGRw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -219,6 +219,7 @@
         "@codemirror/view": "^6.0.0",
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0",
+        "@lezer/markdown": "^1.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "stress:wikipedia": "node scripts/stress-test-wikipedia.js"
   },
   "dependencies": {
-    "@atomic-editor/editor": "^0.3.0",
+    "@atomic-editor/editor": "^0.6.0",
     "@capacitor/android": "^8.3.1",
     "@capacitor/core": "^8.3.0",
     "@capacitor/ios": "^8.3.0",

--- a/src/components/atoms/AtomReader.tsx
+++ b/src/components/atoms/AtomReader.tsx
@@ -43,10 +43,9 @@ const AtomicCodeMirrorEditor = lazy(async () => {
 interface AtomReaderProps {
   atomId: string;
   highlightText?: string | null;
-  initialEditing?: boolean;
 }
 
-export function AtomReader({ atomId, highlightText, initialEditing }: AtomReaderProps) {
+export function AtomReader({ atomId, highlightText }: AtomReaderProps) {
   const deleteAtom = useAtomsStore(s => s.deleteAtom);
   const fetchTags = useTagsStore(s => s.fetchTags);
   const setSelectedTag = useUIStore(s => s.setSelectedTag);
@@ -146,7 +145,6 @@ export function AtomReader({ atomId, highlightText, initialEditing }: AtomReader
         <AtomReaderContent
           atom={atom}
           highlightText={highlightText}
-          initialEditing={initialEditing}
           onDismiss={overlayDismiss}
           onDelete={async () => {
             await deleteAtom(atomId);
@@ -166,7 +164,6 @@ export function AtomReader({ atomId, highlightText, initialEditing }: AtomReader
 interface AtomReaderContentProps {
   atom: AtomWithTags;
   highlightText?: string | null;
-  initialEditing?: boolean;
   onDismiss: () => void;
   onDelete: () => Promise<void>;
   onTagClick: (tagId: string) => void;
@@ -176,11 +173,13 @@ interface AtomReaderContentProps {
 }
 
 function AtomReaderContent({
-  atom, highlightText, initialEditing,
+  atom, highlightText,
   onDismiss, onDelete, onTagClick, onRelatedAtomClick, onViewGraph, onAtomUpdated,
 }: AtomReaderContentProps) {
   const readerTheme = useUIStore(s => s.readerTheme);
-  const setReaderEditState = useUIStore(s => s.setReaderEditState);
+  const isEditing = useUIStore(s => s.readerState.editing);
+  const setReaderEditing = useUIStore(s => s.setReaderEditing);
+  const setReaderSaveStatus = useUIStore(s => s.setReaderSaveStatus);
   const retryTagging = useAtomsStore(s => s.retryTagging);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const editorHandleRef = useRef<AtomicCodeMirrorEditorHandle | null>(null);
@@ -201,28 +200,54 @@ function AtomReaderContent({
   }, [retryTagging, atom, onAtomUpdated]);
 
   useEffect(() => {
-    setReaderEditState(Boolean(initialEditing), saveStatus);
-    return () => {
-      setReaderEditState(false, 'idle');
-    };
-  }, [initialEditing, saveStatus, setReaderEditState]);
+    setReaderSaveStatus(saveStatus);
+  }, [saveStatus, setReaderSaveStatus]);
 
   useEffect(() => {
     startEditing();
   }, [startEditing]);
 
+  // An empty atom has nothing to read — force edit mode so the surface is
+  // usable and the empty-atom delete-on-close flow stays reachable.
   useEffect(() => {
-    if (!initialEditing) return;
-    const id = requestAnimationFrame(() => {
-      editorHandleRef.current?.focus();
-    });
-    return () => cancelAnimationFrame(id);
-  }, [initialEditing]);
+    if (!atom.content.trim() && !useUIStore.getState().readerState.editing) {
+      setReaderEditing(true);
+    }
+    // Mode is captured per document, not re-derived as content changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [atom.id, setReaderEditing]);
 
+  // `flushDraft` changes identity on every draft edit; the mode-transition
+  // effect below must not re-run (and steal focus) on keystrokes, so it
+  // reads the latest through a ref.
+  const flushDraftRef = useRef(flushDraft);
+  useEffect(() => { flushDraftRef.current = flushDraft; }, [flushDraft]);
+
+  // Mode transitions: entering edit focuses the editor; leaving edit
+  // finalizes the draft (save + embedding/tagging pipeline) and returns
+  // focus to the container so Escape and `i` keep working. On mount there
+  // is no transition — the effect just sets focus for the opening mode.
+  // A mode flip that coincides with navigation (`sameAtom` false) is not
+  // an edit→read transition of the new document, so nothing is flushed —
+  // the previous document's draft is handled by useInlineEditor.
+  const prevEditingRef = useRef(isEditing);
+  const prevAtomIdRef = useRef(atom.id);
   useEffect(() => {
-    if (initialEditing) return;
+    const wasEditing = prevEditingRef.current;
+    const sameAtom = prevAtomIdRef.current === atom.id;
+    prevEditingRef.current = isEditing;
+    prevAtomIdRef.current = atom.id;
+    if (isEditing) {
+      const id = requestAnimationFrame(() => {
+        editorHandleRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(id);
+    }
+    if (wasEditing && sameAtom) {
+      void flushDraftRef.current();
+    }
     containerRef.current?.focus({ preventScroll: true });
-  }, [initialEditing, atom.id]);
+  }, [isEditing, atom.id]);
 
   useEffect(() => {
     readerEditorActions.current = {
@@ -260,8 +285,30 @@ function AtomReaderContent({
         editorHandleRef.current?.openSearch();
         return;
       }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'e') {
+        e.preventDefault();
+        setReaderEditing(!isEditing);
+        return;
+      }
+      // Vim-style: `i` enters edit mode from read mode (Escape steps back
+      // out). Only when the keystroke isn't destined for a real input.
+      if (
+        e.key === 'i' && !isEditing && !showDeleteModal &&
+        !e.metaKey && !e.ctrlKey && !e.altKey &&
+        !isTypingTarget(e.target)
+      ) {
+        e.preventDefault();
+        setReaderEditing(true);
+        return;
+      }
       if (e.key === 'Escape' && !showDeleteModal) {
         e.preventDefault();
+        // Step out gradually: edit → read (finalizing the draft), then
+        // read → close.
+        if (isEditing) {
+          setReaderEditing(false);
+          return;
+        }
         void (async () => {
           await flushDraft();
           onDismiss();
@@ -270,7 +317,7 @@ function AtomReaderContent({
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [flushDraft, onDismiss, saveNow, showDeleteModal]);
+  }, [flushDraft, isEditing, onDismiss, saveNow, setReaderEditing, showDeleteModal]);
 
   const [revealed, setRevealed] = useState(false);
   useEffect(() => {
@@ -371,7 +418,8 @@ function AtomReaderContent({
                 documentId={atom.id}
                 markdownSource={editContent}
                 initialRevealText={highlightText}
-                blurEditorOnMount={!initialEditing}
+                readOnly={!isEditing}
+                blurEditorOnMount={!isEditing}
                 onMarkdownChange={setEditContent}
                 onLinkClick={(url) => {
                   void openExternalUrl(url);
@@ -496,6 +544,14 @@ function AtomReaderContent({
       </Modal>
     </div>
   );
+}
+
+/// Whether a keystroke is destined for a real text input, so single-letter
+/// shortcuts (`i`) must not hijack it. The read-mode editor body is not
+/// contenteditable, so it never matches.
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 }
 
 function searchResultsToAtomLinkSuggestions(

--- a/src/components/layout/MainView.tsx
+++ b/src/components/layout/MainView.tsx
@@ -9,6 +9,7 @@ import {
   Library,
   Network,
   BookOpen,
+  Pencil,
   Search,
   Filter,
   Telescope,
@@ -315,6 +316,23 @@ export function MainView() {
           </div>
         </LayoutGroup>
 
+        {/* Read/edit mode toggle — visible whenever an atom tab is active.
+            Shows the action, not the state: pencil switches to edit, book
+            back to reading. Also the only mode affordance on touch, where
+            Cmd+E and `i` don't exist. */}
+        {readerState.atomId && (
+          <button
+            onClick={() => useUIStore.getState().setReaderEditing(!readerState.editing)}
+            className="p-1.5 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors shrink-0"
+            title={readerState.editing ? 'Reading view (⌘E)' : 'Edit note (⌘E)'}
+            aria-label={readerState.editing ? 'Switch to reading view' : 'Edit note'}
+          >
+            {readerState.editing
+              ? <BookOpen className="w-4 h-4" strokeWidth={2} />
+              : <Pencil className="w-4 h-4" strokeWidth={2} />}
+          </button>
+        )}
+
         {/* Save status — visible whenever an atom tab is active and saving */}
         {readerState.atomId && readerState.saveStatus !== 'idle' && (
           <span className={`text-xs shrink-0 ${
@@ -426,7 +444,7 @@ export function MainView() {
         {localGraph.isOpen && localGraph.centerAtomId ? (
           <LocalGraphView />
         ) : readerState.atomId ? (
-          <AtomReader atomId={readerState.atomId} highlightText={readerState.highlightText} initialEditing={readerState.editing} />
+          <AtomReader atomId={readerState.atomId} highlightText={readerState.highlightText} />
         ) : wikiReaderState.tagId && wikiReaderState.tagName ? (
           <WikiReader
             tagId={wikiReaderState.tagId}

--- a/src/index.css
+++ b/src/index.css
@@ -83,10 +83,21 @@
   --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
   --font-family-mono: var(--font-mono);
 
-  /* Map Atomic's theme tokens onto @atomic-editor/editor's custom properties.
-   * The editor package defines its own `--atomic-editor-*` namespace
-   * with dark-neutral fallbacks; this block is what makes the editor
-   * track our theme (including `data-theme`/`data-font` overrides). */
+}
+
+/* Map Atomic's theme tokens onto @atomic-editor/editor's custom properties.
+ * The editor package defines its own `--atomic-editor-*` namespace with
+ * dark-neutral fallbacks; this block is what makes the editor track our
+ * theme (including `data-theme`/`data-font` overrides).
+ *
+ * The mapping is declared on BOTH `:root` and the reader's
+ * `[data-reader-theme]` container. A `var()` inside a custom property is
+ * substituted where the property is *declared*, not where it's used — so
+ * the `:root` declaration bakes in root-level tokens, and a nested
+ * container that re-tunes `--color-*` (the reader's light mode) needs the
+ * mapping re-declared on itself to pick those up. */
+:root,
+[data-reader-theme] {
   --atomic-editor-font: var(--font-sans);
   --atomic-editor-font-mono: var(--font-mono);
   --atomic-editor-fg: var(--color-text-primary);
@@ -99,8 +110,8 @@
   --atomic-editor-accent: var(--color-accent);
   --atomic-editor-accent-bright: var(--color-accent-light);
   --atomic-editor-accent-soft: color-mix(in srgb, var(--color-accent) 72%, white 28%);
-  --atomic-editor-link: var(--atomic-prose-link, #60a5fa);
-  --atomic-editor-link-hover: var(--atomic-prose-link-hover, #93c5fd);
+  --atomic-editor-link: var(--color-accent-light);
+  --atomic-editor-link-hover: color-mix(in srgb, var(--color-accent-light) 80%, white 20%);
   --atomic-editor-code-bg: color-mix(in srgb, var(--color-bg-card) 88%, black 12%);
   --atomic-editor-selection-bg: color-mix(in srgb, var(--color-accent) 28%, var(--color-bg-main) 72%);
   --atomic-editor-search-bg: color-mix(in srgb, var(--color-accent) 26%, transparent 74%);
@@ -132,6 +143,33 @@
   --scrollbar-track: #fafafa;
   --scrollbar-thumb: #d0d0d0;
   --scrollbar-thumb-hover: #b0b0b0;
+}
+
+/* Pale editor surfaces. The editor package's code-syntax palette and
+ * reveal-highlight defaults are tuned for dark backdrops, and its own
+ * light re-tune only fires under `[data-theme="light"]` — an attribute
+ * value Atomic never sets (the reader's light mode is `data-reader-theme`,
+ * and liquid-glass is its own data-theme value). Re-map them here for our
+ * two pale surfaces. Syntax colors mirror the package's light palette
+ * (GitHub-light-derived; see @atomic-editor/editor styles.css
+ * `[data-theme="light"]`); the reveal tint derives from our accent. */
+[data-reader-theme="light"],
+[data-theme="liquid-glass"] {
+  --atomic-editor-hl-keyword: #cf222e;
+  --atomic-editor-hl-string: #0a3069;
+  --atomic-editor-hl-number: #0550ae;
+  --atomic-editor-hl-comment: #6e7781;
+  --atomic-editor-hl-type: #953800;
+  --atomic-editor-hl-function: #8250df;
+  --atomic-editor-hl-property: #0550ae;
+  --atomic-editor-hl-regexp: #116329;
+  --atomic-editor-hl-escape: #0550ae;
+  --atomic-editor-hl-tag: #116329;
+  --atomic-editor-hl-variable: #24292f;
+  --atomic-editor-hl-operator: #cf222e;
+  --atomic-editor-hl-invalid: #82071e;
+  --atomic-editor-initial-reveal-bg: color-mix(in srgb, var(--color-accent) 16%, transparent 84%);
+  --atomic-editor-initial-reveal-bg-strong: color-mix(in srgb, var(--color-accent) 30%, transparent 70%);
 }
 
 [data-font="satoshi"] { --font-sans: 'Satoshi', -apple-system, BlinkMacSystemFont, sans-serif; }

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -143,7 +143,11 @@ interface UIStore {
   // Legacy public openers (delegate to openEntry)
   openReader: (atomId: string, highlightText?: string, opts?: { newTab?: boolean }) => void;
   openReaderEditing: (atomId: string, opts?: { newTab?: boolean }) => void;
-  setReaderEditState: (editing: boolean, saveStatus?: 'idle' | 'saving' | 'saved' | 'error') => void;
+  /// Switch the open reader between read and edit mode. Also writes the
+  /// mode back into the active tab's current atom entry so it survives
+  /// tab switches and restarts (tab stacks are persisted).
+  setReaderEditing: (editing: boolean) => void;
+  setReaderSaveStatus: (saveStatus: 'idle' | 'saving' | 'saved' | 'error') => void;
   closeReader: () => void;
   openWikiReader: (tagId: string, tagName: string, highlightText?: string, opts?: { newTab?: boolean }) => void;
   openReportDetail: (reportId: string, opts?: { newTab?: boolean; title?: string }) => void;
@@ -680,9 +684,22 @@ export const useUIStore = create<UIStore>()(
         );
       },
 
-      setReaderEditState: (editing, saveStatus) =>
+      setReaderEditing: (editing) =>
+        set((state) => {
+          const tabs = state.tabs.map((tab) => {
+            if (tab.id !== state.activeTabId) return tab;
+            const entry = tab.stack[tab.stackIndex];
+            if (!entry || entry.type !== 'atom' || entry.editing === editing) return tab;
+            const stack = [...tab.stack];
+            stack[tab.stackIndex] = { ...entry, editing };
+            return { ...tab, stack };
+          });
+          return { tabs, readerState: { ...state.readerState, editing } };
+        }),
+
+      setReaderSaveStatus: (saveStatus) =>
         set((state) => ({
-          readerState: { ...state.readerState, editing, ...(saveStatus !== undefined ? { saveStatus } : {}) },
+          readerState: { ...state.readerState, saveStatus },
         })),
 
       closeReader: () => {


### PR DESCRIPTION
## What

Adds a true **read mode** to the atom reader and makes it the default for existing atoms. Bumps `@atomic-editor/editor` 0.3.0 → 0.6.0 (which ships compartment-based `readOnly`, `==highlight==` syntax, table hardening, and list-layout fixes) and aligns editor styling with the design system.

### Mode policy
- **Existing atoms open in read mode** — fully rendered, links open on click, checkboxes still toggleable (and autosaved), find-in-note works, no accidental edits, no keyboard pop on mobile.
- **New-atom flows and empty atoms open in edit mode** (all `openReaderEditing` call sites, plus a force-edit override for empty content so the delete-empty-on-close flow stays reachable).

### Switching
- **Cmd/Ctrl+E** toggles read ↔ edit; **`i`** enters edit vim-style from read mode.
- **Escape** steps out gradually: edit → read (flushing the draft — save + embedding/tagging pipeline), then read → close. The flush-on-leaving-edit is a nicer finalize point than today's only-on-close.
- A **pencil/book toggle** in the titlebar (the only affordance on touch).
- Mode is **per-tab and persistent**: `setReaderEditing` writes it back into the active tab's atom entry, which already carried a persisted `editing` flag.

The sidebar (source URL, tags, delete) deliberately stays interactive in read mode — read mode protects the document body.

### Style alignment (`index.css`)
- Editor links tracked `--atomic-prose-link`, a token defined nowhere — i.e. hardcoded off-system blues. Now derived from `--color-accent-light`, so dark (violet), reader-light (violet), and liquid-glass (sky) all track their accent.
- **Fixes a pre-existing bug: reader light mode never restyled the editor body.** `var()` inside a custom property substitutes where the property is *declared*, so the `:root`-level token → `--atomic-editor-*` mapping baked in dark values and the reader's `data-reader-theme="light"` container never re-resolved it. The mapping is now also declared on `[data-reader-theme]`.
- The editor's code-syntax palette and reveal tint are dark-tuned and upstream only re-tunes them under `[data-theme="light"]`, which Atomic never sets — both pale surfaces (reader light mode, liquid-glass) now re-map them explicitly. This also fixes Palenight-on-pale code blocks under liquid-glass.

## Verification

- `tsc --noEmit`, `vitest` (33 passing), production build.
- Playwright E2E smoke against a scratch `atomic-server` + built bundle — 14/14:
  default-read on existing atoms, readonly styling hook, rendered (no raw syntax) body, `==highlight==`, checkbox toggle autosaves from read mode, `i` → edit, titlebar action flips, Escape → read with draft flushed to the server, Ctrl+E → edit, mode persists across reload via the tab entry, Escape from read closes the reader, empty atom force-opens in edit.
- Screenshots of dark / reader-light / liquid-glass verifying link colors, syntax palettes, highlight, checkboxes, blockquote rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)