### PR TITLE
MCP: expand tool surface to 16 tools with annotations + per-client docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Create a token from Settings > Connection > API Tokens, or via the CLI:
 atomic-server token create --name "claude"
 ```
 
-**Available tools:** `semantic_search`, `read_atom`, `create_atom`, `ingest_url`, `update_atom`
+**Available tools:** search and retrieval (`semantic_search`, `read_atom`, `find_similar`), browsing (`list_tags`, `list_atoms`, `list_databases`), synthesized knowledge (`list_wikis`, `get_wiki`, `list_reports`, `get_report_findings`), writing (`create_atom`, `ingest_url`, `update_atom`, `edit_atom`), and ChatGPT-compatible `search`/`fetch` aliases. See the [MCP Server guide](https://atomicapp.ai/manual/guides/mcp-server/) for per-client setup (claude.ai, Claude Code, Cursor, ChatGPT).
 
 ## Architecture
 

--- a/crates/atomic-server/src/mcp/server.rs
+++ b/crates/atomic-server/src/mcp/server.rs
@@ -2,6 +2,9 @@ use crate::event_bridge::{embedding_event_callback, ingestion_event_callback};
 use crate::mcp::types::*;
 use crate::state::ServerEvent;
 use atomic_core::manager::DatabaseManager;
+use atomic_core::models::{
+    AtomKind, KindFilter, ListAtomsParams, SortField, SortOrder, SourceFilter, TagWithCount,
+};
 use atomic_core::AtomicCore;
 use atomic_core::{apply_atom_edits, AtomEditOperation};
 use rmcp::{
@@ -40,6 +43,46 @@ pub struct DbSelection(pub Option<String>);
 #[derive(Clone)]
 pub struct RequestManager(pub Arc<DatabaseManager>);
 
+/// Serialize a tool response as pretty-printed JSON text content.
+///
+/// Every tool returns its structured payload this way; keeping the
+/// serialization in one place keeps the error mapping consistent.
+fn json_result<T: serde::Serialize>(value: &T) -> Result<CallToolResult, ErrorData> {
+    let text = serde_json::to_string_pretty(value)
+        .map_err(|e| ErrorData::internal_error(format!("Serialization error: {}", e), None))?;
+    Ok(CallToolResult::success(vec![Content::text(text)]))
+}
+
+/// Map a hierarchical [`TagWithCount`] tree into the compact wire shape.
+fn tag_tree(nodes: &[TagWithCount]) -> Vec<TagNode> {
+    nodes
+        .iter()
+        .map(|node| TagNode {
+            tag_id: node.tag.id.clone(),
+            name: node.tag.name.clone(),
+            atom_count: node.atom_count,
+            children: tag_tree(&node.children),
+        })
+        .collect()
+}
+
+/// Find a tag by ID or case-insensitive name anywhere in the tree.
+fn find_tag<'a>(
+    nodes: &'a [TagWithCount],
+    needle: &str,
+    needle_lower: &str,
+) -> Option<&'a TagWithCount> {
+    for node in nodes {
+        if node.tag.id == needle || node.tag.name.to_lowercase() == needle_lower {
+            return Some(node);
+        }
+        if let Some(found) = find_tag(&node.children, needle, needle_lower) {
+            return Some(found);
+        }
+    }
+    None
+}
+
 /// MCP Server for Atomic knowledge base
 #[derive(Clone)]
 pub struct AtomicMcpServer {
@@ -57,11 +100,24 @@ impl AtomicMcpServer {
         }
     }
 
+    /// The manager this request resolves against: the per-request
+    /// [`RequestManager`] override when a composing layer installed one,
+    /// otherwise the manager baked in at [`Self::new`].
+    fn request_manager<'a>(
+        &'a self,
+        context: &'a RequestContext<RoleServer>,
+    ) -> &'a Arc<DatabaseManager> {
+        context
+            .extensions
+            .get::<RequestManager>()
+            .map(|m| &m.0)
+            .unwrap_or(&self.manager)
+    }
+
     /// Resolve the correct AtomicCore for the request.
     ///
-    /// The manager is the per-request [`RequestManager`] override when a
-    /// composing layer installed one, otherwise the manager baked in at
-    /// [`Self::new`] — the same fallback shape as the data plane's
+    /// The manager comes from [`Self::request_manager`] — the same fallback
+    /// shape as the data plane's
     /// [`request_manager`](crate::db_extractor::request_manager). The database
     /// *within* that manager is then selected from the [`DbSelection`]
     /// extension (the `?db=` parameter), so selection lives in one place
@@ -70,11 +126,7 @@ impl AtomicMcpServer {
         &self,
         context: &RequestContext<RoleServer>,
     ) -> Result<AtomicCore, ErrorData> {
-        let manager = context
-            .extensions
-            .get::<RequestManager>()
-            .map(|m| &m.0)
-            .unwrap_or(&self.manager);
+        let manager = self.request_manager(context);
         let db_id = context
             .extensions
             .get::<DbSelection>()
@@ -94,9 +146,17 @@ impl AtomicMcpServer {
 
 #[tool_router]
 impl AtomicMcpServer {
+    // ==================== Search & retrieval ====================
+
     /// Search for atoms using hybrid keyword + semantic search
     #[tool(
-        description = "Search your memory for relevant knowledge. Use this before answering questions that may relate to previously stored information. Returns matching atoms ranked by relevance. Set since_days to constrain to recent atoms (e.g., 7 for last week, 30 for last month) when the question is time-sensitive."
+        title = "Search memory",
+        description = "Search your memory for relevant knowledge. Use this before answering questions that may relate to previously stored information. Returns matching atoms ranked by relevance. Set since_days to constrain to recent atoms (e.g., 7 for last week, 30 for last month) when the question is time-sensitive. Set tag_id to scope the search to one topic, and include_generated=true to also search report findings.",
+        annotations(
+            title = "Search memory",
+            read_only_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn semantic_search(
         &self,
@@ -109,16 +169,21 @@ impl AtomicMcpServer {
         // agents) get a captured-only view by default. The `kind`
         // discriminator landed in phase 1 so background-generated content
         // (report findings, etc.) wouldn't surface in external retrievers
-        // unless the caller opts in. Threading the filter through
-        // `SearchOptions` rather than post-filtering keeps result counts
-        // accurate at `limit` and pushes the constraint into the SQL.
+        // unless the caller opts in — which `include_generated` now allows.
+        // Threading the filter through `SearchOptions` rather than
+        // post-filtering keeps result counts accurate at `limit` and pushes
+        // the constraint into the SQL.
+        let kinds = if params.include_generated.unwrap_or(false) {
+            KindFilter::All
+        } else {
+            KindFilter::only(AtomKind::Captured)
+        };
         let options =
             atomic_core::SearchOptions::new(params.query, atomic_core::SearchMode::Hybrid, limit)
                 .with_threshold(0.3)
                 .with_since_days(params.since_days)
-                .with_kinds(atomic_core::models::KindFilter::only(
-                    atomic_core::models::AtomKind::Captured,
-                ));
+                .with_scope(params.tag_id.into_iter().collect())
+                .with_kinds(kinds);
 
         let results = core
             .search(options)
@@ -135,15 +200,14 @@ impl AtomicMcpServer {
             })
             .collect();
 
-        let response_text = serde_json::to_string_pretty(&search_results)
-            .map_err(|e| ErrorData::internal_error(format!("Serialization error: {}", e), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(response_text)]))
+        json_result(&search_results)
     }
 
     /// Read a single atom with optional line-based pagination
     #[tool(
-        description = "Read the full content of a specific atom. Use this after semantic_search returns a relevant result and you need the complete text. Supports pagination for large atoms."
+        title = "Read atom",
+        description = "Read the full content of a specific atom. Use this after semantic_search returns a relevant result and you need the complete text. Supports pagination for large atoms.",
+        annotations(title = "Read atom", read_only_hint = true, open_world_hint = false)
     )]
     async fn read_atom(
         &self,
@@ -194,15 +258,392 @@ impl AtomicMcpServer {
             updated_at: atom_with_tags.atom.updated_at,
         };
 
-        let response_text = serde_json::to_string_pretty(&response)
-            .map_err(|e| ErrorData::internal_error(format!("Serialization error: {}", e), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(response_text)]))
+        json_result(&response)
     }
+
+    /// Find atoms semantically similar to a given atom
+    #[tool(
+        title = "Find similar atoms",
+        description = "Find atoms semantically related to a given atom. Use this to traverse the knowledge graph outward from a relevant atom — surfacing connected ideas that a keyword search would miss.",
+        annotations(
+            title = "Find similar atoms",
+            read_only_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn find_similar(
+        &self,
+        context: RequestContext<RoleServer>,
+        Parameters(params): Parameters<FindSimilarParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let core = self.resolve_core(&context).await?;
+        let limit = params.limit.unwrap_or(10).clamp(1, 50);
+
+        match core.get_atom(&params.atom_id).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Atom not found: {}",
+                    params.atom_id
+                ))]));
+            }
+            Err(e) => return Err(ErrorData::internal_error(e.to_string(), None)),
+        }
+
+        // 0.5 is the same threshold the app uses for related-atom semantic
+        // edges — below that, neighbors stop being meaningfully "related".
+        let results = core
+            .find_similar(&params.atom_id, limit, 0.5)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let items: Vec<SimilarAtomItem> = results
+            .into_iter()
+            .map(|r| SimilarAtomItem {
+                atom_id: r.atom.atom.id.clone(),
+                title: r.atom.atom.title.clone(),
+                content_preview: r.atom.atom.content.chars().take(200).collect(),
+                similarity_score: r.similarity_score,
+            })
+            .collect();
+
+        json_result(&items)
+    }
+
+    // ==================== Browsing & navigation ====================
+
+    /// List the hierarchical tag tree
+    #[tool(
+        title = "List tags",
+        description = "List the tag tree that organizes this knowledge base, with per-tag atom counts. Use it to discover topics, to find tag IDs for scoped searches (semantic_search tag_id), for tagging atoms (update_atom tag_ids), and for wiki lookups (get_wiki). Set min_count to prune rarely-used leaf tags.",
+        annotations(title = "List tags", read_only_hint = true, open_world_hint = false)
+    )]
+    async fn list_tags(
+        &self,
+        context: RequestContext<RoleServer>,
+        Parameters(params): Parameters<ListTagsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let core = self.resolve_core(&context).await?;
+        let min_count = params.min_count.unwrap_or(0).max(0);
+
+        let tags = core
+            .get_all_tags_filtered(min_count)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        json_result(&tag_tree(&tags))
+    }
+
+    /// List atoms with pagination and optional tag filtering
+    #[tool(
+        title = "List atoms",
+        description = "Browse atoms as a paginated list, most recently updated first. Set tag_id (from list_tags) to browse one topic, including atoms under descendant tags. Returns summaries only — use read_atom for full content.",
+        annotations(title = "List atoms", read_only_hint = true, open_world_hint = false)
+    )]
+    async fn list_atoms(
+        &self,
+        context: RequestContext<RoleServer>,
+        Parameters(params): Parameters<ListAtomsToolParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let core = self.resolve_core(&context).await?;
+        let limit = params.limit.unwrap_or(20).clamp(1, 100);
+        let offset = params.offset.unwrap_or(0).max(0);
+        let kinds = if params.include_generated.unwrap_or(false) {
+            KindFilter::All
+        } else {
+            KindFilter::only(AtomKind::Captured)
+        };
+
+        let list_params = ListAtomsParams {
+            tag_id: params.tag_id,
+            limit,
+            offset,
+            cursor: None,
+            cursor_id: None,
+            source_filter: SourceFilter::All,
+            source_value: None,
+            sort_by: SortField::Updated,
+            sort_order: SortOrder::Desc,
+        };
+
+        let page = core
+            .list_atoms(&list_params, &kinds)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let has_more = offset + (page.atoms.len() as i32) < page.total_count;
+        let atoms: Vec<AtomListItem> = page
+            .atoms
+            .into_iter()
+            .map(|a| AtomListItem {
+                atom_id: a.id,
+                title: a.title,
+                snippet: a.snippet,
+                tags: a.tags.into_iter().map(|t| t.name).collect(),
+                source_url: a.source_url,
+                created_at: a.created_at,
+                updated_at: a.updated_at,
+            })
+            .collect();
+
+        let response = AtomListResponse {
+            atoms,
+            total_count: page.total_count,
+            offset,
+            has_more,
+        };
+
+        json_result(&response)
+    }
+
+    /// List the knowledge databases available to this connection
+    #[tool(
+        title = "List databases",
+        description = "List the knowledge databases available to this connection and which one tool calls currently operate on. The database is selected by the connection URL (?db=<id>) or the X-Atomic-Database header — tool calls cannot switch it, but this shows the user's options.",
+        annotations(
+            title = "List databases",
+            read_only_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_databases(
+        &self,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let manager = self.request_manager(&context);
+        let (databases, active) = manager
+            .list_databases()
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        // The request-level ?db= selection wins over the manager's active
+        // database — mirror resolve_core so "selected" reflects what tool
+        // calls on this connection actually hit.
+        let selected = context
+            .extensions
+            .get::<DbSelection>()
+            .and_then(|s| s.0.clone())
+            .unwrap_or(active);
+
+        let items: Vec<DatabaseListItem> = databases
+            .into_iter()
+            .map(|d| DatabaseListItem {
+                selected: d.id == selected,
+                database_id: d.id,
+                name: d.name,
+                is_default: d.is_default,
+            })
+            .collect();
+
+        json_result(&items)
+    }
+
+    // ==================== Synthesized knowledge ====================
+
+    /// List wiki articles
+    #[tool(
+        title = "List wiki articles",
+        description = "List the wiki articles in this knowledge base. Wikis are synthesized overviews of everything stored under a tag, with citations back to source atoms. Use get_wiki to read one.",
+        annotations(
+            title = "List wiki articles",
+            read_only_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_wikis(
+        &self,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let core = self.resolve_core(&context).await?;
+        let articles = core
+            .get_all_wiki_articles()
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let items: Vec<WikiListItem> = articles
+            .into_iter()
+            .map(|a| WikiListItem {
+                tag_id: a.tag_id,
+                tag_name: a.tag_name,
+                atom_count: a.atom_count,
+                updated_at: a.updated_at,
+            })
+            .collect();
+
+        json_result(&items)
+    }
+
+    /// Read the wiki article for a tag
+    #[tool(
+        title = "Read wiki article",
+        description = "Read the synthesized wiki article for a tag — a curated overview of everything stored under that topic. Prefer this over piecing together many search results when the user asks for a summary of a topic. Inline [N] markers in the content resolve to the returned citations. Accepts a tag ID or exact tag name.",
+        annotations(
+            title = "Read wiki article",
+            read_only_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn get_wiki(
+        &self,
+        context: RequestContext<RoleServer>,
+        Parameters(params): Parameters<GetWikiParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let core = self.resolve_core(&context).await?;
+
+        let tags = core
+            .get_all_tags()
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let needle_lower = params.tag.to_lowercase();
+        let tag = match find_tag(&tags, &params.tag, &needle_lower) {
+            Some(t) => t,
+            None => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Tag not found: {} (use list_tags to see available tags)",
+                    params.tag
+                ))]));
+            }
+        };
+
+        let wiki = core
+            .get_wiki(&tag.tag.id)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let Some(wiki) = wiki else {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "No wiki article exists for tag '{}' yet. Wiki articles are generated in the Atomic app; atoms under the tag can still be browsed with list_atoms or semantic_search.",
+                tag.tag.name
+            ))]));
+        };
+
+        let response = WikiResponse {
+            tag_id: wiki.article.tag_id,
+            tag_name: tag.tag.name.clone(),
+            content: wiki.article.content,
+            atom_count: wiki.article.atom_count,
+            updated_at: wiki.article.updated_at,
+            citations: wiki
+                .citations
+                .into_iter()
+                .map(|c| WikiCitationItem {
+                    citation_index: c.citation_index,
+                    atom_id: c.atom_id,
+                    excerpt: c.excerpt,
+                    source_url: c.source_url,
+                })
+                .collect(),
+        };
+
+        json_result(&response)
+    }
+
+    /// List report definitions
+    #[tool(
+        title = "List reports",
+        description = "List the automated research reports configured in this knowledge base. Reports run on a schedule and write their findings back as atoms. Use get_report_findings to read a report's output.",
+        annotations(title = "List reports", read_only_hint = true, open_world_hint = false)
+    )]
+    async fn list_reports(
+        &self,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let core = self.resolve_core(&context).await?;
+        let reports = core
+            .list_reports()
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let items: Vec<ReportListItem> = reports
+            .into_iter()
+            .map(|r| ReportListItem {
+                report_id: r.id,
+                name: r.name,
+                description: r.description,
+                schedule: r.schedule,
+                schedule_tz: r.schedule_tz,
+                enabled: r.enabled,
+                last_run_at: r.last_run_at,
+                last_error: r.last_error,
+            })
+            .collect();
+
+        json_result(&items)
+    }
+
+    /// Read the most recent findings of a report
+    #[tool(
+        title = "Read report findings",
+        description = "Read the most recent findings a report produced. Each finding is a research write-up whose inline [N] markers resolve to the returned citations pointing at source atoms.",
+        annotations(
+            title = "Read report findings",
+            read_only_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn get_report_findings(
+        &self,
+        context: RequestContext<RoleServer>,
+        Parameters(params): Parameters<GetReportFindingsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let core = self.resolve_core(&context).await?;
+        let limit = params.limit.unwrap_or(3).clamp(1, 10);
+
+        match core.get_report(&params.report_id).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Report not found: {} (use list_reports to see available reports)",
+                    params.report_id
+                ))]));
+            }
+            Err(e) => return Err(ErrorData::internal_error(e.to_string(), None)),
+        }
+
+        let findings = core
+            .list_findings_for_report(&params.report_id, limit)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let mut items = Vec::with_capacity(findings.len());
+        for (finding, atom) in findings {
+            let citations = core
+                .list_citations_for_finding(&finding.finding_atom_id)
+                .await
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+            items.push(ReportFindingItem {
+                atom_id: atom.atom.id,
+                title: atom.atom.title,
+                report_name: finding.report_name_snapshot,
+                created_at: finding.created_at,
+                content: atom.atom.content,
+                citations: citations
+                    .into_iter()
+                    .map(|c| FindingCitationItem {
+                        position: c.position,
+                        cited_atom_id: c.cited_atom_id,
+                        excerpt: c.excerpt,
+                    })
+                    .collect(),
+            });
+        }
+
+        json_result(&items)
+    }
+
+    // ==================== Writing ====================
 
     /// Create a new atom with markdown content
     #[tool(
-        description = "Remember something new. Create an atom when you learn information worth retaining across conversations — user preferences, decisions, project context, or important facts. Write concise, self-contained markdown."
+        title = "Create atom",
+        description = "Remember something new. Create an atom when you learn information worth retaining across conversations — user preferences, decisions, project context, or important facts. Write concise, self-contained markdown.",
+        annotations(
+            title = "Create atom",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
     )]
     async fn create_atom(
         &self,
@@ -240,15 +681,20 @@ impl AtomicMcpServer {
             embedding_status: result.atom.embedding_status.clone(),
         };
 
-        let response_text = serde_json::to_string_pretty(&response)
-            .map_err(|e| ErrorData::internal_error(format!("Serialization error: {}", e), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(response_text)]))
+        json_result(&response)
     }
 
     /// Ingest a URL into Atomic
     #[tool(
-        description = "Fetch a URL, extract its article content, and save it as an atom. Use this when the user asks to remember, save, or ingest a web page. If the URL already exists as an atom source_url, returns the existing atom_id with already_exists=true instead of creating a duplicate."
+        title = "Save web page",
+        description = "Fetch a URL, extract its article content, and save it as an atom. Use this when the user asks to remember, save, or ingest a web page. If the URL already exists as an atom source_url, returns the existing atom_id with already_exists=true instead of creating a duplicate.",
+        annotations(
+            title = "Save web page",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        )
     )]
     async fn ingest_url(
         &self,
@@ -271,11 +717,7 @@ impl AtomicMcpServer {
                 already_exists: true,
             };
 
-            let response_text = serde_json::to_string_pretty(&response).map_err(|e| {
-                ErrorData::internal_error(format!("Serialization error: {}", e), None)
-            })?;
-
-            return Ok(CallToolResult::success(vec![Content::text(response_text)]));
+            return json_result(&response);
         }
 
         let request = atomic_core::IngestionRequest {
@@ -301,15 +743,20 @@ impl AtomicMcpServer {
             already_exists: false,
         };
 
-        let response_text = serde_json::to_string_pretty(&response)
-            .map_err(|e| ErrorData::internal_error(format!("Serialization error: {}", e), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(response_text)]))
+        json_result(&response)
     }
 
     /// Update an existing atom with optional full-content, metadata, or tag changes
     #[tool(
-        description = "Compatibility full/partial atom update. Omitted fields are preserved. Content is optional so callers can update metadata or tag_ids without rewriting markdown. Prefer edit_atom for content changes unless replacing the whole atom intentionally."
+        title = "Update atom",
+        description = "Compatibility full/partial atom update. Omitted fields are preserved. Content is optional so callers can update metadata or tag_ids (from list_tags) without rewriting markdown. Prefer edit_atom for content changes unless replacing the whole atom intentionally.",
+        annotations(
+            title = "Update atom",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn update_atom(
         &self,
@@ -380,15 +827,20 @@ impl AtomicMcpServer {
             embedding_status: result.atom.embedding_status.clone(),
         };
 
-        let response_text = serde_json::to_string_pretty(&response)
-            .map_err(|e| ErrorData::internal_error(format!("Serialization error: {}", e), None))?;
-
-        Ok(CallToolResult::success(vec![Content::text(response_text)]))
+        json_result(&response)
     }
 
     /// Apply targeted edits to an atom's markdown content
     #[tool(
-        description = "Apply safe edits to an existing atom. Supports replace, insert_after, append, and replace_all. replace and insert_after require exact text that appears exactly once. The whole operation fails without saving if any edit is invalid. Prefer this over update_atom for markdown changes."
+        title = "Edit atom",
+        description = "Apply safe edits to an existing atom. Supports replace, insert_after, append, and replace_all. replace and insert_after require exact text that appears exactly once. The whole operation fails without saving if any edit is invalid. Prefer this over update_atom for markdown changes.",
+        annotations(
+            title = "Edit atom",
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
     )]
     async fn edit_atom(
         &self,
@@ -455,10 +907,91 @@ impl AtomicMcpServer {
             embedding_status: result.atom.embedding_status.clone(),
         };
 
-        let response_text = serde_json::to_string_pretty(&response)
-            .map_err(|e| ErrorData::internal_error(format!("Serialization error: {}", e), None))?;
+        json_result(&response)
+    }
 
-        Ok(CallToolResult::success(vec![Content::text(response_text)]))
+    // ==================== ChatGPT-compatible aliases ====================
+    //
+    // ChatGPT's deep-research mode only invokes read-only tools named
+    // exactly `search` and `fetch` with these schemas
+    // (https://developers.openai.com/api/docs/mcp). They are thin aliases
+    // of semantic_search and read_atom in the wire shape that surface
+    // expects; other clients can use either pair.
+
+    /// ChatGPT-compatible search alias
+    #[tool(
+        title = "Search",
+        description = "Search the knowledge base and return matching documents. Alias of semantic_search in the search/fetch document shape.",
+        annotations(title = "Search", read_only_hint = true, open_world_hint = false)
+    )]
+    async fn search(
+        &self,
+        context: RequestContext<RoleServer>,
+        Parameters(params): Parameters<DeepSearchParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let core = self.resolve_core(&context).await?;
+        let options =
+            atomic_core::SearchOptions::new(params.query, atomic_core::SearchMode::Hybrid, 10)
+                .with_threshold(0.3)
+                .with_kinds(KindFilter::only(AtomKind::Captured));
+
+        let results = core
+            .search(options)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let response = DeepSearchResponse {
+            results: results
+                .into_iter()
+                .map(|r| DeepSearchResult {
+                    id: r.atom.atom.id.clone(),
+                    title: r.atom.atom.title.clone(),
+                    text: r.matching_chunk_content,
+                    url: r.atom.atom.source_url.clone(),
+                })
+                .collect(),
+        };
+
+        json_result(&response)
+    }
+
+    /// ChatGPT-compatible fetch alias
+    #[tool(
+        title = "Fetch",
+        description = "Fetch the full content of a document returned by search. Alias of read_atom in the search/fetch document shape.",
+        annotations(title = "Fetch", read_only_hint = true, open_world_hint = false)
+    )]
+    async fn fetch(
+        &self,
+        context: RequestContext<RoleServer>,
+        Parameters(params): Parameters<FetchParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let core = self.resolve_core(&context).await?;
+
+        let atom_with_tags = match core.get_atom(&params.id).await {
+            Ok(Some(a)) => a,
+            Ok(None) => {
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Atom not found: {}",
+                    params.id
+                ))]));
+            }
+            Err(e) => return Err(ErrorData::internal_error(e.to_string(), None)),
+        };
+
+        let response = FetchResponse {
+            id: atom_with_tags.atom.id,
+            title: atom_with_tags.atom.title,
+            text: atom_with_tags.atom.content,
+            url: atom_with_tags.atom.source_url,
+            metadata: FetchMetadata {
+                created_at: atom_with_tags.atom.created_at,
+                updated_at: atom_with_tags.atom.updated_at,
+                tags: atom_with_tags.tags.into_iter().map(|t| t.name).collect(),
+            },
+        };
+
+        json_result(&response)
     }
 }
 
@@ -468,7 +1001,10 @@ impl ServerHandler for AtomicMcpServer {
         ServerInfo {
             instructions: Some(
                 "Atomic is your long-term memory. Search before answering from recall. \
-                 Remember what's worth retaining. Update what's gone stale."
+                 Remember what's worth retaining. Update what's gone stale. Beyond raw \
+                 notes: list_tags shows how knowledge is organized, get_wiki returns a \
+                 synthesized overview of a topic with citations, and get_report_findings \
+                 returns the output of scheduled research reports."
                     .to_string(),
             ),
             capabilities: ServerCapabilities::builder().enable_tools().build(),

--- a/crates/atomic-server/src/mcp/types.rs
+++ b/crates/atomic-server/src/mcp/types.rs
@@ -17,6 +17,14 @@ pub struct SemanticSearchParams {
     /// Use this when the user asks about recent notes ("this week", "last month", etc.).
     #[serde(default)]
     pub since_days: Option<i32>,
+
+    /// Optional tag ID to scope results to atoms under that tag (from list_tags).
+    #[serde(default)]
+    pub tag_id: Option<String>,
+
+    /// Include report-generated finding atoms alongside captured notes (default: false).
+    #[serde(default)]
+    pub include_generated: Option<bool>,
 }
 
 /// Input parameters for read_atom tool
@@ -63,7 +71,7 @@ pub struct UpdateAtomParams {
     #[serde(default)]
     pub published_at: Option<String>,
 
-    /// Optional replacement tag IDs. Omit to preserve current tags; pass [] to clear tags.
+    /// Optional replacement tag IDs (from list_tags). Omit to preserve current tags; pass [] to clear tags.
     #[serde(default)]
     pub tag_ids: Option<Vec<String>>,
 }
@@ -125,6 +133,77 @@ pub struct IngestUrlParams {
     pub url: String,
 }
 
+/// Input parameters for list_tags tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListTagsParams {
+    /// Prune leaf tags with fewer than this many atoms (default: 0, keep everything)
+    #[serde(default)]
+    pub min_count: Option<i32>,
+}
+
+/// Input parameters for list_atoms tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListAtomsToolParams {
+    /// Optional tag ID to filter by (from list_tags; includes atoms under descendant tags)
+    #[serde(default)]
+    pub tag_id: Option<String>,
+
+    /// Maximum number of atoms to return (default: 20, max: 100)
+    #[serde(default)]
+    pub limit: Option<i32>,
+
+    /// Offset for pagination, 0-indexed (default: 0)
+    #[serde(default)]
+    pub offset: Option<i32>,
+
+    /// Include report-generated finding atoms alongside captured notes (default: false)
+    #[serde(default)]
+    pub include_generated: Option<bool>,
+}
+
+/// Input parameters for find_similar tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindSimilarParams {
+    /// The UUID of the atom to find semantic neighbors for
+    pub atom_id: String,
+
+    /// Maximum number of results to return (default: 10, max: 50)
+    #[serde(default)]
+    pub limit: Option<i32>,
+}
+
+/// Input parameters for the ChatGPT-compatible search tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeepSearchParams {
+    /// The search query
+    pub query: String,
+}
+
+/// Input parameters for the ChatGPT-compatible fetch tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FetchParams {
+    /// The atom ID returned by a previous search call
+    pub id: String,
+}
+
+/// Input parameters for get_wiki tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetWikiParams {
+    /// Tag ID or exact tag name (case-insensitive) whose wiki article to read
+    pub tag: String,
+}
+
+/// Input parameters for get_report_findings tool
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetReportFindingsParams {
+    /// The report ID (from list_reports)
+    pub report_id: String,
+
+    /// Maximum number of findings to return, most recent first (default: 3, max: 10)
+    #[serde(default)]
+    pub limit: Option<i32>,
+}
+
 // ==================== Tool Output Types ====================
 
 /// A search result with atom content and similarity score
@@ -166,4 +245,157 @@ pub struct IngestUrlResponse {
     pub title: String,
     pub content_length: usize,
     pub already_exists: bool,
+}
+
+/// A node in the hierarchical tag tree
+#[derive(Debug, Serialize)]
+pub struct TagNode {
+    pub tag_id: String,
+    pub name: String,
+    pub atom_count: i32,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<TagNode>,
+}
+
+/// One atom in a paginated listing (summary only, no full content)
+#[derive(Debug, Serialize)]
+pub struct AtomListItem {
+    pub atom_id: String,
+    pub title: String,
+    pub snippet: String,
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Paginated atom listing response
+#[derive(Debug, Serialize)]
+pub struct AtomListResponse {
+    pub atoms: Vec<AtomListItem>,
+    pub total_count: i32,
+    pub offset: i32,
+    pub has_more: bool,
+}
+
+/// One knowledge database visible to this connection
+#[derive(Debug, Serialize)]
+pub struct DatabaseListItem {
+    pub database_id: String,
+    pub name: String,
+    pub is_default: bool,
+    /// True for the database this connection's tool calls operate on.
+    pub selected: bool,
+}
+
+/// A semantic neighbor of an atom
+#[derive(Debug, Serialize)]
+pub struct SimilarAtomItem {
+    pub atom_id: String,
+    pub title: String,
+    pub content_preview: String,
+    pub similarity_score: f32,
+}
+
+/// Envelope for the ChatGPT-compatible search tool
+#[derive(Debug, Serialize)]
+pub struct DeepSearchResponse {
+    pub results: Vec<DeepSearchResult>,
+}
+
+/// One result row for the ChatGPT-compatible search tool
+#[derive(Debug, Serialize)]
+pub struct DeepSearchResult {
+    pub id: String,
+    pub title: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+/// Full document for the ChatGPT-compatible fetch tool
+#[derive(Debug, Serialize)]
+pub struct FetchResponse {
+    pub id: String,
+    pub title: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub metadata: FetchMetadata,
+}
+
+/// Metadata block for the ChatGPT-compatible fetch tool
+#[derive(Debug, Serialize)]
+pub struct FetchMetadata {
+    pub created_at: String,
+    pub updated_at: String,
+    pub tags: Vec<String>,
+}
+
+/// Wiki article summary for list view
+#[derive(Debug, Serialize)]
+pub struct WikiListItem {
+    pub tag_id: String,
+    pub tag_name: String,
+    pub atom_count: i32,
+    pub updated_at: String,
+}
+
+/// Wiki article with its citations
+#[derive(Debug, Serialize)]
+pub struct WikiResponse {
+    pub tag_id: String,
+    pub tag_name: String,
+    pub content: String,
+    pub atom_count: i32,
+    pub updated_at: String,
+    pub citations: Vec<WikiCitationItem>,
+}
+
+/// One inline citation in a wiki article: `[N]` markers in the content
+/// resolve to `citation_index` entries here.
+#[derive(Debug, Serialize)]
+pub struct WikiCitationItem {
+    pub citation_index: i32,
+    pub atom_id: String,
+    pub excerpt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+}
+
+/// Report definition summary
+#[derive(Debug, Serialize)]
+pub struct ReportListItem {
+    pub report_id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub schedule: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schedule_tz: Option<String>,
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_run_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+/// A report finding (agent-authored research atom) with its citations
+#[derive(Debug, Serialize)]
+pub struct ReportFindingItem {
+    pub atom_id: String,
+    pub title: String,
+    pub report_name: String,
+    pub created_at: String,
+    pub content: String,
+    pub citations: Vec<FindingCitationItem>,
+}
+
+/// One `[N]` citation marker in a finding, resolved to its source atom
+#[derive(Debug, Serialize)]
+pub struct FindingCitationItem {
+    pub position: i32,
+    pub cited_atom_id: String,
+    pub excerpt: String,
 }

--- a/crates/atomic-server/tests/e2e_mcp.rs
+++ b/crates/atomic-server/tests/e2e_mcp.rs
@@ -8,7 +8,9 @@
 //!
 //! Deeper MCP protocol semantics (tool dispatch, session lifecycle,
 //! cancellation) belong in the rmcp crate's own suite; this file owns the
-//! "does our server expose MCP at all" contract.
+//! "does our server expose MCP at all" contract — plus the *tool surface*
+//! contract (names, titles, read-only/destructive annotations), which the
+//! docs and the connectors-directory listing depend on.
 
 mod support;
 
@@ -181,4 +183,162 @@ fn initialize_request() -> Value {
             "clientInfo": { "name": "atomic-e2e", "version": "0.0.0" }
         }
     })
+}
+
+/// Extract the JSON-RPC `result` object from a Streamable HTTP response body,
+/// which may be plain JSON or SSE-framed (`data: {...}` lines).
+fn extract_jsonrpc_result(content_type: &str, body: &str) -> Value {
+    let payloads: Vec<Value> = if content_type.starts_with("application/json") {
+        vec![serde_json::from_str(body)
+            .unwrap_or_else(|e| panic!("invalid JSON body: {e}\nbody = {body}"))]
+    } else {
+        body.lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter_map(|payload| serde_json::from_str::<Value>(payload).ok())
+            .collect()
+    };
+    payloads
+        .into_iter()
+        .find_map(|v| v.get("result").cloned())
+        .unwrap_or_else(|| panic!("no JSON-RPC result in response; body = {body}"))
+}
+
+/// The tool surface is a public contract: the docs (README, manual guide) and
+/// the connectors-directory listing enumerate these names, and clients gate
+/// write confirmation on the annotations. Storage-independent, so SQLite only.
+#[actix_web::test]
+async fn mcp_tools_list_pins_tool_surface_sqlite() {
+    const READ_ONLY: &[&str] = &[
+        "semantic_search",
+        "read_atom",
+        "find_similar",
+        "list_tags",
+        "list_atoms",
+        "list_databases",
+        "list_wikis",
+        "get_wiki",
+        "list_reports",
+        "get_report_findings",
+        "search",
+        "fetch",
+    ];
+    const WRITE: &[&str] = &["create_atom", "ingest_url", "update_atom", "edit_atom"];
+
+    let Some(ctx) = TestCtx::new(Backend::Sqlite).await else {
+        return;
+    };
+    let server = spawn_live_server(&ctx).await;
+    let client = reqwest::Client::new();
+    let mcp_url = format!("{}/mcp", server.base_url);
+
+    let resp = client
+        .post(&mcp_url)
+        .bearer_auth(&ctx.token)
+        .header("Accept", "application/json, text/event-stream")
+        .json(&initialize_request())
+        .send()
+        .await
+        .expect("POST /mcp initialize");
+    assert!(resp.status().is_success(), "initialize: {}", resp.status());
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .expect("initialize response carries Mcp-Session-Id")
+        .to_string();
+
+    let resp = client
+        .post(&mcp_url)
+        .bearer_auth(&ctx.token)
+        .header("Accept", "application/json, text/event-stream")
+        .header("Mcp-Session-Id", &session_id)
+        .json(&json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+        .send()
+        .await
+        .expect("POST /mcp initialized notification");
+    assert!(
+        resp.status().is_success(),
+        "initialized notification: {}",
+        resp.status()
+    );
+
+    let resp = client
+        .post(&mcp_url)
+        .bearer_auth(&ctx.token)
+        .header("Accept", "application/json, text/event-stream")
+        .header("Mcp-Session-Id", &session_id)
+        .json(&json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }))
+        .send()
+        .await
+        .expect("POST /mcp tools/list");
+    assert!(resp.status().is_success(), "tools/list: {}", resp.status());
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    let body = resp.text().await.expect("read tools/list body");
+    let result = extract_jsonrpc_result(&content_type, &body);
+
+    let tools = result
+        .get("tools")
+        .and_then(|t| t.as_array())
+        .expect("tools/list result carries a tools array");
+    let by_name: std::collections::HashMap<&str, &Value> = tools
+        .iter()
+        .map(|t| {
+            (
+                t.get("name")
+                    .and_then(|n| n.as_str())
+                    .expect("tool has a name"),
+                t,
+            )
+        })
+        .collect();
+    assert_eq!(by_name.len(), tools.len(), "duplicate tool names");
+
+    for name in READ_ONLY.iter().chain(WRITE) {
+        let tool = by_name
+            .get(name)
+            .unwrap_or_else(|| panic!("tools/list missing {name}"));
+        let annotations = tool
+            .get("annotations")
+            .unwrap_or_else(|| panic!("{name} missing annotations"));
+        assert!(
+            annotations
+                .get("title")
+                .and_then(|t| t.as_str())
+                .is_some_and(|t| !t.is_empty()),
+            "{name} missing annotation title"
+        );
+    }
+    for name in READ_ONLY {
+        assert_eq!(
+            by_name[name]["annotations"]["readOnlyHint"],
+            json!(true),
+            "{name} should be annotated read-only"
+        );
+    }
+    for name in WRITE {
+        assert_eq!(
+            by_name[name]["annotations"]["readOnlyHint"],
+            json!(false),
+            "{name} should be annotated as a write tool"
+        );
+        assert!(
+            by_name[name]["annotations"]
+                .get("destructiveHint")
+                .is_some(),
+            "{name} must declare destructiveHint"
+        );
+    }
+    assert_eq!(
+        tools.len(),
+        READ_ONLY.len() + WRITE.len(),
+        "tool surface changed — update this test, the README tool list, and \
+         docs/manual/guides/mcp-server.md"
+    );
+
+    server.stop().await;
 }

--- a/crates/mcp-bridge/README.md
+++ b/crates/mcp-bridge/README.md
@@ -1,0 +1,61 @@
+# atomic-mcp-bridge
+
+A stdio-to-HTTP bridge for Atomic's MCP server. MCP clients that only speak
+stdio (Claude Desktop's local server config, and any client using the
+`command` form) run this binary; it forwards each JSON-RPC message to an
+Atomic server's Streamable HTTP `/mcp` endpoint and relays the responses —
+including SSE-framed ones — back over stdout.
+
+The desktop app bundles the bridge as a sidecar-adjacent binary and shows the
+exact path under **Settings > Integrations > MCP Integration**. Tools are
+advertised by the server, so new server-side tools never require a bridge
+update.
+
+## Configuration
+
+Everything is environment-variable driven:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ATOMIC_URL` | *(unset)* | Full base URL of the Atomic server (e.g. `https://you.atomicapp.ai`). Wins over host/port when set — use this for remote HTTPS servers |
+| `ATOMIC_HOST` | `127.0.0.1` | Host of the local Atomic server (plain HTTP) |
+| `ATOMIC_PORT` | `44380` | Port of the local Atomic server |
+| `ATOMIC_TOKEN` | *(auto-discovered)* | Bearer token for `/mcp`. When unset, the bridge reads the desktop app's local token file (`<data-dir>/com.atomic.app/local_server_token`), so the bundled desktop setup needs no configuration |
+
+## Example client config
+
+```json
+{
+  "mcpServers": {
+    "atomic": {
+      "command": "/Applications/Atomic.app/Contents/MacOS/atomic-mcp-bridge"
+    }
+  }
+}
+```
+
+Pointing the bridge at a remote server:
+
+```json
+{
+  "mcpServers": {
+    "atomic": {
+      "command": "atomic-mcp-bridge",
+      "env": {
+        "ATOMIC_URL": "https://atomic.example.com",
+        "ATOMIC_TOKEN": "YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Note: clients that support Streamable HTTP directly (claude.ai, Claude Code,
+Cursor) don't need the bridge — point them at `https://server/mcp` with a
+Bearer header instead. See `docs/manual/guides/mcp-server.md`.
+
+## Limitations
+
+The bridge forwards request/response traffic only. It does not open the
+standalone GET (server-to-client) stream, so server-initiated notifications
+don't flow through it — none of Atomic's current tools require them.

--- a/crates/mcp-bridge/src/main.rs
+++ b/crates/mcp-bridge/src/main.rs
@@ -13,7 +13,6 @@ use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
-use tracing;
 
 const DEFAULT_PORT: u16 = 44380;
 const DEFAULT_HOST: &str = "127.0.0.1";
@@ -24,6 +23,26 @@ const TOKEN_FILE_NAME: &str = "local_server_token";
 /// Must match Tauri's `app.path().app_data_dir()` for identifier `com.atomic.app`.
 fn atomic_data_dir() -> Option<PathBuf> {
     dirs::data_dir().map(|d| d.join("com.atomic.app"))
+}
+
+/// Resolve the server's MCP endpoint. `ATOMIC_URL` (a full base URL such as
+/// `https://you.atomicapp.ai`) wins so the bridge can front remote HTTPS
+/// servers; otherwise compose the local-sidecar form from
+/// `ATOMIC_HOST`/`ATOMIC_PORT`.
+fn resolve_endpoint() -> String {
+    if let Ok(url) = env::var("ATOMIC_URL") {
+        let trimmed = url.trim_end_matches('/');
+        if trimmed.ends_with("/mcp") {
+            return trimmed.to_string();
+        }
+        return format!("{}/mcp", trimmed);
+    }
+    let port: u16 = env::var("ATOMIC_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(DEFAULT_PORT);
+    let host = env::var("ATOMIC_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string());
+    format!("http://{}:{}/mcp", host, port)
 }
 
 /// Discover the auth token: ATOMIC_TOKEN env var, then local token file on disk.
@@ -273,14 +292,8 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
 
-    // Parse configuration from environment or args
-    let port: u16 = env::var("ATOMIC_PORT")
-        .ok()
-        .and_then(|p| p.parse().ok())
-        .unwrap_or(DEFAULT_PORT);
-
-    let host = env::var("ATOMIC_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string());
-    let endpoint = format!("http://{}:{}/mcp", host, port);
+    // Parse configuration from environment
+    let endpoint = resolve_endpoint();
 
     let auth_token = discover_token();
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -110,7 +110,7 @@ The current manual is intentionally small and several implemented features need 
 - WebSocket events: embedding/tagging pipeline, chat streaming/tool events, ingestion/feed events, queue progress, atom lifecycle events (including report findings flowing through `AtomCreated`), `DashboardFeaturedChanged`, and lag handling.
 - AI providers: OpenRouter, Ollama, and OpenAI-compatible providers, including model defaults, embedding dimensions, context length, connection tests, and re-embedding implications.
 - Browser extension configuration and real installation/build steps from `extension/`.
-- MCP remote OAuth/discovery behavior, Streamable HTTP endpoint details, bridge environment variables, and multi-database `db` query use.
+- MCP Streamable HTTP endpoint details (sessions, SSE framing) beyond the guide basics. Remote OAuth/discovery, bridge environment variables, per-client setup, and multi-database `db` query use are now covered in `manual/guides/mcp-server.md`.
 - Docker and reverse proxy production details: bind address, `PUBLIC_URL`, storage backend, persistent volumes, WebSocket forwarding, and token bootstrapping.
 - Capacitor mobile setup and capabilities as actually implemented in `mobile/ios/` and `mobile/android/`.
 

--- a/docs/manual/cloud/api-tokens-and-mcp.md
+++ b/docs/manual/cloud/api-tokens-and-mcp.md
@@ -41,7 +41,7 @@ To pin the agent to one knowledge base, add the database id:
 https://<your-subdomain>.atomicapp.ai/mcp?db=<database-id>
 ```
 
-The MCP tools (semantic search, reading and writing atoms, URL ingestion) are advertised by the server, so new tools appear in your agent automatically as Atomic gains them. For the general MCP guide — including claude.ai custom connectors and the desktop stdio bridge — see [MCP Server](/guides/mcp-server/).
+The MCP tools — semantic search, atom reading and writing, URL ingestion, tag and database browsing, plus wiki articles and report findings — are advertised by the server, so new tools appear in your agent automatically as Atomic gains them. For the general MCP guide — including the claude.ai custom-connector walkthrough, Claude Code, Cursor, ChatGPT, and the desktop stdio bridge — see [MCP Server](/guides/mcp-server/).
 
 ## REST API
 

--- a/docs/manual/guides/mcp-server.md
+++ b/docs/manual/guides/mcp-server.md
@@ -3,23 +3,54 @@ title: MCP Server
 description: Give AI agents long-term memory by connecting them to Atomic through the Model Context Protocol.
 ---
 
-Atomic exposes an MCP server so AI agents can search, read, create, update, and ingest atoms. You can use it locally through the desktop app bridge or remotely through the self-hosted HTTP endpoint.
+Atomic exposes an MCP server so AI agents can search, browse, and write to your knowledge base — including the synthesized layers (wiki articles and report findings) that plain note-search tools don't have. You can use it locally through the desktop app bridge or remotely through the HTTP endpoint.
 
 ## Tools
 
-Atomic exposes five MCP tools:
+Atomic exposes sixteen MCP tools. All read tools are annotated read-only, so clients that gate write actions (like claude.ai) won't prompt for them.
+
+### Search and retrieval
 
 | Tool | What It Does |
 |------|--------------|
-| `semantic_search` | Hybrid keyword + semantic search over atoms, with optional `since_days` recency filtering |
+| `semantic_search` | Hybrid keyword + semantic search over atoms. Optional `since_days` recency filter, `tag_id` topic scoping, and `include_generated` to also search report findings |
 | `read_atom` | Read full atom content by ID, with line-based pagination |
+| `find_similar` | Semantic neighbors of an atom — traverse the knowledge graph outward from a relevant result |
+
+### Browsing and navigation
+
+| Tool | What It Does |
+|------|--------------|
+| `list_tags` | The hierarchical tag tree with atom counts — the map of how the knowledge base is organized, and the source of `tag_id` values for other tools |
+| `list_atoms` | Paginated atom listing, most recently updated first, optionally filtered to a tag |
+| `list_databases` | The knowledge databases available to this connection, and which one tool calls operate on |
+
+### Synthesized knowledge
+
+| Tool | What It Does |
+|------|--------------|
+| `list_wikis` | All wiki articles — synthesized overviews of everything stored under a tag |
+| `get_wiki` | Read one wiki article by tag ID or name, with citations back to source atoms |
+| `list_reports` | Automated research reports configured in the knowledge base |
+| `get_report_findings` | The most recent findings a report produced, with citations |
+
+### Writing
+
+| Tool | What It Does |
+|------|--------------|
 | `create_atom` | Store new markdown memory as an atom |
-| `ingest_url` | Fetch a URL, extract article content, and save it as an atom |
-| `update_atom` | Replace an existing atom's markdown content |
+| `ingest_url` | Fetch a URL, extract article content, and save it as an atom. Returns the existing atom with `already_exists: true` on duplicate URLs |
+| `update_atom` | Full/partial atom update — content, metadata, or tags (`tag_ids` from `list_tags`) |
+| `edit_atom` | Targeted, safe markdown edits: `replace`, `insert_after`, `append`, `replace_all` |
 
-The server instructions tell agents to search before answering from memory, remember durable context, and update stale atoms instead of duplicating them.
+### ChatGPT compatibility
 
-`ingest_url` accepts a single `url` argument and returns the `atom_id`, source `url`, extracted `title`, `content_length`, and `already_exists`. If the URL already exists as an atom `source_url`, the tool returns the existing atom with `already_exists: true` instead of creating a duplicate.
+| Tool | What It Does |
+|------|--------------|
+| `search` | Alias of `semantic_search` in the document shape ChatGPT's deep research mode requires |
+| `fetch` | Alias of `read_atom` in the same document shape |
+
+The server instructions tell agents to search before answering from memory, remember durable context, update stale atoms instead of duplicating them, and reach for wikis when the user wants a topic overview.
 
 ## Desktop App: Local Bridge
 
@@ -40,6 +71,17 @@ Example for Claude Code, Claude Desktop, or any stdio MCP client:
 ```
 
 On Windows the binary name is `atomic-mcp-bridge.exe`. On Linux the path depends on the installed package layout.
+
+### Bridge configuration
+
+The bridge is configured entirely through environment variables — useful when the server isn't on the default local port or you're pointing the bridge at a remote instance:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ATOMIC_URL` | *(unset)* | Full base URL of a remote server (e.g. `https://you.atomicapp.ai`). Wins over host/port when set |
+| `ATOMIC_HOST` | `127.0.0.1` | Host of the local Atomic server |
+| `ATOMIC_PORT` | `44380` | Port of the local Atomic server |
+| `ATOMIC_TOKEN` | *(auto)* | Bearer token. When unset, the bridge reads the desktop app's local token file automatically |
 
 ## Remote or Self-Hosted: Streamable HTTP
 
@@ -66,6 +108,59 @@ Use a Bearer token:
 
 Some clients use `"type": "url"` for HTTP MCP servers. If your client requires it, add that field to the `atomic` object.
 
+## Connect Specific Clients
+
+### claude.ai and Claude Desktop (custom connector)
+
+claude.ai custom connectors authenticate with OAuth rather than a pasted token, and Atomic implements the full flow:
+
+1. In claude.ai (or Claude Desktop), open **Settings → Connectors → Add custom connector**.
+2. Name it (e.g. "Atomic") and paste your MCP URL — `https://<your-subdomain>.atomicapp.ai/mcp` for cloud, or `https://your-server.example/mcp` for self-hosted.
+3. Click **Connect**. Your browser opens Atomic's consent page: on cloud you approve with your existing login; on self-hosted you approve by pasting an API token once.
+4. Done — Claude can now use every Atomic tool, and read-only tools run without confirmation prompts.
+
+Self-hosted note: the OAuth flow requires `PUBLIC_URL` to be set (see [OAuth and Public URL](#oauth-and-public-url) below). Without it, use a client that supports Bearer headers instead.
+
+### Claude Code
+
+```bash
+claude mcp add --transport http atomic https://your-server.example/mcp \
+  --header "Authorization: Bearer YOUR_TOKEN"
+```
+
+Or with the desktop app installed, use the stdio bridge and skip tokens entirely:
+
+```bash
+claude mcp add atomic /Applications/Atomic.app/Contents/MacOS/atomic-mcp-bridge
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "atomic": {
+      "url": "https://your-server.example/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### ChatGPT
+
+ChatGPT connects to remote MCP servers on Plus/Pro and Business plans:
+
+1. Enable developer mode: **Settings → Apps & Connectors → Advanced settings → Developer mode**.
+2. Add a connector with your Atomic MCP URL.
+3. In deep research, ChatGPT uses Atomic's `search` and `fetch` tools; in developer-mode chats it can use the full tool set.
+
+The server must be reachable from the public internet — ChatGPT cannot connect to localhost, so use a cloud tenant or a self-hosted server with a public URL.
+
 ## Create a Token
 
 From the UI, create a dedicated token in Settings or the onboarding integration step.
@@ -86,7 +181,7 @@ To target a specific database, add the `db` query parameter:
 https://your-server.example/mcp?db=<database-id>
 ```
 
-Without `db`, MCP tools use the active database.
+Without `db`, MCP tools use the active database. Agents can call `list_databases` to see what exists and which database their connection operates on — but switching requires changing the connection URL.
 
 ## OAuth and Public URL
 
@@ -115,7 +210,8 @@ Add guidance like this to your project instructions:
 You have access to Atomic, your long-term memory. Search Atomic before answering
 questions that may relate to past context. Store durable preferences, decisions,
 project context, and important facts. Update stale atoms instead of creating
-duplicates.
+duplicates. When asked for an overview of a topic, check get_wiki before piecing
+together search results.
 ```
 
 ## Troubleshooting
@@ -123,7 +219,8 @@ duplicates.
 - **Desktop bridge cannot connect** - open Atomic first; the sidecar runs while the desktop app is running.
 - **HTTP MCP returns 401** - create a new token and update your MCP client config.
 - **Remote OAuth discovery fails** - set `PUBLIC_URL` and verify the `.well-known` routes through your proxy.
-- **Agent cannot find expected memory** - check that it is using the intended database.
+- **Agent cannot find expected memory** - check that it is using the intended database (`list_databases` shows which one the connection operates on).
+- **Search can't see report findings** - external clients get captured notes only by default; pass `include_generated: true` to `semantic_search`, or read findings directly with `get_report_findings`.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Grows the MCP server from 6 tools to 16 and makes the surface directory-ready. This is the "week 1 + wiki/report read tools" slice of the MCP expansion plan.

**New tools (all read-only):**
- `list_tags`, `list_atoms`, `list_databases` — navigation; `list_tags` finally makes `update_atom`'s `tag_ids` usable
- `find_similar` — semantic-neighbor traversal (0.5 edge threshold)
- `list_wikis` / `get_wiki` — synthesized wiki articles with citations; accepts tag ID or case-insensitive name
- `list_reports` / `get_report_findings` — report findings with resolved `[N]` citations
- `search` / `fetch` — aliases in the document shape ChatGPT deep-research requires

**Existing tools:**
- `semantic_search` gains `tag_id` scoping and `include_generated` (report findings stay hidden from external clients unless opted in)
- Every tool now carries a `title` plus `readOnlyHint`/`destructiveHint` annotations — a Claude connectors-directory requirement; clients stop confirmation-prompting the 12 read tools
- Response serialization consolidated into one `json_result` helper

**Bridge:** new `ATOMIC_URL` env var (host/port form could only compose `http://`, so the bridge couldn't front remote HTTPS servers), plus a first README for the crate.

**Docs:** manual guide was two tools stale ("five tools"); now covers all 16 with per-client walkthroughs (claude.ai custom connector OAuth flow, Claude Code, Cursor, ChatGPT developer mode), bridge env vars, and fixes the cloud doc's dangling cross-reference.

## Test plan

- New e2e test pins the full tool surface on the wire — names, titles, read-only/destructive hints — and fails with doc-update instructions if the surface drifts
- Full `atomic-server` suite green (SQLite + Postgres), `atomic-cloud` checks clean, MCP Inspector smoke test passes
- Live end-to-end run with real OpenRouter inference: seeded atoms + a 102KB URL ingestion through MCP, auto-tagging, wiki generation, and an agentic report run; exercised all 16 tools via the MCP Inspector CLI including `?db=` multi-database selection, `include_generated` visibility both ways, and the ChatGPT alias envelope shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)