### PR TITLE
Fix parallel-execution flake in deferred_pipeline_leaves_jobs_in_ledger

### DIFF
--- a/crates/atomic-core/tests/pipeline_tests.rs
+++ b/crates/atomic-core/tests/pipeline_tests.rs
@@ -997,15 +997,21 @@ async fn deferred_pipeline_leaves_jobs_in_ledger() {
         "deferred save must emit no pipeline events"
     );
 
-    // The parked job stays claimable: a worker (here: inline mode restored
-    // and the queue drained) runs it to completion.
-    core.set_inline_pipeline(true);
+    // The parked job stays claimable: a dedicated worker claims it and runs
+    // it to completion. `run_pipeline_jobs_batch` is the deferred-mode
+    // execution entry point, and — unlike `process_queued_pipeline_jobs` —
+    // it doesn't route through the process-global EMBEDDING_BATCH_SEMAPHORE.
+    // That semaphore (2 permits) is shared by every concurrently running
+    // test in this binary, and the spawning path returns 0 from its
+    // saturated branch (the work is handed to a parked waiter), so a
+    // synchronous claimed-count assertion through it flakes under parallel
+    // test execution.
     let (cb, mut rx) = event_collector();
-    let queued = core
-        .process_queued_pipeline_jobs(cb)
+    let claimed = core
+        .run_pipeline_jobs_batch(10, cb)
         .await
         .expect("drain queue");
-    assert_eq!(queued, 1, "the deferred job must still be claimable");
+    assert_eq!(claimed, 1, "the deferred job must still be claimable");
     await_pipeline(&mut rx, &atom_id).await;
 
     let fetched = core.get_atom(&atom_id).await.unwrap().expect("persisted");


### PR DESCRIPTION
## Summary

`deferred_pipeline_leaves_jobs_in_ledger` fails under parallel test execution — reliably on a loaded machine (6/6 in local repro), intermittently on CI (main on Jul 19, then twice on #223's runs). Root cause: the test drains via `process_queued_pipeline_jobs`, which routes through the process-global `EMBEDDING_BATCH_SEMAPHORE` (2 permits shared across all databases — and therefore across all concurrently running tests in the binary). When sibling tests hold both permits, the saturated branch parks an empty-handed waiter and returns `0` **by design** — the job still gets processed moments later — so the test's synchronous `queued == 1` assertion is contention-sensitive.

Fix: drain through `run_pipeline_jobs_batch`, the deferred-mode worker entry point that claims synchronously and takes no semaphore. The claimed-count assertion becomes deterministic, and the test now matches the production topology it simulates (inline-off hosts drive the ledger from a worker, not the fire-and-forget spawn path). Product code untouched.

## Test plan

- Full `pipeline_tests` binary with default parallelism: 10/10 green (previously 6/6 red on this machine)
- Isolated and `--test-threads=1` runs still green

Unblocks CI on #223, which fails on this pre-existing flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)