### PR TITLE
sidebar: contextual panels per view + reader table of contents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,15 @@ const EditorHarnessPage = lazy(async () => {
   return { default: mod.EditorHarnessPage };
 });
 
+// Standalone /toc-harness page used while building the contextual sidebar's
+// table of contents — exercises heading parsing, click-to-scroll, and scroll
+// tracking against both rendered markdown and CodeMirror before the readers
+// depend on any of it. Lazy-loaded so the main app bundle is unaffected.
+const TocHarnessPage = lazy(async () => {
+  const mod = await import('./components/toc-harness/TocHarnessPage');
+  return { default: mod.TocHarnessPage };
+});
+
 function App() {
   // Initialize embedding event listener
   useEmbeddingEvents();
@@ -36,6 +45,14 @@ function App() {
           element={
             <Suspense fallback={null}>
               <EditorHarnessPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/toc-harness"
+          element={
+            <Suspense fallback={null}>
+              <TocHarnessPage />
             </Suspense>
           }
         />

--- a/src/components/DatabaseSwitcher.tsx
+++ b/src/components/DatabaseSwitcher.tsx
@@ -62,7 +62,7 @@ export function DatabaseSwitcher() {
   }
 
   return (
-    <div className="relative flex-1 min-w-0" ref={dropdownRef}>
+    <div className="relative w-full min-w-0" ref={dropdownRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="w-full flex items-center gap-1.5 px-2 py-1.5 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"

--- a/src/components/atoms/AtomReader.tsx
+++ b/src/components/atoms/AtomReader.tsx
@@ -14,6 +14,11 @@ import { formatDate } from '../../lib/date';
 import { getTransport, isDemoInstance } from '../../lib/transport';
 import { readerEditorActions } from '../../lib/reader-editor-bridge';
 import { atomLinkExtension, type AtomLinkSuggestion, type AtomLinkSuggestionSource } from '../../editor/atom-links';
+import { scrollToOffset, tocViewExtension } from '../../editor/toc-scroll';
+import { useTocItems, type TocItem } from '../toc/useTocItems';
+import { useCm6ScrollSpy } from '../toc/useCm6ScrollSpy';
+import { useTocPublisher } from '../toc/useTocPublisher';
+import type { EditorView } from '@codemirror/view';
 import type {
   AtomicCodeMirrorEditorHandle,
   AtomicCodeMirrorEditorProps,
@@ -185,7 +190,9 @@ function AtomReaderContent({
   const setReaderSaveStatus = useUIStore(s => s.setReaderSaveStatus);
   const retryTagging = useAtomsStore(s => s.retryTagging);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
   const editorHandleRef = useRef<AtomicCodeMirrorEditorHandle | null>(null);
+  const cmViewRef = useRef<EditorView | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [showTagSelector, setShowTagSelector] = useState(false);
@@ -388,15 +395,36 @@ function AtomReaderContent({
     };
   }, []);
 
-  const atomLinkExtensions = useMemo(
-    () => atomLinkExtension({
-      currentAtomId: atom.id,
-      suggestAtoms: suggestAtomLinks,
-      resolveAtom: resolveAtomLink,
-      openAtom: (id, opts) => onRelatedAtomClick(id, opts),
-    }),
+  // The editor reads `extensions` once per mount, so everything it needs has
+  // to arrive in this one array. `cmViewRef` is stable, and the editor is keyed
+  // on `${atom.id}:${editorRevision}`, so each remount re-captures its view.
+  const editorExtensions = useMemo(
+    () => [
+      atomLinkExtension({
+        currentAtomId: atom.id,
+        suggestAtoms: suggestAtomLinks,
+        resolveAtom: resolveAtomLink,
+        openAtom: (id, opts) => onRelatedAtomClick(id, opts),
+      }),
+      tocViewExtension(cmViewRef),
+    ],
     [atom.id, onRelatedAtomClick, resolveAtomLink, suggestAtomLinks],
   );
+
+  // Outline from the live draft, so a heading typed in edit mode shows up in
+  // the sidebar without waiting for a save.
+  const tocItems = useTocItems(editContent);
+  const activeTocId = useCm6ScrollSpy(scrollerRef, cmViewRef, tocItems);
+  const scrollToTocItem = useCallback((item: TocItem) => {
+    const view = cmViewRef.current;
+    if (view) scrollToOffset(view, item.offset);
+  }, []);
+  useTocPublisher({
+    source: 'atom',
+    items: tocItems,
+    activeId: activeTocId,
+    scrollToItem: scrollToTocItem,
+  });
 
   return (
     <div
@@ -412,7 +440,7 @@ function AtomReaderContent({
           the viewport may be wide while the reader is narrow — without
           container queries the desktop two-column would render at ~600px
           and squeeze the editor. */}
-      <div className="@container flex-1 overflow-y-auto scrollbar-auto-hide">
+      <div ref={scrollerRef} className="@container flex-1 overflow-y-auto scrollbar-auto-hide">
         <div className="max-w-6xl mx-auto px-3 py-5 sm:px-4 sm:py-6 @4xl:px-6 @4xl:flex @4xl:gap-10">
           <div className="flex-1 min-w-0">
             <Suspense fallback={null}>
@@ -428,7 +456,7 @@ function AtomReaderContent({
                   void openExternalUrl(url);
                 }}
                 editorHandleRef={editorHandleRef}
-                extensions={atomLinkExtensions}
+                extensions={editorExtensions}
               />
             </Suspense>
           </div>

--- a/src/components/dashboard/RecentAtomsPanel.tsx
+++ b/src/components/dashboard/RecentAtomsPanel.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getTransport } from '../../lib/transport';
+import type { AtomSummary, PaginatedAtoms } from '../../stores/atoms';
+import { useDatabasesStore } from '../../stores/databases';
+import { useUIStore } from '../../stores/ui';
+import { formatRelativeDate, formatShortRelativeDate } from '../../lib/date';
+
+/** Enough to fill the panel without paging; this is a jump list, not a view. */
+const RECENT_LIMIT = 20;
+
+/** Atom events arrive in bursts (imports, feed polls, a pipeline draining). */
+const REFRESH_DEBOUNCE_MS = 600;
+
+/// The dashboard's sidebar: the notes you touched most recently, newest
+/// first, one click from the reader.
+///
+/// The query is deliberately component-local rather than routed through
+/// `useAtomsStore`: that store's list *is* the atoms view — its filter,
+/// sort, and pagination cursors all describe it — so writing this fixed
+/// 20-row query into it would corrupt the view the user goes back to.
+export function RecentAtomsPanel() {
+  const [atoms, setAtoms] = useState<AtomSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const openReader = useUIStore(s => s.openReader);
+
+  // A database switch resets the data stores, but nothing clears rows held in
+  // component state — so the active id is a load dependency here.
+  const activeDatabaseId = useDatabasesStore(s => s.activeId);
+
+  // Responses can land out of order (a database switch racing an event-driven
+  // refresh); only the newest request may paint.
+  const requestSeq = useRef(0);
+
+  const load = useCallback(async () => {
+    const seq = ++requestSeq.current;
+    try {
+      const result = await getTransport().invoke<PaginatedAtoms>('list_atoms', {
+        limit: RECENT_LIMIT,
+        sortBy: 'updated',
+        sortOrder: 'desc',
+      });
+      if (seq !== requestSeq.current) return;
+      setAtoms(result.atoms);
+      setError(null);
+    } catch (e) {
+      if (seq !== requestSeq.current) return;
+      setError(String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    // A switch invalidates the rows outright: show the skeleton rather than
+    // the previous database's notes while the new page is in flight.
+    if (activeDatabaseId) setAtoms(null);
+    void load();
+  }, [load, activeDatabaseId]);
+
+  // Keep the list live without polling. The panel body stays mounted while
+  // the sidebar is collapsed, so the refresh is debounced into a single
+  // request per burst rather than one per atom.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const scheduleRefresh = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => void load(), REFRESH_DEBOUNCE_MS);
+    };
+    const transport = getTransport();
+    const unsubs = ['atom-created', 'atom-updated'].map(event =>
+      transport.subscribe(event, scheduleRefresh)
+    );
+    return () => {
+      clearTimeout(timer);
+      unsubs.forEach(unsub => unsub());
+    };
+  }, [load]);
+
+  const open = (atomId: string, opts?: { newTab?: boolean }) => {
+    openReader(atomId, undefined, opts);
+  };
+
+  return (
+    <div className="h-full overflow-y-auto scrollbar-hidden">
+      {error && (
+        <p className="px-3 py-2 text-xs text-red-400 leading-relaxed">{error}</p>
+      )}
+
+      {atoms === null ? (
+        error ? null : (
+          <div className="flex flex-col gap-1 px-3 py-2">
+            {Array.from({ length: 5 }, (_, i) => (
+              <div key={i} className="py-1.5">
+                <div
+                  className="h-3.5 rounded bg-[var(--color-bg-card)] animate-pulse"
+                  style={{ width: `${70 + i * 15}px` }}
+                />
+              </div>
+            ))}
+          </div>
+        )
+      ) : atoms.length === 0 ? (
+        error ? null : (
+          <p className="px-3 py-4 text-xs text-[var(--color-text-secondary)] leading-relaxed">
+            Nothing captured yet. Notes you write or import show up here, most recent first.
+          </p>
+        )
+      ) : (
+        atoms.map((atom) => {
+          const title = atom.title || 'Untitled';
+          return (
+            <button
+              key={atom.id}
+              type="button"
+              onClick={(e) => open(atom.id, { newTab: e.metaKey || e.ctrlKey })}
+              onAuxClick={(e) => {
+                if (e.button === 1) {
+                  e.preventDefault();
+                  open(atom.id, { newTab: true });
+                }
+              }}
+              className="w-full flex items-baseline gap-2 px-3 py-2 text-left hover:bg-[var(--color-bg-card)] transition-colors"
+            >
+              <span
+                className="flex-1 min-w-0 truncate text-sm text-[var(--color-text-primary)]"
+                title={title}
+              >
+                {title}
+              </span>
+              <span
+                className="shrink-0 text-[11px] text-[var(--color-text-tertiary)]"
+                title={formatRelativeDate(atom.updated_at)}
+              >
+                {formatShortRelativeDate(atom.updated_at)}
+              </span>
+            </button>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/widgets/BriefingContent.tsx
+++ b/src/components/dashboard/widgets/BriefingContent.tsx
@@ -1,13 +1,22 @@
 import { Fragment, type ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import type { Element } from 'hast';
 import { CitationLink } from '../../wiki/CitationLink';
 import type { FindingCitation } from '../../../stores/featuredReport';
 
 interface BriefingContentProps {
   content: string;
   citations: FindingCitation[];
+  /** Ids to stamp on rendered headings, keyed by their offset in `content`.
+   *  Opt-in: only surfaces that drive a table of contents pass it. */
+  headingIdByOffset?: Map<number, string>;
   onCitationClick: (citation: FindingCitation, element: HTMLElement) => void;
+}
+
+interface HeadingProps {
+  node?: Element;
+  children?: ReactNode;
 }
 
 /**
@@ -15,7 +24,7 @@ interface BriefingContentProps {
  * clickable CitationLink buttons. Intentionally simpler than WikiArticleContent:
  * no wiki-links, no search highlighting, no related tags.
  */
-export function BriefingContent({ content, citations, onCitationClick }: BriefingContentProps) {
+export function BriefingContent({ content, citations, headingIdByOffset, onCitationClick }: BriefingContentProps) {
   const citationMap = new Map(citations.map(c => [c.citation_index, c]));
 
   const processTextWithCitations = (text: string): (string | JSX.Element)[] => {
@@ -48,6 +57,14 @@ export function BriefingContent({ content, citations, onCitationClick }: Briefin
     return children;
   };
 
+  // Heading ids are matched by source offset rather than re-slugged from the
+  // rendered text, so they survive the demotion below and stay identical to
+  // whatever outline the caller parsed.
+  const headingId = (node?: Element): string | undefined => {
+    const offset = node?.position?.start?.offset;
+    return offset === undefined ? undefined : headingIdByOffset?.get(offset);
+  };
+
   // Agent-authored markdown is body content, not page structure: whatever
   // heading level the model chose, it renders as a modest section header
   // and can never compete with the app's own chrome. h1–h3 demote to a
@@ -58,12 +75,12 @@ export function BriefingContent({ content, citations, onCitationClick }: Briefin
     li: ({ children }: { children?: ReactNode }) => <li>{processChildren(children)}</li>,
     strong: ({ children }: { children?: ReactNode }) => <strong>{processChildren(children)}</strong>,
     em: ({ children }: { children?: ReactNode }) => <em>{processChildren(children)}</em>,
-    h1: ({ children }: { children?: ReactNode }) => <h3>{processChildren(children)}</h3>,
-    h2: ({ children }: { children?: ReactNode }) => <h3>{processChildren(children)}</h3>,
-    h3: ({ children }: { children?: ReactNode }) => <h3>{processChildren(children)}</h3>,
-    h4: ({ children }: { children?: ReactNode }) => <h4>{processChildren(children)}</h4>,
-    h5: ({ children }: { children?: ReactNode }) => <h4>{processChildren(children)}</h4>,
-    h6: ({ children }: { children?: ReactNode }) => <h4>{processChildren(children)}</h4>,
+    h1: ({ node, children }: HeadingProps) => <h3 id={headingId(node)}>{processChildren(children)}</h3>,
+    h2: ({ node, children }: HeadingProps) => <h3 id={headingId(node)}>{processChildren(children)}</h3>,
+    h3: ({ node, children }: HeadingProps) => <h3 id={headingId(node)}>{processChildren(children)}</h3>,
+    h4: ({ node, children }: HeadingProps) => <h4 id={headingId(node)}>{processChildren(children)}</h4>,
+    h5: ({ node, children }: HeadingProps) => <h4 id={headingId(node)}>{processChildren(children)}</h4>,
+    h6: ({ node, children }: HeadingProps) => <h4 id={headingId(node)}>{processChildren(children)}</h4>,
   };
 
   return (

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -4,7 +4,7 @@ import { MainView } from './MainView';
 import { LoadingIndicator } from '../ui/LoadingIndicator';
 import { ServerConnectionStatus } from '../ui/ServerConnectionStatus';
 import { RouterBridge } from '../../router/RouterBridge';
-import { SettingsModal } from '../settings/SettingsModal';
+import { SettingsModal, type SettingsTab } from '../settings/SettingsModal';
 import { OnboardingWizard } from '../onboarding';
 import { CommandPalette } from '../command-palette';
 import { SearchPalette } from '../search-palette/SearchPalette';
@@ -32,6 +32,7 @@ export function Layout() {
   const fetchTags = useTagsStore(s => s.fetchTags);
   const [isSetupRequired, setIsSetupRequired] = useState<boolean | null>(null); // null = checking
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTab | undefined>(undefined);
 
   // Command palette state
   const commandPaletteOpen = useUIStore((state) => state.commandPaletteOpen);
@@ -100,9 +101,14 @@ export function Layout() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [toggleCommandPalette, toggleSearchPalette, openSearchPalette, commandPaletteOpen, searchPaletteOpen]);
 
-  // Listen for custom settings event from command palette
+  // Listen for the app-wide settings event. Dispatchers may name a tab
+  // (`detail.tab`); those that don't — the command palette, the top-bar gear —
+  // leave the modal wherever the user last had it.
   useEffect(() => {
-    const handleOpenSettings = () => setSettingsOpen(true);
+    const handleOpenSettings = (e: Event) => {
+      setSettingsInitialTab((e as CustomEvent<{ tab?: SettingsTab } | undefined>).detail?.tab);
+      setSettingsOpen(true);
+    };
     window.addEventListener('open-settings', handleOpenSettings);
     return () => window.removeEventListener('open-settings', handleOpenSettings);
   }, []);
@@ -226,6 +232,7 @@ export function Layout() {
         <SettingsModal
           isOpen={settingsOpen}
           onClose={() => setSettingsOpen(false)}
+          initialTab={settingsInitialTab}
         />
       </div>
     </div>

--- a/src/components/layout/LeftPanel.tsx
+++ b/src/components/layout/LeftPanel.tsx
@@ -1,15 +1,69 @@
-import { useState, useRef, useEffect } from 'react';
-import { isDemoInstance } from '../../lib/transport';
+import { useRef, useEffect } from 'react';
 import { TagTree } from '../tags/TagTree';
-import { SettingsButton, SettingsModal, type SettingsTab } from '../settings';
-import { DatabaseSwitcher } from '../DatabaseSwitcher';
+import { TocPanel } from '../toc/TocPanel';
+import { WikiArticlesList } from '../wiki/WikiArticlesList';
+import { RecentAtomsPanel } from '../dashboard/RecentAtomsPanel';
+import { LatestFindingsPanel } from '../reports/LatestFindingsPanel';
 import { useUIStore } from '../../stores/ui';
+import { useTocStore, type TocSource } from '../../stores/toc';
 import { isTauri } from '../../lib/platform';
+import { SIDEBAR_CONTEXT_TITLES, useSidebarContext, type SidebarContext } from './sidebar-context';
 
 const COLLAPSE_BREAKPOINT = 768;
+
+const TOC_EMPTY_LABELS: Record<TocSource, string> = {
+  atom: 'No headings in this note',
+  wiki: 'No headings in this article',
+  finding: 'No headings in this finding',
+};
+
+/// The tag tree's empty state offers to configure tag categories. Layout owns
+/// the app's single SettingsModal, so ask for it by event rather than by prop.
+function openTagCategorySettings() {
+  window.dispatchEvent(new CustomEvent('open-settings', { detail: { tab: 'tag-categories' } }));
+}
+
+/// Table of contents for the reader that is currently mounted. The reader
+/// publishes its outline from an effect, one commit after the context flips,
+/// so until its publication lands render nothing — showing the previous
+/// document's headings, or a premature empty state, would both be wrong.
+function TocSidebar({ source }: { source: TocSource }) {
+  const publishedSource = useTocStore((s) => s.source);
+  const items = useTocStore((s) => s.items);
+  const activeId = useTocStore((s) => s.activeId);
+  const scrollToItem = useTocStore((s) => s.scrollToItem);
+
+  if (publishedSource !== source) return null;
+
+  return (
+    <TocPanel
+      items={items}
+      activeId={activeId}
+      onItemClick={scrollToItem}
+      emptyLabel={TOC_EMPTY_LABELS[source]}
+    />
+  );
+}
+
+/// Panel body for the current context. Swapping the body never touches the
+/// panel's open/closed state — that stays the user's manual toggle.
+function SidebarBody({ context }: { context: SidebarContext }) {
+  switch (context.kind) {
+    case 'tags':
+      return <TagTree onOpenTagSettings={openTagCategorySettings} />;
+    case 'toc':
+      return <TocSidebar source={context.source} />;
+    case 'wiki-list':
+      return <WikiArticlesList />;
+    case 'recent':
+      return <RecentAtomsPanel />;
+    case 'findings':
+      return <LatestFindingsPanel reportId={context.reportId} />;
+  }
+}
+
 export function LeftPanel() {
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [settingsInitialTab, setSettingsInitialTab] = useState<SettingsTab | undefined>(undefined);
+  const context = useSidebarContext();
   const leftPanelOpen = useUIStore(s => s.leftPanelOpen);
   const setLeftPanelOpen = useUIStore(s => s.setLeftPanelOpen);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -69,30 +123,18 @@ export function LeftPanel() {
         <div
           className="h-full w-[250px] bg-[var(--color-bg-panel)]/80 border-r border-[var(--color-border)] backdrop-blur-xl flex flex-col overflow-hidden md:absolute md:inset-y-0 md:left-0 md:translate-x-0 md:pointer-events-auto"
         >
-          {/* Titlebar row with settings button */}
+          {/* Titlebar row — names whatever the body is currently showing */}
           <div className={`h-[52px] flex items-center px-3 flex-shrink-0 gap-1 ${isTauri() ? 'pl-[78px]' : ''}`} data-tauri-drag-region>
-            <DatabaseSwitcher />
-            {!isDemoInstance() && (
-              <SettingsButton onClick={() => { setSettingsInitialTab(undefined); setIsSettingsOpen(true); }} />
-            )}
+            <span className="text-xs font-semibold text-[var(--color-text-tertiary)] uppercase tracking-wider truncate select-none">
+              {SIDEBAR_CONTEXT_TITLES[context.kind]}
+            </span>
           </div>
 
-          {/* Tag Tree with integrated search */}
+          {/* Contextual body */}
           <div className="flex-1 overflow-hidden">
-            <TagTree
-              onOpenTagSettings={() => {
-                setSettingsInitialTab('tag-categories');
-                setIsSettingsOpen(true);
-              }}
-            />
+            <SidebarBody context={context} />
           </div>
         </div>
-
-        <SettingsModal
-          isOpen={isSettingsOpen}
-          onClose={() => setIsSettingsOpen(false)}
-          initialTab={settingsInitialTab}
-        />
       </aside>
     </>
   );

--- a/src/components/layout/MainView.tsx
+++ b/src/components/layout/MainView.tsx
@@ -29,6 +29,8 @@ import { WikiFullView } from '../wiki/WikiFullView';
 import { WikiReader } from '../wiki/WikiReader';
 import { ReportsFullView, ReportDetailView, FindingReader } from '../reports';
 import { ChatViewer } from '../chat/ChatViewer';
+import { DatabaseSwitcher } from '../DatabaseSwitcher';
+import { SettingsButton } from '../settings';
 import { TabStrip } from './TabStrip';
 import { useAtomsStore } from '../../stores/atoms';
 import { useUIStore } from '../../stores/ui';
@@ -399,6 +401,17 @@ export function MainView() {
               <ListIcon className="w-4 h-4" strokeWidth={2} />
             </button>
           </div>
+        )}
+
+        {/* Database switcher — the wrapper's explicit width is load-bearing:
+            the dropdown is pinned `left-0 right-0` to this box, so without it
+            the menu would size itself to the active database's name. */}
+        <div className="relative w-40 max-md:w-28 shrink-0">
+          <DatabaseSwitcher />
+        </div>
+
+        {!isDemoInstance() && (
+          <SettingsButton onClick={() => window.dispatchEvent(new CustomEvent('open-settings'))} />
         )}
 
         {/* Chat sidebar toggle */}

--- a/src/components/layout/sidebar-context.test.ts
+++ b/src/components/layout/sidebar-context.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { deriveSidebarContext, type SidebarContextInput } from './sidebar-context';
+import type { ViewMode } from '../../stores/ui';
+
+function input(overrides: Partial<SidebarContextInput> = {}): SidebarContextInput {
+  return {
+    localGraph: { isOpen: false },
+    readerState: { atomId: null },
+    wikiReaderState: { tagId: null },
+    findingReaderState: { atomId: null },
+    reportsDetailState: { reportId: null },
+    viewMode: 'atoms',
+    ...overrides,
+  };
+}
+
+describe('deriveSidebarContext', () => {
+  it('falls back to the tag tree on the atoms and canvas base views', () => {
+    expect(deriveSidebarContext(input({ viewMode: 'atoms' }))).toEqual({ kind: 'tags' });
+    expect(deriveSidebarContext(input({ viewMode: 'canvas' }))).toEqual({ kind: 'tags' });
+  });
+
+  it('maps the remaining base views to their own panels', () => {
+    expect(deriveSidebarContext(input({ viewMode: 'wiki' }))).toEqual({ kind: 'wiki-list' });
+    expect(deriveSidebarContext(input({ viewMode: 'dashboard' }))).toEqual({ kind: 'recent' });
+    expect(deriveSidebarContext(input({ viewMode: 'reports' }))).toEqual({
+      kind: 'findings',
+      reportId: null,
+    });
+  });
+
+  it('shows a table of contents for each of the three readers', () => {
+    expect(deriveSidebarContext(input({ readerState: { atomId: 'a1' } }))).toEqual({
+      kind: 'toc',
+      source: 'atom',
+    });
+    expect(deriveSidebarContext(input({ wikiReaderState: { tagId: 't1' } }))).toEqual({
+      kind: 'toc',
+      source: 'wiki',
+    });
+    expect(deriveSidebarContext(input({ findingReaderState: { atomId: 'f1' } }))).toEqual({
+      kind: 'toc',
+      source: 'finding',
+    });
+  });
+
+  it('scopes findings to the open report detail tab', () => {
+    expect(deriveSidebarContext(input({ reportsDetailState: { reportId: 'r1' } }))).toEqual({
+      kind: 'findings',
+      reportId: 'r1',
+    });
+  });
+
+  it('keeps the tag tree while the local graph is open', () => {
+    expect(
+      deriveSidebarContext(input({ localGraph: { isOpen: true }, viewMode: 'wiki' })),
+    ).toEqual({ kind: 'tags' });
+  });
+
+  // The projections are mutually exclusive in practice, but the ordering is
+  // what guarantees the sidebar and MainView agree if that ever changes.
+  it('resolves overlapping reader slices in MainView order', () => {
+    const all: SidebarContextInput = input({
+      localGraph: { isOpen: true },
+      readerState: { atomId: 'a1' },
+      wikiReaderState: { tagId: 't1' },
+      findingReaderState: { atomId: 'f1' },
+      reportsDetailState: { reportId: 'r1' },
+      viewMode: 'dashboard',
+    });
+    expect(deriveSidebarContext(all)).toEqual({ kind: 'tags' });
+    expect(deriveSidebarContext({ ...all, localGraph: { isOpen: false } })).toEqual({
+      kind: 'toc',
+      source: 'atom',
+    });
+    expect(
+      deriveSidebarContext({ ...all, localGraph: { isOpen: false }, readerState: { atomId: null } }),
+    ).toEqual({ kind: 'toc', source: 'wiki' });
+    expect(
+      deriveSidebarContext({
+        ...all,
+        localGraph: { isOpen: false },
+        readerState: { atomId: null },
+        wikiReaderState: { tagId: null },
+      }),
+    ).toEqual({ kind: 'toc', source: 'finding' });
+    expect(
+      deriveSidebarContext({
+        ...all,
+        localGraph: { isOpen: false },
+        readerState: { atomId: null },
+        wikiReaderState: { tagId: null },
+        findingReaderState: { atomId: null },
+      }),
+    ).toEqual({ kind: 'findings', reportId: 'r1' });
+  });
+
+  it('returns a context for every view mode', () => {
+    const modes: ViewMode[] = ['dashboard', 'atoms', 'canvas', 'wiki', 'reports'];
+    for (const viewMode of modes) {
+      expect(deriveSidebarContext(input({ viewMode }))).toBeTruthy();
+    }
+  });
+});

--- a/src/components/layout/sidebar-context.ts
+++ b/src/components/layout/sidebar-context.ts
@@ -1,0 +1,70 @@
+import { useShallow } from 'zustand/react/shallow';
+import { useUIStore, type ViewMode } from '../../stores/ui';
+
+/// What the left sidebar shows for the current navigation state. The panel's
+/// open/closed state is never derived — only its content.
+export type SidebarContext =
+  | { kind: 'tags' }
+  | { kind: 'toc'; source: 'atom' | 'wiki' | 'finding' }
+  | { kind: 'wiki-list' }
+  | { kind: 'recent' }
+  | { kind: 'findings'; reportId: string | null };
+
+/// The slices `deriveSidebarContext` reads. Structurally a subset of the UI
+/// store, so the store's state can be passed straight in.
+export interface SidebarContextInput {
+  localGraph: { isOpen: boolean };
+  readerState: { atomId: string | null };
+  wikiReaderState: { tagId: string | null };
+  findingReaderState: { atomId: string | null };
+  reportsDetailState: { reportId: string | null };
+  viewMode: ViewMode;
+}
+
+export const SIDEBAR_CONTEXT_TITLES: Record<SidebarContext['kind'], string> = {
+  tags: 'Tags',
+  toc: 'Contents',
+  'wiki-list': 'Articles',
+  recent: 'Recent',
+  findings: 'Findings',
+};
+
+/// Decide the sidebar's content from the projected reader slices.
+///
+/// The branch order mirrors MainView's content ternary chain (the
+/// `localGraph.isOpen ? … : readerState.atomId ? …` cascade) exactly, and
+/// reads the same fields, so the sidebar and the main view can never disagree
+/// about what the user is looking at. Change one, change the other.
+///
+/// MainView additionally guards on `localGraph.centerAtomId` and
+/// `wikiReaderState.tagName`; those are written atomically with the ids they
+/// accompany by `projectActiveEntry`, so testing the ids alone is equivalent.
+export function deriveSidebarContext(s: SidebarContextInput): SidebarContext {
+  if (s.localGraph.isOpen) return { kind: 'tags' };
+  if (s.readerState.atomId) return { kind: 'toc', source: 'atom' };
+  if (s.wikiReaderState.tagId) return { kind: 'toc', source: 'wiki' };
+  if (s.findingReaderState.atomId) return { kind: 'toc', source: 'finding' };
+  // A report tab is open: show that report's findings so the user can walk
+  // its siblings without leaving the detail view.
+  if (s.reportsDetailState.reportId) {
+    return { kind: 'findings', reportId: s.reportsDetailState.reportId };
+  }
+  switch (s.viewMode) {
+    case 'wiki':
+      return { kind: 'wiki-list' };
+    case 'dashboard':
+      return { kind: 'recent' };
+    case 'reports':
+      return { kind: 'findings', reportId: null };
+    case 'atoms':
+    case 'canvas':
+      return { kind: 'tags' };
+  }
+}
+
+/// Subscribe to the sidebar context. Shallow equality on the derived value
+/// means consumers only re-render when the context actually changes, not on
+/// every unrelated UI-store write.
+export function useSidebarContext(): SidebarContext {
+  return useUIStore(useShallow((s) => deriveSidebarContext(s)));
+}

--- a/src/components/reports/FindingReader.tsx
+++ b/src/components/reports/FindingReader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ArrowLeft, Telescope } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -13,7 +13,13 @@ import { useIsMobile } from '../../hooks';
 import { BriefingContent } from '../dashboard/widgets/BriefingContent';
 import { CitationPopover, CitationForPopover } from '../wiki/CitationPopover';
 import { SigmaCanvas } from '../canvas/SigmaCanvas';
+import { offsetWithinContainer, useDomScrollSpy } from '../toc/useDomScrollSpy';
+import { useTocItems, type TocItem } from '../toc/useTocItems';
+import { useTocPublisher } from '../toc/useTocPublisher';
 import { formatRelativeDate } from '../../lib/date';
+
+/** Space left above a heading scrolled to from the outline. */
+const SCROLL_TOP_MARGIN = 72;
 
 interface FindingReaderProps {
   atomId: string;
@@ -61,6 +67,7 @@ export function FindingReader({ atomId }: FindingReaderProps) {
   const setViewMode = useUIStore(s => s.setViewMode);
   const isMobile = useIsMobile();
 
+  const scrollerRef = useRef<HTMLDivElement>(null);
   const [loaded, setLoaded] = useState<LoadedFinding | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [activeCitation, setActiveCitation] = useState<CitationForPopover | null>(null);
@@ -132,6 +139,32 @@ export function FindingReader({ atomId }: FindingReaderProps) {
     atom_id: c.cited_atom_id,
     excerpt: c.excerpt,
   }));
+
+  // Table of contents, parsed from the raw finding markdown: BriefingContent
+  // demotes every heading to <h3>/<h4>, so true levels can only come from the
+  // source, and the ids it stamps are matched back by offset. Findings are
+  // read-only, so re-parse on the next tick rather than waiting out the
+  // editor-oriented debounce.
+  const headings = useTocItems(content, 0);
+  const headingIdByOffset = useMemo(
+    () => new Map(headings.map((heading) => [heading.offset, heading.id])),
+    [headings],
+  );
+  const activeTocId = useDomScrollSpy(scrollerRef, headings);
+  const scrollToTocItem = useCallback((item: TocItem) => {
+    const container = scrollerRef.current;
+    const el = container?.ownerDocument.getElementById(item.id);
+    if (!container || !el) return;
+    container.scrollTo({ top: offsetWithinContainer(container, el) - SCROLL_TOP_MARGIN });
+  }, []);
+  useTocPublisher({
+    // Nothing to outline until the finding's prose is on screen — before that
+    // the body is a skeleton or an unavailable notice.
+    source: loaded ? 'finding' : null,
+    items: headings,
+    activeId: activeTocId,
+    scrollToItem: scrollToTocItem,
+  });
 
   // Atom ids the mini-canvas scopes to: every distinct atom cited by
   // this finding. The canvas adds 1-hop neighbors from the existing
@@ -233,7 +266,7 @@ export function FindingReader({ atomId }: FindingReaderProps) {
           that doubles as a jump-into-canvas affordance. Desktop floats
           the canvas right of the prose; mobile stacks it above so the
           text isn't pushed into a narrow column. */}
-      <div className="flex-1 overflow-y-auto">
+      <div ref={scrollerRef} className="flex-1 overflow-y-auto">
         <div className="max-w-3xl mx-auto px-6 py-8">
           {!isMobile && citedAtomIds && citedAtomIds.length > 0 && (
             <div className="float-right ml-4 mb-4 w-80 aspect-[4/3]">
@@ -259,6 +292,7 @@ export function FindingReader({ atomId }: FindingReaderProps) {
             <BriefingContent
               content={content}
               citations={citationsForContent}
+              headingIdByOffset={headingIdByOffset}
               onCitationClick={handleCitationClick}
             />
           ) : isLoading ? (

--- a/src/components/reports/LatestFindingsPanel.tsx
+++ b/src/components/reports/LatestFindingsPanel.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useMemo } from 'react';
+import { useReportsStore, type ReportFindingWithAtom } from '../../stores/reports';
+import { useUIStore } from '../../stores/ui';
+import { formatRelativeDate, formatShortRelativeDate } from '../../lib/date';
+
+interface LatestFindingsPanelProps {
+  /** `null` on the reports list — the newest finding from every report. */
+  reportId: string | null;
+}
+
+/// The reports sidebar. Scoped to a report while its tab is open (walk the
+/// siblings without leaving the detail view), otherwise the latest finding
+/// from each report, newest first.
+///
+/// Reads the reports store, which has no unmount reset — the detail view,
+/// the tab strip, and the run-completion subscription all share it.
+export function LatestFindingsPanel({ reportId }: LatestFindingsPanelProps) {
+  const reports = useReportsStore(s => s.reports);
+  const reportsById = useReportsStore(s => s.byId);
+  const lastFindingByReport = useReportsStore(s => s.lastFindingByReport);
+  const scopedFindings = useReportsStore(s =>
+    reportId === null ? undefined : s.findingsByReport[reportId]
+  );
+  const isLoadingList = useReportsStore(s => s.isLoadingList);
+  const loadError = useReportsStore(s => s.loadError);
+  const fetchAll = useReportsStore(s => s.fetchAll);
+  const fetchFindings = useReportsStore(s => s.fetchFindings);
+  const openFindingReader = useUIStore(s => s.openFindingReader);
+
+  useEffect(() => {
+    if (reportId === null) {
+      // Store-guarded: the reports view loads on mount too, and this panel
+      // mounts a commit earlier.
+      void fetchAll();
+      return;
+    }
+    // The detail view — always mounted beside this panel, since a scoped
+    // sidebar means a report tab is open — issues the same load. Only fetch
+    // when nothing is cached for this report yet.
+    if (useReportsStore.getState().findingsByReport[reportId] !== undefined) return;
+    void fetchFindings(reportId);
+  }, [reportId, fetchAll, fetchFindings]);
+
+  const rows = useMemo(() => {
+    // Findings outlive their report, so fall back to the name the run
+    // snapshotted when the live row is gone.
+    const reportName = (item: ReportFindingWithAtom) => {
+      const live = item.finding.report_id ? reportsById[item.finding.report_id]?.name : undefined;
+      return live ?? item.finding.report_name_snapshot;
+    };
+
+    const toRow = (item: ReportFindingWithAtom, withReportName: boolean) => ({
+      atomId: item.atom.id,
+      title: item.atom.title || 'Untitled finding',
+      date: item.finding.created_at,
+      reportName: withReportName ? reportName(item) : null,
+    });
+
+    if (reportId !== null) {
+      // Already most-recent-first from the wire.
+      return (scopedFindings ?? []).map(item => toRow(item, false));
+    }
+    return Object.values(lastFindingByReport)
+      .filter((item): item is ReportFindingWithAtom => item !== null)
+      .sort((a, b) => new Date(b.finding.created_at).getTime() - new Date(a.finding.created_at).getTime())
+      .map(item => toRow(item, true));
+  }, [reportId, scopedFindings, lastFindingByReport, reportsById]);
+
+  // Distinguish "still arriving" from "genuinely empty". Across all reports
+  // that means the list fetch or its per-report last-finding fan-out is
+  // still in flight (`undefined` = never fetched, `null` = has no findings).
+  const isLoading =
+    rows.length === 0 &&
+    (reportId === null
+      ? isLoadingList || reports.some(r => lastFindingByReport[r.id] === undefined)
+      : scopedFindings === undefined);
+
+  const open = (atomId: string, opts?: { newTab?: boolean }) => {
+    openFindingReader(atomId, opts);
+  };
+
+  return (
+    <div className="h-full overflow-y-auto scrollbar-hidden">
+      {reportId === null && loadError && (
+        <p className="px-3 py-2 text-xs text-red-400 leading-relaxed">{loadError}</p>
+      )}
+
+      {isLoading ? (
+        <div className="flex flex-col gap-1 px-3 py-2">
+          {Array.from({ length: 5 }, (_, i) => (
+            <div key={i} className="py-1.5">
+              <div
+                className="h-3.5 rounded bg-[var(--color-bg-card)] animate-pulse"
+                style={{ width: `${70 + i * 15}px` }}
+              />
+            </div>
+          ))}
+        </div>
+      ) : rows.length === 0 ? (
+        loadError ? null : (
+          <p className="px-3 py-4 text-xs text-[var(--color-text-secondary)] leading-relaxed">
+            {reportId === null && reports.length === 0
+              ? 'No reports yet. Create one to have it research your knowledge base on a schedule.'
+              : 'No findings yet. Each run writes one here.'}
+          </p>
+        )
+      ) : (
+        rows.map((row) => (
+          <button
+            key={row.atomId}
+            type="button"
+            onClick={(e) => open(row.atomId, { newTab: e.metaKey || e.ctrlKey })}
+            onAuxClick={(e) => {
+              if (e.button === 1) {
+                e.preventDefault();
+                open(row.atomId, { newTab: true });
+              }
+            }}
+            className="w-full block px-3 py-2 text-left hover:bg-[var(--color-bg-card)] transition-colors"
+          >
+            <span className="flex items-baseline gap-2">
+              <span
+                className="flex-1 min-w-0 truncate text-sm text-[var(--color-text-primary)]"
+                title={row.title}
+              >
+                {row.title}
+              </span>
+              <span
+                className="shrink-0 text-[11px] text-[var(--color-text-tertiary)]"
+                title={formatRelativeDate(row.date)}
+              >
+                {formatShortRelativeDate(row.date)}
+              </span>
+            </span>
+
+            {row.reportName && (
+              <span
+                className="block truncate mt-0.5 text-[11px] text-[var(--color-text-tertiary)]"
+                title={row.reportName}
+              >
+                {row.reportName}
+              </span>
+            )}
+          </button>
+        ))
+      )}
+    </div>
+  );
+}

--- a/src/components/reports/index.ts
+++ b/src/components/reports/index.ts
@@ -2,6 +2,7 @@ export { ReportsFullView } from './ReportsFullView';
 export { ReportDetailView } from './ReportDetailView';
 export { FindingReader } from './FindingReader';
 export { FindingsList } from './FindingsList';
+export { LatestFindingsPanel } from './LatestFindingsPanel';
 export { FindingRow } from './FindingRow';
 export { FeaturedStarButton } from './FeaturedStarButton';
 export { FeaturedDropdown } from './FeaturedDropdown';

--- a/src/components/settings/SettingsButton.tsx
+++ b/src/components/settings/SettingsButton.tsx
@@ -8,10 +8,10 @@ export function SettingsButton({ onClick }: SettingsButtonProps) {
   return (
     <button
       onClick={onClick}
-      className="p-1.5 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
+      className="p-1.5 shrink-0 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded-md transition-colors"
       title="Settings"
     >
-      <Settings className="w-5 h-5" strokeWidth={2} />
+      <Settings className="w-4 h-4" strokeWidth={2} />
     </button>
   );
 }

--- a/src/components/toc-harness/TocHarnessPage.tsx
+++ b/src/components/toc-harness/TocHarnessPage.tsx
@@ -1,0 +1,280 @@
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { Element } from 'hast';
+import type { EditorView } from '@codemirror/view';
+import type { AtomicCodeMirrorEditorProps } from '@atomic-editor/editor';
+import { useFont, useTheme } from '../../hooks';
+import { useSettingsStore } from '../../stores/settings';
+import { scrollToOffset, tocViewExtension } from '../../editor/toc-scroll';
+import { TocPanel } from '../toc/TocPanel';
+import { useCm6ScrollSpy } from '../toc/useCm6ScrollSpy';
+import { offsetWithinContainer, useDomScrollSpy } from '../toc/useDomScrollSpy';
+import { useTocItems, type TocItem } from '../toc/useTocItems';
+import { TOC_FIXTURES, type TocFixtureId } from './sample-content';
+
+// Same lazy boundary the atom reader uses — editor module and its code
+// language registry pinned into one chunk, with the default `codeLanguages`
+// filled in so call sites don't need the sub-path import.
+const AtomicCodeMirrorEditor = lazy(async () => {
+  const [mod, langs] = await Promise.all([
+    import('@atomic-editor/editor'),
+    import('@atomic-editor/editor/code-languages'),
+  ]);
+  const Base = mod.AtomicCodeMirrorEditor;
+  const DEFAULT_LANGUAGES = langs.ATOMIC_CODE_LANGUAGES;
+  const Wrapped = (props: AtomicCodeMirrorEditorProps) => (
+    <Base {...props} codeLanguages={props.codeLanguages ?? DEFAULT_LANGUAGES} />
+  );
+  return { default: Wrapped };
+});
+
+type PaneKind = 'markdown' | 'editor';
+const PANES: { id: PaneKind; label: string }[] = [
+  { id: 'markdown', label: 'react-markdown' },
+  { id: 'editor', label: 'codemirror' },
+];
+
+/** Space left above a heading after clicking it in the outline. */
+const SCROLL_TOP_MARGIN = 72;
+
+const PROSE_CLASSES =
+  'prose prose-invert max-w-none prose-headings:text-[var(--color-text-primary)] ' +
+  'prose-p:text-[var(--color-text-primary)] prose-li:text-[var(--color-text-primary)] ' +
+  'prose-code:text-[var(--color-accent-light)] prose-code:bg-[var(--color-bg-card)] ' +
+  'prose-pre:bg-[var(--color-bg-card)] prose-pre:border prose-pre:border-[var(--color-border)]';
+
+const TOGGLE_BASE = 'rounded border px-2 py-1 text-xs transition-colors ';
+const TOGGLE_ON =
+  'border-[var(--color-accent)] bg-[var(--color-accent-alpha)] text-[var(--color-text-primary)]';
+const TOGGLE_OFF =
+  'border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-hover)]';
+
+/**
+ * What a mounted content pane offers the outline: where the reader currently
+ * is, and how to get somewhere else. Phase C moves this handshake into a
+ * store so the real readers can talk to the real sidebar.
+ */
+interface TocPaneState {
+  activeId: string | null;
+  scrollToItem: (item: TocItem) => void;
+}
+
+type PublishToc = (state: TocPaneState | null) => void;
+
+export function TocHarnessPage() {
+  useTheme();
+  useFont();
+
+  // The theme/font hooks read from the settings store, but the store is
+  // lazy — it's only populated when the SettingsModal opens. The
+  // harness lives outside the normal Layout, so without this fetch it
+  // would always show the built-in defaults regardless of what the
+  // user selected.
+  const fetchSettings = useSettingsStore((s) => s.fetchSettings);
+  useEffect(() => {
+    fetchSettings().catch(() => {
+      // Transport may be disconnected (web mode without saved server
+      // config). The defaults from useFont/useTheme are fine in that
+      // case — no need to surface the failure.
+    });
+  }, [fetchSettings]);
+
+  const [fixtureId, setFixtureId] = useState<TocFixtureId>('long');
+  const [pane, setPane] = useState<PaneKind>('markdown');
+  const [paneToc, setPaneToc] = useState<TocPaneState | null>(null);
+
+  const fixture = TOC_FIXTURES.find((f) => f.id === fixtureId) ?? TOC_FIXTURES[0];
+  const items = useTocItems(fixture.source);
+
+  const handleItemClick = useCallback(
+    (item: TocItem) => paneToc?.scrollToItem(item),
+    [paneToc],
+  );
+
+  return (
+    <div className="h-screen flex flex-col bg-[var(--color-bg-main)] text-[var(--color-text-primary)]">
+      <header className="border-b border-[var(--color-border)] bg-[var(--color-bg-panel)] px-4 py-3">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-semibold tracking-wide">TOC Harness</span>
+            <Link
+              to="/"
+              className="text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-accent-light)]"
+            >
+              ← back to app
+            </Link>
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-[var(--color-text-secondary)]">fixture:</span>
+            {TOC_FIXTURES.map((f) => (
+              <button
+                key={f.id}
+                type="button"
+                onClick={() => setFixtureId(f.id)}
+                className={TOGGLE_BASE + (fixtureId === f.id ? TOGGLE_ON : TOGGLE_OFF)}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Pane toggle — the same outline drives DOM-rendered markdown
+              (the wiki/finding readers) and a CodeMirror document (the atom
+              reader). Only the second one has to survive virtualization. */}
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-[var(--color-text-secondary)]">pane:</span>
+            {PANES.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setPane(p.id)}
+                className={TOGGLE_BASE + (pane === p.id ? TOGGLE_ON : TOGGLE_OFF)}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="ml-auto flex items-center gap-4 text-xs text-[var(--color-text-secondary)]">
+            <span>
+              <span className="font-mono text-[var(--color-text-primary)]">{items.length}</span>{' '}
+              headings
+            </span>
+            <span>
+              active:{' '}
+              <span className="font-mono text-[var(--color-text-primary)]">
+                {paneToc?.activeId ?? '—'}
+              </span>
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 flex overflow-hidden">
+        {/* Stand-in for LeftPanel at its real 250px width, so row density and
+            truncation are honest here. */}
+        <aside className="w-[250px] shrink-0 border-r border-[var(--color-border)] bg-[var(--color-bg-panel)] overflow-hidden">
+          <TocPanel
+            items={items}
+            activeId={paneToc?.activeId ?? null}
+            onItemClick={handleItemClick}
+            title="Contents"
+            emptyLabel="No headings in this note"
+          />
+        </aside>
+
+        {pane === 'markdown' ? (
+          <MarkdownPane source={fixture.source} items={items} publish={setPaneToc} />
+        ) : (
+          <EditorPane
+            documentId={`toc-harness-${fixture.id}`}
+            source={fixture.source}
+            items={items}
+            publish={setPaneToc}
+          />
+        )}
+      </main>
+    </div>
+  );
+}
+
+interface PaneProps {
+  source: string;
+  items: TocItem[];
+  publish: PublishToc;
+}
+
+/**
+ * Rendered-markdown pane. Heading ids come from the parse, keyed by source
+ * offset — the technique the wiki and finding readers will use, since
+ * re-slugging the rendered children would drift from `parseHeadings` on
+ * duplicates and inline markup.
+ */
+function MarkdownPane({ source, items, publish }: PaneProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const activeId = useDomScrollSpy(containerRef, items);
+
+  const components = useMemo(() => {
+    const idByOffset = new Map(items.map((item) => [item.offset, item.id]));
+    const idFor = (node?: Element) => {
+      const offset = node?.position?.start?.offset;
+      return offset === undefined ? undefined : idByOffset.get(offset);
+    };
+    const headings: Components = {
+      h1: ({ node, children }) => <h1 id={idFor(node)}>{children}</h1>,
+      h2: ({ node, children }) => <h2 id={idFor(node)}>{children}</h2>,
+      h3: ({ node, children }) => <h3 id={idFor(node)}>{children}</h3>,
+      h4: ({ node, children }) => <h4 id={idFor(node)}>{children}</h4>,
+      h5: ({ node, children }) => <h5 id={idFor(node)}>{children}</h5>,
+      h6: ({ node, children }) => <h6 id={idFor(node)}>{children}</h6>,
+    };
+    return headings;
+  }, [items]);
+
+  const scrollToItem = useCallback((item: TocItem) => {
+    const container = containerRef.current;
+    const el = container?.ownerDocument.getElementById(item.id);
+    if (!container || !el) return;
+    container.scrollTo({ top: offsetWithinContainer(container, el) - SCROLL_TOP_MARGIN });
+  }, []);
+
+  useEffect(() => {
+    publish({ activeId, scrollToItem });
+    return () => publish(null);
+  }, [publish, activeId, scrollToItem]);
+
+  return (
+    <div ref={containerRef} className="flex-1 overflow-y-auto scrollbar-auto-hide">
+      <div className={`max-w-3xl mx-auto px-8 py-6 ${PROSE_CLASSES}`}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+          {source}
+        </ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * CodeMirror pane, laid out like the atom reader: the editor grows to its
+ * content height inside a page-level scroller, so scrolling and scroll
+ * tracking both go through this container rather than `view.scrollDOM`.
+ */
+function EditorPane({ documentId, source, items, publish }: PaneProps & { documentId: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const activeId = useCm6ScrollSpy(containerRef, viewRef, items);
+
+  // The editor captures `extensions` once per document identity, so this has
+  // to be a stable reference over a stable ref.
+  const extensions = useMemo(() => [tocViewExtension(viewRef)], []);
+
+  const scrollToItem = useCallback((item: TocItem) => {
+    const view = viewRef.current;
+    if (view) scrollToOffset(view, item.offset, SCROLL_TOP_MARGIN);
+  }, []);
+
+  useEffect(() => {
+    publish({ activeId, scrollToItem });
+    return () => publish(null);
+  }, [publish, activeId, scrollToItem]);
+
+  return (
+    <div ref={containerRef} className="flex-1 overflow-y-auto scrollbar-auto-hide">
+      <div className="max-w-3xl mx-auto px-8 py-6">
+        <Suspense fallback={null}>
+          <AtomicCodeMirrorEditor
+            key={documentId}
+            documentId={documentId}
+            markdownSource={source}
+            readOnly
+            blurEditorOnMount
+            extensions={extensions}
+          />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/components/toc-harness/sample-content.ts
+++ b/src/components/toc-harness/sample-content.ts
@@ -1,0 +1,157 @@
+// Fixtures for the table-of-contents harness. Each one isolates a case the
+// TOC has to get right: a long note where CodeMirror virtualization hides
+// most headings from the DOM, a wiki-shaped article whose title lives in the
+// body, and a note with nothing to outline at all.
+
+const FILLER_WORDS = [
+  'atom', 'graph', 'tag', 'embedding', 'vector', 'semantic', 'reader', 'wiki',
+  'canvas', 'chat', 'agent', 'retrieval', 'chunk', 'similarity', 'index',
+  'query', 'markdown', 'editor', 'viewport', 'render', 'prose', 'block',
+  'paragraph', 'heading', 'outline', 'anchor', 'offset', 'scroll', 'sidebar',
+  'pipeline', 'transport', 'facade', 'store', 'callback', 'payload', 'cursor',
+];
+
+/** Deterministic filler so the fixtures are byte-stable across reloads. */
+function paragraph(seed: number, wordCount = 44): string {
+  const words: string[] = [];
+  for (let i = 0; i < wordCount; i++) {
+    words.push(FILLER_WORDS[(seed * 7 + i * 13) % FILLER_WORDS.length]);
+  }
+  const body = words.join(' ');
+  return `${body.charAt(0).toUpperCase()}${body.slice(1)}.`;
+}
+
+const LONG_DOC_TOPICS = [
+  'Ingestion',
+  'Chunking',
+  'Embedding',
+  'Auto-tagging',
+  'Semantic edges',
+  'Wiki synthesis',
+  'Agentic chat',
+  'Canvas layout',
+  'Scheduled tasks',
+  'Feed polling',
+  'MCP surface',
+  'Migration',
+];
+
+function buildLongDoc(): string {
+  const lines: string[] = [
+    '# Pipeline Field Notes',
+    '',
+    paragraph(0),
+    '',
+  ];
+
+  LONG_DOC_TOPICS.forEach((topic, i) => {
+    lines.push(`## ${topic}`, '', paragraph(i + 1), '');
+
+    // Repeated verbatim in every section — the duplicate-slug case, and the
+    // reason clicks have to travel by offset rather than by text match.
+    lines.push('### Implementation notes', '', paragraph(i + 11), '');
+
+    // Fenced code whose lines start with `#`. A regex outline would list
+    // these; a parsed one never sees them.
+    if (i % 2 === 0) {
+      lines.push(
+        '```bash',
+        '# Not a heading — a shell comment',
+        `atomic ${topic.toLowerCase().replace(/\s+/g, '-')} --dry-run`,
+        '## Not a heading either',
+        '```',
+        '',
+      );
+    } else {
+      lines.push(
+        '```python',
+        '# Not a heading — a Python comment',
+        `def ${topic.toLowerCase().replace(/[^a-z]+/g, '_')}(atoms):`,
+        '    return [a for a in atoms if a.embedding is not None]',
+        '```',
+        '',
+      );
+    }
+
+    lines.push('#### Edge cases', '', paragraph(i + 21, 30), '');
+    lines.push(
+      `- ${paragraph(i + 31, 9)}`,
+      `- ${paragraph(i + 41, 11)}`,
+      `- ${paragraph(i + 51, 8)}`,
+      '',
+    );
+
+    lines.push('### Open questions', '', paragraph(i + 61), '');
+  });
+
+  lines.push('## Implementation notes', '', paragraph(99), '');
+  lines.push('## Appendix', '', paragraph(101), '');
+  return lines.join('\n');
+}
+
+const LONG_DOC = buildLongDoc();
+
+const WIKI_DOC = [
+  '# Distributed Systems',
+  '',
+  paragraph(3),
+  '',
+  '## Consensus',
+  '',
+  paragraph(4),
+  '',
+  '### Raft',
+  '',
+  paragraph(5),
+  '',
+  '### Paxos',
+  '',
+  paragraph(6),
+  '',
+  '## Replication',
+  '',
+  paragraph(7),
+  '',
+  '### Leader-follower',
+  '',
+  paragraph(8),
+  '',
+  '### Quorum reads',
+  '',
+  paragraph(9),
+  '',
+  '## Failure modes',
+  '',
+  paragraph(10),
+  '',
+].join('\n');
+
+const HEADINGLESS_DOC = [
+  paragraph(12),
+  '',
+  paragraph(13),
+  '',
+  '- ' + paragraph(14, 10),
+  '- ' + paragraph(15, 12),
+  '',
+  '```json',
+  '{ "note": "# this is not a heading" }',
+  '```',
+  '',
+  paragraph(16),
+  '',
+].join('\n');
+
+export type TocFixtureId = 'long' | 'wiki' | 'headingless';
+
+export interface TocFixture {
+  id: TocFixtureId;
+  label: string;
+  source: string;
+}
+
+export const TOC_FIXTURES: TocFixture[] = [
+  { id: 'long', label: 'long note', source: LONG_DOC },
+  { id: 'wiki', label: 'wiki article', source: WIKI_DOC },
+  { id: 'headingless', label: 'no headings', source: HEADINGLESS_DOC },
+];

--- a/src/components/toc/TocPanel.tsx
+++ b/src/components/toc/TocPanel.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react';
+import type { TocItem } from './useTocItems';
+
+interface TocPanelProps {
+  items: TocItem[];
+  activeId: string | null;
+  onItemClick: (item: TocItem) => void;
+  /** Shown in place of the list when there are no headings. */
+  emptyLabel?: string;
+  /** Optional section label above the list. */
+  title?: string;
+}
+
+/** Base inset, matching the tag tree's rows. */
+const BASE_INDENT = 8;
+const INDENT_PER_LEVEL = 12;
+
+/**
+ * Table of contents for the left sidebar. Purely presentational — the owner
+ * supplies the items, the active id, and what a click means.
+ */
+export function TocPanel({ items, activeId, onItemClick, emptyLabel, title }: TocPanelProps) {
+  const activeRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [activeId]);
+
+  // Notes rarely start at `#`, and a wiki article's body is all `##`. Indent
+  // from the shallowest heading present so the outline hugs the left edge
+  // whatever level the document happens to use.
+  const minDepth = items.length > 0 ? Math.min(...items.map((item) => item.depth)) : 1;
+
+  return (
+    <div className="flex flex-col h-full">
+      {title && (
+        <div className="px-3 py-2 shrink-0">
+          <span className="text-xs font-semibold text-[var(--color-text-tertiary)] uppercase tracking-wider">
+            {title}
+          </span>
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="px-3 py-4">
+          <p className="text-xs text-[var(--color-text-secondary)] leading-relaxed">
+            {emptyLabel ?? 'No headings'}
+          </p>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto scrollbar-hidden px-1 pb-2">
+          {items.map((item) => {
+            const isActive = item.id === activeId;
+            return (
+              <button
+                key={item.id}
+                ref={isActive ? activeRef : undefined}
+                type="button"
+                onClick={() => onItemClick(item)}
+                title={item.text}
+                style={{ paddingLeft: `${BASE_INDENT + (item.depth - minDepth) * INDENT_PER_LEVEL}px` }}
+                className={`w-full flex items-center pr-2 py-1.5 rounded-md text-left text-sm transition-colors ${
+                  item.depth === minDepth ? 'font-medium' : ''
+                } ${
+                  isActive
+                    ? 'bg-[var(--color-accent)]/20 text-[var(--color-text-primary)]'
+                    : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-card)] hover:text-[var(--color-text-primary)]'
+                }`}
+              >
+                <span className="truncate">{item.text}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/toc/index.ts
+++ b/src/components/toc/index.ts
@@ -1,0 +1,4 @@
+export { TocPanel } from './TocPanel';
+export { useTocItems, type TocItem } from './useTocItems';
+export { useDomScrollSpy, offsetWithinContainer } from './useDomScrollSpy';
+export { useCm6ScrollSpy } from './useCm6ScrollSpy';

--- a/src/components/toc/useCm6ScrollSpy.ts
+++ b/src/components/toc/useCm6ScrollSpy.ts
@@ -1,0 +1,98 @@
+import { RefObject, useEffect, useState } from 'react';
+import type { EditorView } from '@codemirror/view';
+import type { TocEditorViewRef } from '../../editor/toc-scroll';
+import type { TocItem } from './useTocItems';
+
+/** Distance below the container's top edge at which a heading counts as reached. */
+const DEFAULT_TOP_MARGIN = 80;
+
+/** ~1s at 60fps — long enough for the lazy editor chunk to mount, short
+ *  enough that a view which never arrives doesn't spin a frame loop. */
+const VIEW_WAIT_FRAMES = 60;
+
+/**
+ * Vertical position of a document offset, measured against `container`'s
+ * scroll origin.
+ *
+ * Positions come from CM6's height map rather than the DOM because the lines
+ * in question are usually not rendered. Rows outside the measured range are
+ * estimated, which is more than accurate enough to decide which heading the
+ * reader is under.
+ */
+function blockTopInContainer(
+  view: EditorView,
+  container: HTMLElement,
+  offset: number,
+): number {
+  const pos = Math.max(0, Math.min(offset, view.state.doc.length));
+  return (
+    view.documentTop +
+    view.lineBlockAt(pos).top -
+    container.getBoundingClientRect().top +
+    container.scrollTop
+  );
+}
+
+function activeItemId(
+  view: EditorView,
+  container: HTMLElement,
+  items: TocItem[],
+  topMargin: number,
+): string | null {
+  const threshold = container.scrollTop + topMargin;
+  let active: string | null = null;
+  for (const item of items) {
+    if (blockTopInContainer(view, container, item.offset) > threshold) break;
+    active = item.id;
+  }
+  return active;
+}
+
+/**
+ * Track which heading the reader is currently under, for content rendered by
+ * CodeMirror. `containerRef` is the element that actually scrolls — in the
+ * readers that is the page-level scroller wrapping the editor, not
+ * `view.scrollDOM`.
+ */
+export function useCm6ScrollSpy(
+  containerRef: RefObject<HTMLElement | null>,
+  viewRef: TocEditorViewRef,
+  items: TocItem[],
+  topMargin = DEFAULT_TOP_MARGIN,
+): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || items.length === 0) {
+      setActiveId(null);
+      return;
+    }
+
+    let frame = 0;
+    let framesWaited = 0;
+    const measure = () => {
+      frame = 0;
+      const view = viewRef.current;
+      if (!view) {
+        // The editor mounts behind a lazy() boundary, so the view can appear
+        // several frames after this effect runs.
+        if (framesWaited++ < VIEW_WAIT_FRAMES) frame = requestAnimationFrame(measure);
+        return;
+      }
+      setActiveId(activeItemId(view, container, items, topMargin));
+    };
+    const onScroll = () => {
+      if (frame === 0) frame = requestAnimationFrame(measure);
+    };
+
+    measure();
+    container.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      container.removeEventListener('scroll', onScroll);
+      if (frame !== 0) cancelAnimationFrame(frame);
+    };
+  }, [containerRef, viewRef, items, topMargin]);
+
+  return activeId;
+}

--- a/src/components/toc/useDomScrollSpy.ts
+++ b/src/components/toc/useDomScrollSpy.ts
@@ -1,0 +1,74 @@
+import { RefObject, useEffect, useState } from 'react';
+import type { TocItem } from './useTocItems';
+
+/** Distance below the container's top edge at which a heading counts as reached. */
+const DEFAULT_TOP_MARGIN = 80;
+
+/**
+ * Vertical position of `el` measured against `container`'s scroll origin.
+ *
+ * `offsetTop` would only be right when the scroll container happens to be the
+ * element's `offsetParent`; rendered markdown nests headings several wrappers
+ * deep, so measure with rects instead.
+ */
+export function offsetWithinContainer(container: HTMLElement, el: HTMLElement): number {
+  return (
+    el.getBoundingClientRect().top -
+    container.getBoundingClientRect().top +
+    container.scrollTop
+  );
+}
+
+function activeItemId(
+  container: HTMLElement,
+  items: TocItem[],
+  topMargin: number,
+): string | null {
+  const threshold = container.scrollTop + topMargin;
+  let active: string | null = null;
+  for (const item of items) {
+    const el = container.ownerDocument.getElementById(item.id);
+    if (!el) continue;
+    if (offsetWithinContainer(container, el) > threshold) break;
+    active = item.id;
+  }
+  return active;
+}
+
+/**
+ * Track which heading the reader is currently under, for DOM-rendered
+ * markdown. Headings are located by their injected element ids.
+ */
+export function useDomScrollSpy(
+  containerRef: RefObject<HTMLElement | null>,
+  items: TocItem[],
+  topMargin = DEFAULT_TOP_MARGIN,
+): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || items.length === 0) {
+      setActiveId(null);
+      return;
+    }
+
+    let frame = 0;
+    const measure = () => {
+      frame = 0;
+      setActiveId(activeItemId(container, items, topMargin));
+    };
+    const onScroll = () => {
+      if (frame === 0) frame = requestAnimationFrame(measure);
+    };
+
+    measure();
+    container.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      container.removeEventListener('scroll', onScroll);
+      if (frame !== 0) cancelAnimationFrame(frame);
+    };
+  }, [containerRef, items, topMargin]);
+
+  return activeId;
+}

--- a/src/components/toc/useTocItems.ts
+++ b/src/components/toc/useTocItems.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from 'react';
+import { parseHeadings } from '../../lib/markdown-headings';
+
+/**
+ * A heading as the table of contents consumes it. `id` is the parsed slug —
+ * unique within a document, and the same string readers inject as the DOM id
+ * on rendered headings so a scroll spy can find them again.
+ */
+export interface TocItem {
+  id: string;
+  depth: number;
+  text: string;
+  offset: number;
+  line: number;
+}
+
+function tocItemsFrom(source: string): TocItem[] {
+  return parseHeadings(source).map((heading) => ({
+    id: heading.slug,
+    depth: heading.depth,
+    text: heading.text,
+    offset: heading.offset,
+    line: heading.line,
+  }));
+}
+
+/**
+ * Table-of-contents items for a markdown source.
+ *
+ * The first parse is synchronous so a reader never flashes an empty outline
+ * on open; later changes are debounced because the live editor calls this on
+ * every keystroke and a re-parse of a long note is not free.
+ */
+export function useTocItems(source: string, debounceMs = 300): TocItem[] {
+  const [items, setItems] = useState<TocItem[]>(() => tocItemsFrom(source));
+  const parsedSourceRef = useRef(source);
+
+  useEffect(() => {
+    if (parsedSourceRef.current === source) return;
+    const timer = window.setTimeout(() => {
+      parsedSourceRef.current = source;
+      setItems(tocItemsFrom(source));
+    }, debounceMs);
+    return () => window.clearTimeout(timer);
+  }, [source, debounceMs]);
+
+  return items;
+}

--- a/src/components/toc/useTocPublisher.ts
+++ b/src/components/toc/useTocPublisher.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { useTocStore, type TocSource } from '../../stores/toc';
+import type { TocItem } from './useTocItems';
+
+interface UseTocPublisherArgs {
+  /** `null` while the reader has no document on screen (loading, empty state,
+   *  a replaced body) — the panel then shows nothing rather than claiming the
+   *  document has no headings. */
+  source: TocSource | null;
+  items: TocItem[];
+  activeId: string | null;
+  scrollToItem: (item: TocItem) => void;
+}
+
+/**
+ * Hand the mounted reader's outline to the left sidebar for as long as the
+ * reader is showing the document it describes.
+ *
+ * Publishing and withdrawing are separate effects on purpose: the outline is
+ * cleared on unmount, not on every change, so a re-parse while the user types
+ * updates the panel in place rather than blanking it for a frame.
+ */
+export function useTocPublisher({ source, items, activeId, scrollToItem }: UseTocPublisherArgs): void {
+  const publish = useTocStore((s) => s.publish);
+  const setActiveId = useTocStore((s) => s.setActiveId);
+  const clear = useTocStore((s) => s.clear);
+
+  useEffect(() => {
+    if (source === null) {
+      clear();
+      return;
+    }
+    publish({ source, items, scrollToItem });
+  }, [publish, clear, source, items, scrollToItem]);
+
+  useEffect(() => {
+    setActiveId(activeId);
+  }, [setActiveId, activeId]);
+
+  useEffect(() => clear, [clear]);
+}

--- a/src/components/wiki/WikiArticleCard.tsx
+++ b/src/components/wiki/WikiArticleCard.tsx
@@ -1,50 +1,55 @@
-import { BookOpen } from 'lucide-react';
 import { WikiArticleSummary } from '../../stores/wiki';
-import { formatRelativeDate } from '../../lib/date';
+import { formatRelativeDate, formatShortRelativeDate } from '../../lib/date';
 
 interface WikiArticleCardProps {
   article: WikiArticleSummary;
   isActive?: boolean;
-  onClick: () => void;
+  onClick: (opts?: { newTab?: boolean }) => void;
 }
 
+/// One article row in the sidebar's article list. Sized for the 250px panel,
+/// so the meta line stays on one line: short relative date, source count, and
+/// inbound links only when there are any.
 export function WikiArticleCard({ article, isActive, onClick }: WikiArticleCardProps) {
-  const updatedAt = formatRelativeDate(article.updated_at);
-
   return (
     <div
-      onClick={onClick}
-      className={`group px-4 py-3 cursor-pointer transition-colors ${
+      onClick={(e) => onClick({ newTab: e.metaKey || e.ctrlKey })}
+      onAuxClick={(e) => {
+        if (e.button === 1) {
+          e.preventDefault();
+          onClick({ newTab: true });
+        }
+      }}
+      className={`px-3 py-2 cursor-pointer transition-colors ${
         isActive
-          ? 'bg-[var(--color-accent)]/10'
+          ? 'bg-[var(--color-accent)]/20'
           : 'hover:bg-[var(--color-bg-card)]'
       }`}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex-1 min-w-0">
-          {/* Tag name as title */}
-          <h3 className="text-[var(--color-text-primary)] font-medium truncate mb-1">
-            {article.tag_name}
-          </h3>
+      <div className="flex items-baseline gap-2">
+        <span
+          className="flex-1 min-w-0 truncate text-sm font-medium text-[var(--color-text-primary)]"
+          title={article.tag_name}
+        >
+          {article.tag_name}
+        </span>
+        <span
+          className="shrink-0 text-[11px] text-[var(--color-text-tertiary)]"
+          title={formatRelativeDate(article.updated_at)}
+        >
+          {formatShortRelativeDate(article.updated_at)}
+        </span>
+      </div>
 
-          {/* Meta info */}
-          <div className="flex items-center gap-3 text-xs text-[var(--color-text-tertiary)]">
-            <span>{updatedAt}</span>
-            <span className="text-[var(--color-text-secondary)]">
-              {article.atom_count} {article.atom_count === 1 ? 'source' : 'sources'}
-            </span>
-            {article.inbound_links > 0 && (
-              <span className="text-[var(--color-accent-light)]">
-                {article.inbound_links} {article.inbound_links === 1 ? 'link' : 'links'}
-              </span>
-            )}
-          </div>
-        </div>
-
-        {/* Wiki icon indicator */}
-        <div className="p-1.5 text-[var(--color-text-tertiary)]">
-          <BookOpen className="w-4 h-4" strokeWidth={2} />
-        </div>
+      <div className="flex items-center gap-2 mt-0.5 text-[11px] text-[var(--color-text-tertiary)]">
+        <span>
+          {article.atom_count} source{article.atom_count !== 1 ? 's' : ''}
+        </span>
+        {article.inbound_links > 0 && (
+          <span className="text-[var(--color-accent-light)]">
+            {article.inbound_links} link{article.inbound_links !== 1 ? 's' : ''}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/components/wiki/WikiArticleContent.tsx
+++ b/src/components/wiki/WikiArticleContent.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useCallback, Fragment, ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Plus } from 'lucide-react';
-import { WikiArticle, WikiCitation, WikiLink, RelatedTag } from '../../stores/wiki';
+import type { Element } from 'hast';
+import { WikiCitation, WikiLink, RelatedTag } from '../../stores/wiki';
 import { CitationLink } from './CitationLink';
 import { CitationPopover } from './CitationPopover';
 import { WikiLinkInline } from './WikiLinkInline';
@@ -11,8 +12,16 @@ import { MarkdownImage } from '../ui/MarkdownImage';
 import { useContentSearch } from '../../hooks';
 import { formatRelativeTime } from '../../lib/date';
 
+/// Anchor for the article's own title. The body markdown is rendered with its
+/// leading `# Title` removed (see `stripArticleTitle` in WikiReader), so an
+/// outline entry for the title has to point at this rendered heading instead
+/// of at a source offset.
+export const WIKI_TITLE_ANCHOR_ID = '__top';
+
 interface WikiArticleContentProps {
-  article: WikiArticle;
+  /** The article body, exactly as it should render — the caller has already
+   *  stripped the leading title so heading offsets it parsed line up here. */
+  content: string;
   citations: WikiCitation[];
   wikiLinks: WikiLink[];
   relatedTags: RelatedTag[];
@@ -24,11 +33,20 @@ interface WikiArticleContentProps {
    *  article scrolls to / highlights that match on open. Used by the search
    *  palette to take a wiki hit straight to its specific occurrence. */
   highlightText?: string | null;
+  /** Ids to stamp on rendered headings, keyed by their offset in `content`.
+   *  Supplied by whoever owns the table of contents so its entries and the
+   *  DOM agree on names. */
+  headingIdByOffset?: Map<number, string>;
   onViewAtom: (atomId: string, highlightText?: string) => void;
   onNavigateToArticle: (tagId: string, tagName: string) => void;
 }
 
-export function WikiArticleContent({ article, citations, wikiLinks, relatedTags, tagName, updatedAt, sourceCount, titleActions, highlightText, onViewAtom, onNavigateToArticle }: WikiArticleContentProps) {
+interface HeadingProps {
+  node?: Element;
+  children?: ReactNode;
+}
+
+export function WikiArticleContent({ content, citations, wikiLinks, relatedTags, tagName, updatedAt, sourceCount, titleActions, highlightText, headingIdByOffset, onViewAtom, onNavigateToArticle }: WikiArticleContentProps) {
   const [activeCitation, setActiveCitation] = useState<WikiCitation | null>(null);
   const [anchorRect, setAnchorRect] = useState<{ top: number; left: number; bottom: number; width: number } | null>(null);
 
@@ -45,7 +63,7 @@ export function WikiArticleContent({ article, citations, wikiLinks, relatedTags,
     goToNext,
     goToPrevious,
     processChildren: highlightChildren,
-  } = useContentSearch(article.content);
+  } = useContentSearch(content);
 
   // Keyboard handler for Ctrl+F / Cmd+F
   useEffect(() => {
@@ -165,6 +183,14 @@ export function WikiArticleContent({ article, citations, wikiLinks, relatedTags,
     return children;
   }, [isSearchOpen, searchQuery, highlightChildren, wikiLinks, citations]);
 
+  // Heading ids come from the outline's own parse, matched by source offset.
+  // Re-slugging the rendered children here would drift from it on duplicate
+  // titles and on inline markup.
+  const headingId = (node?: Element): string | undefined => {
+    const offset = node?.position?.start?.offset;
+    return offset === undefined ? undefined : headingIdByOffset?.get(offset);
+  };
+
   // Custom components for react-markdown
   const components = {
     p: ({ children }: { children?: ReactNode }) => (
@@ -188,23 +214,23 @@ export function WikiArticleContent({ article, citations, wikiLinks, relatedTags,
     del: ({ children }: { children?: ReactNode }) => (
       <del>{processChildren(children)}</del>
     ),
-    h1: ({ children }: { children?: ReactNode }) => (
-      <h1>{processChildren(children)}</h1>
+    h1: ({ node, children }: HeadingProps) => (
+      <h1 id={headingId(node)}>{processChildren(children)}</h1>
     ),
-    h2: ({ children }: { children?: ReactNode }) => (
-      <h2>{processChildren(children)}</h2>
+    h2: ({ node, children }: HeadingProps) => (
+      <h2 id={headingId(node)}>{processChildren(children)}</h2>
     ),
-    h3: ({ children }: { children?: ReactNode }) => (
-      <h3>{processChildren(children)}</h3>
+    h3: ({ node, children }: HeadingProps) => (
+      <h3 id={headingId(node)}>{processChildren(children)}</h3>
     ),
-    h4: ({ children }: { children?: ReactNode }) => (
-      <h4>{processChildren(children)}</h4>
+    h4: ({ node, children }: HeadingProps) => (
+      <h4 id={headingId(node)}>{processChildren(children)}</h4>
     ),
-    h5: ({ children }: { children?: ReactNode }) => (
-      <h5>{processChildren(children)}</h5>
+    h5: ({ node, children }: HeadingProps) => (
+      <h5 id={headingId(node)}>{processChildren(children)}</h5>
     ),
-    h6: ({ children }: { children?: ReactNode }) => (
-      <h6>{processChildren(children)}</h6>
+    h6: ({ node, children }: HeadingProps) => (
+      <h6 id={headingId(node)}>{processChildren(children)}</h6>
     ),
     blockquote: ({ children }: { children?: ReactNode }) => (
       <blockquote>{processChildren(children)}</blockquote>
@@ -250,7 +276,7 @@ export function WikiArticleContent({ article, citations, wikiLinks, relatedTags,
           {/* Article title */}
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0">
-              <h1 className="text-2xl font-bold text-[var(--color-text-primary)] mb-1">{tagName}</h1>
+              <h1 id={WIKI_TITLE_ANCHOR_ID} className="text-2xl font-bold text-[var(--color-text-primary)] mb-1">{tagName}</h1>
               <p className="text-xs text-[var(--color-text-secondary)]">
                 Updated {formatRelativeTime(updatedAt)} • {sourceCount} source{sourceCount !== 1 ? 's' : ''}
               </p>
@@ -265,7 +291,7 @@ export function WikiArticleContent({ article, citations, wikiLinks, relatedTags,
 
           <div className="prose prose-invert prose-headings:text-[var(--color-text-primary)] prose-h2:border-b prose-h2:border-[var(--color-border)] prose-h2:pb-1.5 prose-h2:mb-3 prose-p:text-[var(--color-text-primary)] prose-p:leading-relaxed prose-a:text-[var(--color-text-primary)] prose-a:underline prose-a:decoration-[var(--color-border-hover)] hover:prose-a:decoration-current prose-strong:text-[var(--color-text-primary)] prose-code:text-[var(--color-accent-light)] prose-code:bg-[var(--color-bg-card)] prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-[var(--color-bg-card)] prose-pre:border prose-pre:border-[var(--color-border)] prose-blockquote:border-l-[var(--color-accent)] prose-blockquote:text-[var(--color-text-secondary)] prose-li:text-[var(--color-text-primary)] prose-hr:border-[var(--color-border)]">
             <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
-              {article.content.replace(/^#\s+[^\n]+\n+/, '')}
+              {content}
             </ReactMarkdown>
           </div>
         </div>

--- a/src/components/wiki/WikiArticlesList.tsx
+++ b/src/components/wiki/WikiArticlesList.tsx
@@ -1,103 +1,124 @@
-import { useState } from 'react';
-import { BookOpen, Plus } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Plus } from 'lucide-react';
 import { useWikiStore } from '../../stores/wiki';
+import { useUIStore } from '../../stores/ui';
 import { WikiArticleCard } from './WikiArticleCard';
 import { NewWikiModal } from './NewWikiModal';
 
+/// The wiki view's sidebar: every article, plus the tags with enough material
+/// to become one. Both kinds of row open a wiki reader tab — a suggestion just
+/// lands on the reader's generate affordance instead of an article.
 export function WikiArticlesList() {
   const articles = useWikiStore(s => s.articles);
   const suggestedArticles = useWikiStore(s => s.suggestedArticles);
   const isLoadingList = useWikiStore(s => s.isLoadingList);
   const error = useWikiStore(s => s.error);
-  const openArticle = useWikiStore(s => s.openArticle);
-  const openAndGenerate = useWikiStore(s => s.openAndGenerate);
-  const currentTagId = useWikiStore(s => s.currentTagId);
+  const fetchAllArticles = useWikiStore(s => s.fetchAllArticles);
+
+  // Tabs-model successor to the wiki store's `currentTagId`. Opening an
+  // article swaps this panel for that article's outline, so the highlight only
+  // shows if the list is ever mounted alongside a reader.
+  const activeTagId = useUIStore(s => s.wikiReaderState.tagId);
+  const openWikiReader = useUIStore(s => s.openWikiReader);
+
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const initializedRef = useRef(false);
 
-  if (isLoadingList && articles.length === 0) {
-    return (
-      <div className="flex items-center justify-center h-full text-[var(--color-text-secondary)]">
-        Loading wiki articles...
-      </div>
-    );
-  }
+  // The panel loads its own data rather than relying on the wiki view being
+  // mounted beside it; the store collapses the concurrent pair of fetches.
+  useEffect(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+    fetchAllArticles();
+  }, [fetchAllArticles]);
 
-  if (error) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full gap-4 p-4">
-        <p className="text-red-400">{error}</p>
-      </div>
-    );
-  }
+  const openArticle = (tagId: string, tagName: string, opts?: { newTab?: boolean }) => {
+    openWikiReader(tagId, tagName, undefined, opts);
+  };
+
+  const isEmpty = articles.length === 0 && suggestedArticles.length === 0;
 
   return (
     <div className="h-full flex flex-col">
-      {/* Scrollable content: articles + suggestions */}
-      <div className="flex-1 overflow-y-auto">
-        {articles.length === 0 && suggestedArticles.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full gap-4 p-8 text-center">
-            <div className="w-16 h-16 rounded-full bg-[var(--color-bg-card)] flex items-center justify-center">
-              <BookOpen className="w-8 h-8 text-[var(--color-text-secondary)]" strokeWidth={2} />
-            </div>
-            <div>
-              <p className="text-[var(--color-text-primary)] font-medium mb-1">No wiki articles yet</p>
-              <p className="text-[var(--color-text-secondary)] text-sm">
-                Generate a wiki article from your atoms to synthesize knowledge
-              </p>
-            </div>
+      <div className="flex-1 overflow-y-auto scrollbar-hidden">
+        {error && (
+          <p className="px-3 py-2 text-xs text-red-400 leading-relaxed">{error}</p>
+        )}
+
+        {isLoadingList && isEmpty ? (
+          <div className="flex flex-col gap-1 px-3 py-2">
+            {Array.from({ length: 5 }, (_, i) => (
+              <div key={i} className="py-1.5">
+                <div
+                  className="h-3.5 rounded bg-[var(--color-bg-card)] animate-pulse"
+                  style={{ width: `${70 + i * 15}px` }}
+                />
+              </div>
+            ))}
           </div>
+        ) : isEmpty ? (
+          // A failure shown above already accounts for the empty panel — don't
+          // also claim there is simply nothing here.
+          error ? null : (
+            <p className="px-3 py-4 text-xs text-[var(--color-text-secondary)] leading-relaxed">
+              No wiki articles yet. Generate one from a tag to synthesize what your atoms say about it.
+            </p>
+          )
         ) : (
           <>
-            {/* Existing Articles */}
-            {articles.length > 0 && (
-              <div className="divide-y divide-[var(--color-border)]">
-                {articles.map((article) => (
-                  <WikiArticleCard
-                    key={article.id}
-                    article={article}
-                    isActive={article.tag_id === currentTagId}
-                    onClick={() => openArticle(article.tag_id, article.tag_name)}
-                  />
-                ))}
-              </div>
-            )}
+            {articles.map((article) => (
+              <WikiArticleCard
+                key={article.id}
+                article={article}
+                isActive={article.tag_id === activeTagId}
+                onClick={(opts) => openArticle(article.tag_id, article.tag_name, opts)}
+              />
+            ))}
 
-            {/* Suggested Articles */}
             {suggestedArticles.length > 0 && (
-              <div className="border-t border-[var(--color-border)]">
-                <div className="px-4 pt-3 pb-1">
-                  <h3 className="text-[10px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
-                    Suggested Articles
-                  </h3>
+              <div className={articles.length > 0 ? 'mt-2 border-t border-[var(--color-border)]' : ''}>
+                <div className="px-3 pt-3 pb-1">
+                  <span className="text-[10px] font-semibold text-[var(--color-text-tertiary)] uppercase tracking-wider">
+                    Suggested
+                  </span>
                 </div>
-                <div className="divide-y divide-[var(--color-border)]">
-                  {suggestedArticles.map((suggestion) => (
-                    <button
-                      key={suggestion.tag_id}
-                      onClick={() => openAndGenerate(suggestion.tag_id, suggestion.tag_name)}
-                      className="w-full group flex items-center justify-between px-4 py-2.5 hover:bg-[var(--color-bg-elevated)] transition-colors text-left"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <span className="text-sm text-[var(--color-text-primary)]">
-                          {suggestion.tag_name}
+                {suggestedArticles.map((suggestion) => (
+                  <button
+                    key={suggestion.tag_id}
+                    type="button"
+                    onClick={(e) => openArticle(suggestion.tag_id, suggestion.tag_name, { newTab: e.metaKey || e.ctrlKey })}
+                    onAuxClick={(e) => {
+                      if (e.button === 1) {
+                        e.preventDefault();
+                        openArticle(suggestion.tag_id, suggestion.tag_name, { newTab: true });
+                      }
+                    }}
+                    className="w-full group flex items-center gap-2 px-3 py-2 text-left hover:bg-[var(--color-bg-card)] transition-colors"
+                  >
+                    <span className="flex-1 min-w-0">
+                      <span
+                        className="block truncate text-sm text-[var(--color-text-primary)]"
+                        title={suggestion.tag_name}
+                      >
+                        {suggestion.tag_name}
+                      </span>
+                      <span className="flex items-center gap-2 mt-0.5 text-[11px] text-[var(--color-text-tertiary)]">
+                        <span>
+                          {suggestion.atom_count} atom{suggestion.atom_count !== 1 ? 's' : ''}
                         </span>
-                        <div className="flex items-center gap-2 mt-0.5">
-                          <span className="text-[11px] text-[var(--color-text-tertiary)]">
-                            {suggestion.atom_count} atom{suggestion.atom_count !== 1 ? 's' : ''}
+                        {suggestion.mention_count > 0 && (
+                          <span>
+                            {suggestion.mention_count} mention{suggestion.mention_count !== 1 ? 's' : ''}
                           </span>
-                          {suggestion.mention_count > 0 && (
-                            <span className="text-[11px] text-[var(--color-text-tertiary)]">
-                              {suggestion.mention_count} mention{suggestion.mention_count !== 1 ? 's' : ''}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                      <div className="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity ml-2">
-                        <Plus className="w-4 h-4 text-[var(--color-accent)]" strokeWidth={2} />
-                      </div>
-                    </button>
-                  ))}
-                </div>
+                        )}
+                      </span>
+                    </span>
+                    <Plus
+                      className="w-4 h-4 shrink-0 text-[var(--color-accent)] opacity-0 group-hover:opacity-100 transition-opacity"
+                      strokeWidth={2}
+                    />
+                  </button>
+                ))}
               </div>
             )}
           </>
@@ -115,7 +136,6 @@ export function WikiArticlesList() {
         </button>
       </div>
 
-      {/* New Wiki Modal */}
       <NewWikiModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
     </div>
   );

--- a/src/components/wiki/WikiFullView.tsx
+++ b/src/components/wiki/WikiFullView.tsx
@@ -9,7 +9,6 @@ export function WikiFullView() {
   const suggestedArticles = useWikiStore(s => s.suggestedArticles);
   const isLoadingList = useWikiStore(s => s.isLoadingList);
   const fetchAllArticles = useWikiStore(s => s.fetchAllArticles);
-  const reset = useWikiStore(s => s.reset);
 
   const openWikiReader = useUIStore(s => s.openWikiReader);
 
@@ -22,10 +21,9 @@ export function WikiFullView() {
     fetchAllArticles();
   }, [fetchAllArticles]);
 
-  // Clean up wiki store state on unmount
-  useEffect(() => {
-    return () => { reset(); };
-  }, [reset]);
+  // No unmount reset: opening a reader tab unmounts this view, and wiping the
+  // store there costs the sidebar list its data on every tab open/close.
+  // Switching databases still resets it — see stores/databases.ts.
 
   const handleArticleClick = (tagId: string, tagName: string, opts?: { newTab?: boolean }) => {
     openWikiReader(tagId, tagName, undefined, opts);

--- a/src/components/wiki/WikiReader.tsx
+++ b/src/components/wiki/WikiReader.tsx
@@ -1,11 +1,14 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Clock, RefreshCw } from 'lucide-react';
 import { useWikiStore } from '../../stores/wiki';
 import { useUIStore } from '../../stores/ui';
-import { WikiArticleContent } from './WikiArticleContent';
+import { WikiArticleContent, WIKI_TITLE_ANCHOR_ID } from './WikiArticleContent';
 import { WikiEmptyState } from './WikiEmptyState';
 import { WikiGenerating } from './WikiGenerating';
 import { WikiProposalDiff } from './WikiProposalDiff';
+import { offsetWithinContainer, useDomScrollSpy } from '../toc/useDomScrollSpy';
+import { useTocItems, type TocItem } from '../toc/useTocItems';
+import { useTocPublisher } from '../toc/useTocPublisher';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
 import { formatRelativeTime } from '../../lib/date';
@@ -14,6 +17,17 @@ interface WikiReaderProps {
   tagId: string;
   tagName: string;
   highlightText?: string | null;
+}
+
+/** Space left above a heading scrolled to from the outline. */
+const SCROLL_TOP_MARGIN = 72;
+
+/// The generator opens every article with a `# Tag Name` line, which the
+/// reader already shows as page chrome. Strip it once here so the rendered
+/// body and the parsed outline see the exact same string — heading offsets
+/// only mean anything against the text react-markdown was handed.
+function stripArticleTitle(content: string): string {
+  return content.replace(/^#\s+[^\n]+\n+/, '');
 }
 
 export function WikiReader({ tagId, tagName, highlightText }: WikiReaderProps) {
@@ -58,7 +72,52 @@ export function WikiReader({ tagId, tagName, highlightText }: WikiReaderProps) {
   const [showRegenerateModal, setShowRegenerateModal] = useState(false);
   const [showVersions, setShowVersions] = useState(false);
   const versionsRef = useRef<HTMLDivElement>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
   const prevTagIdRef = useRef<string | null>(null);
+
+  // Table of contents. Computed above the loading/error/empty returns below so
+  // the hook order stays fixed; `scrollerRef` simply has nothing to measure
+  // until the article renders.
+  const displayContent = useMemo(
+    () => stripArticleTitle(selectedVersion?.content ?? currentArticle?.article.content ?? ''),
+    [selectedVersion, currentArticle],
+  );
+  // Nothing is typed here — the content only changes when another article
+  // loads — so re-parse on the next tick rather than holding the previous
+  // article's outline for the editor-oriented debounce.
+  const headings = useTocItems(displayContent, 0);
+  const headingIdByOffset = useMemo(
+    () => new Map(headings.map((heading) => [heading.offset, heading.id])),
+    [headings],
+  );
+  // The stripped title is still on screen as the page's own heading, so the
+  // outline opens with it — clicking it returns to the top of the article.
+  const tocItems = useMemo<TocItem[]>(
+    () => [
+      { id: WIKI_TITLE_ANCHOR_ID, depth: 1, text: tagName, offset: 0, line: 1 },
+      ...headings,
+    ],
+    [headings, tagName],
+  );
+  const activeTocId = useDomScrollSpy(scrollerRef, tocItems);
+  const scrollToTocItem = useCallback((item: TocItem) => {
+    const container = scrollerRef.current;
+    const el = container?.ownerDocument.getElementById(item.id);
+    if (!container || !el) return;
+    container.scrollTo({ top: offsetWithinContainer(container, el) - SCROLL_TOP_MARGIN });
+  }, []);
+  // Every other state below — loading, error, generating, no article yet, the
+  // proposal diff — renders something other than the article body, and an
+  // outline of a document that isn't on screen would only mislead.
+  const isArticleVisible =
+    !isLoading && !error && !isGenerating && !!currentArticle &&
+    !(reviewingProposal && proposal && !selectedVersion);
+  useTocPublisher({
+    source: isArticleVisible ? 'wiki' : null,
+    items: tocItems,
+    activeId: activeTocId,
+    scrollToItem: scrollToTocItem,
+  });
 
   // Fetch article data when tagId changes
   useEffect(() => {
@@ -150,9 +209,6 @@ export function WikiReader({ tagId, tagName, highlightText }: WikiReaderProps) {
     );
   }
 
-  const displayArticle = selectedVersion
-    ? { content: selectedVersion.content, id: selectedVersion.id, tag_id: selectedVersion.tag_id, created_at: selectedVersion.created_at, updated_at: selectedVersion.created_at, atom_count: selectedVersion.atom_count }
-    : currentArticle.article;
   const displayCitations = selectedVersion
     ? selectedVersion.citations
     : currentArticle.citations;
@@ -208,9 +264,10 @@ export function WikiReader({ tagId, tagName, highlightText }: WikiReaderProps) {
           isDismissing={isDismissing}
         />
       ) : (
-        <div className="flex-1 overflow-y-auto scrollbar-auto-hide">
+        <div ref={scrollerRef} className="flex-1 overflow-y-auto scrollbar-auto-hide">
           <WikiArticleContent
-            article={displayArticle}
+            content={displayContent}
+            headingIdByOffset={headingIdByOffset}
             citations={displayCitations}
             wikiLinks={selectedVersion ? [] : wikiLinks}
             relatedTags={selectedVersion ? [] : relatedTags}

--- a/src/editor/toc-scroll/index.ts
+++ b/src/editor/toc-scroll/index.ts
@@ -1,0 +1,41 @@
+import { EditorView, ViewPlugin } from '@codemirror/view';
+import type { Extension } from '@codemirror/state';
+import type { MutableRefObject } from 'react';
+
+export type TocEditorViewRef = MutableRefObject<EditorView | null>;
+
+/**
+ * Publish the mounted `EditorView` into `viewRef` so code outside the editor
+ * can drive it by document offset.
+ *
+ * The editor captures its `extensions` prop once at mount (keyed on
+ * `documentId`), so the ref identity must be stable — pass a `useRef` value,
+ * never a freshly built object.
+ */
+export function tocViewExtension(viewRef: TocEditorViewRef): Extension {
+  return ViewPlugin.define((view) => {
+    viewRef.current = view;
+    return {
+      destroy() {
+        // Guard against clobbering a newer view: on a document swap the next
+        // editor's plugin is constructed before this one is destroyed.
+        if (viewRef.current === view) viewRef.current = null;
+      },
+    };
+  });
+}
+
+/**
+ * Scroll a document offset to the top of the viewport.
+ *
+ * CM6 only renders the lines near the viewport, so a DOM query for a heading
+ * far down a long note finds nothing. Going through `scrollIntoView` lets the
+ * editor resolve the position against its own height map and land exactly,
+ * measured or not.
+ */
+export function scrollToOffset(view: EditorView, offset: number, yMargin = 72): void {
+  const pos = Math.max(0, Math.min(offset, view.state.doc.length));
+  view.dispatch({
+    effects: EditorView.scrollIntoView(pos, { y: 'start', yMargin }),
+  });
+}

--- a/src/lib/markdown-headings.test.ts
+++ b/src/lib/markdown-headings.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { parseHeadings } from './markdown-headings';
+import { MATCH_END, MATCH_START } from '../components/search-palette/markdownToPlainText';
+
+describe('parseHeadings', () => {
+  it('returns an empty list for empty and headingless sources', () => {
+    expect(parseHeadings('')).toEqual([]);
+    expect(parseHeadings('Just a paragraph.\n\n- and a list\n- of items\n')).toEqual([]);
+  });
+
+  it('reports depth, text, offset and line for ATX headings', () => {
+    const source = ['# Title', '', 'Intro prose.', '', '### Deep', ''].join('\n');
+    expect(parseHeadings(source)).toEqual([
+      { depth: 1, text: 'Title', offset: 0, line: 1, slug: 'title' },
+      { depth: 3, text: 'Deep', offset: source.indexOf('### Deep'), line: 5, slug: 'deep' },
+    ]);
+  });
+
+  it('points offsets at the first character of the heading', () => {
+    const source = 'Lead in.\n\n## Second\n\nMore.\n\n#### Fourth\n';
+    for (const heading of parseHeadings(source)) {
+      expect(source.slice(heading.offset)).toMatch(/^#+ /);
+    }
+  });
+
+  it('ignores `#` lines inside fenced code blocks', () => {
+    const source = [
+      '# Real heading',
+      '',
+      '```bash',
+      '# not a heading, just a shell comment',
+      'echo hi',
+      '```',
+      '',
+      '```python',
+      '## also not a heading',
+      '```',
+      '',
+      '## Second real heading',
+      '',
+    ].join('\n');
+    expect(parseHeadings(source).map((h) => h.text)).toEqual([
+      'Real heading',
+      'Second real heading',
+    ]);
+  });
+
+  it('ignores `#` lines inside indented code blocks', () => {
+    const source = 'Prose.\n\n    # indented code, not a heading\n\n## Actual\n';
+    expect(parseHeadings(source).map((h) => h.text)).toEqual(['Actual']);
+  });
+
+  it('parses setext headings', () => {
+    const source = 'Big Title\n=========\n\nSmaller\n-------\n';
+    expect(parseHeadings(source)).toEqual([
+      { depth: 1, text: 'Big Title', offset: 0, line: 1, slug: 'big-title' },
+      { depth: 2, text: 'Smaller', offset: source.indexOf('Smaller'), line: 4, slug: 'smaller' },
+    ]);
+  });
+
+  it('flattens inline formatting into plain text', () => {
+    const source = '## The **bold** and `code()` [linked](https://example.com) bit\n';
+    const [heading] = parseHeadings(source);
+    expect(heading.text).toBe('The bold and code() linked bit');
+    expect(heading.slug).toBe('the-bold-and-code-linked-bit');
+  });
+
+  it('gives duplicate headings unique slugs while keeping their own offsets', () => {
+    const source = '## Setup\n\na\n\n## Setup\n\nb\n\n## Setup\n';
+    const headings = parseHeadings(source);
+    expect(headings.map((h) => h.slug)).toEqual(['setup', 'setup-2', 'setup-3']);
+    expect(headings.map((h) => h.offset)).toEqual([
+      0,
+      source.indexOf('## Setup', 1),
+      source.lastIndexOf('## Setup'),
+    ]);
+  });
+
+  it('does not collide when a literal heading already owns a suffixed slug', () => {
+    const source = '## Setup\n\n## Setup 2\n\n## Setup\n';
+    expect(parseHeadings(source).map((h) => h.slug)).toEqual(['setup', 'setup-2', 'setup-3']);
+  });
+
+  it('falls back to a stable slug when a heading has no slug-able characters', () => {
+    const source = '## ???\n\n## !!!\n';
+    expect(parseHeadings(source).map((h) => h.slug)).toEqual(['section', 'section-2']);
+  });
+
+  it('strips FTS match markers from heading text and slugs', () => {
+    const source = `## Vector ${MATCH_START}search${MATCH_END} notes\n`;
+    const [heading] = parseHeadings(source);
+    expect(heading.text).toBe('Vector search notes');
+    expect(heading.slug).toBe('vector-search-notes');
+  });
+
+  it('finds headings nested inside block containers', () => {
+    const source = '> ## Quoted heading\n\n- item\n\n  ### Nested heading\n';
+    expect(parseHeadings(source).map((h) => h.text)).toEqual([
+      'Quoted heading',
+      'Nested heading',
+    ]);
+  });
+
+  it('returns headings in document order with ascending offsets', () => {
+    const source = '# A\n\n## B\n\n### C\n\n## D\n';
+    const offsets = parseHeadings(source).map((h) => h.offset);
+    expect(offsets).toEqual([...offsets].sort((a, b) => a - b));
+    expect(new Set(offsets).size).toBe(offsets.length);
+  });
+
+  it('keeps unicode headings distinguishable', () => {
+    const headings = parseHeadings('## Café\n\n## 日本語\n');
+    expect(headings.map((h) => h.text)).toEqual(['Café', '日本語']);
+    expect(new Set(headings.map((h) => h.slug)).size).toBe(2);
+  });
+
+  it('handles trailing closing hashes and extra whitespace', () => {
+    const [heading] = parseHeadings('##   Spaced   out   ##\n');
+    expect(heading.text).toBe('Spaced out');
+    expect(heading.slug).toBe('spaced-out');
+  });
+});

--- a/src/lib/markdown-headings.ts
+++ b/src/lib/markdown-headings.ts
@@ -1,0 +1,130 @@
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import { gfmFromMarkdown } from 'mdast-util-gfm';
+import { gfm } from 'micromark-extension-gfm';
+import { stripMatchMarkers } from '../components/search-palette/markdownToPlainText';
+
+/** A heading found in a markdown source, in document order. */
+export interface HeadingEntry {
+  /** 1-6, as written (`#` → 1). Setext headings report 1 or 2. */
+  depth: number;
+  /** Rendered text of the heading, inline markup removed. */
+  text: string;
+  /** Character offset of the heading's first character in the source. */
+  offset: number;
+  /** 1-based line number of the heading's first character. */
+  line: number;
+  /** URL/DOM-safe id, unique within the returned list. */
+  slug: string;
+}
+
+/** Minimal structural view of the mdast nodes this module touches. */
+interface MdastNode {
+  type: string;
+  value?: string;
+  depth?: number;
+  position?: { start?: { offset?: number; line?: number } };
+  children?: MdastNode[];
+}
+
+function collectHeadingNodes(node: MdastNode, out: MdastNode[]): void {
+  if (node.type === 'heading') {
+    // Headings cannot nest, so there is nothing below one to descend into.
+    out.push(node);
+    return;
+  }
+  if (node.children) {
+    for (const child of node.children) collectHeadingNodes(child, out);
+  }
+}
+
+function collectInlineText(node: MdastNode, out: string[]): void {
+  if (node.type === 'text' || node.type === 'inlineCode') {
+    if (typeof node.value === 'string') out.push(node.value);
+    return;
+  }
+  if (node.type === 'break') {
+    out.push(' ');
+    return;
+  }
+  if (node.children) {
+    for (const child of node.children) collectInlineText(child, out);
+  }
+}
+
+function headingText(node: MdastNode): string {
+  const parts: string[] = [];
+  collectInlineText(node, parts);
+  return stripMatchMarkers(parts.join('')).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Lowercase, collapse every run of non-alphanumerics to a single dash, trim
+ * dashes. Unicode letters and digits count as alphanumeric so notes written
+ * in non-Latin scripts still get meaningful slugs instead of all colliding
+ * on the fallback.
+ */
+function slugify(text: string): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug.length > 0 ? slug : 'section';
+}
+
+function uniqueSlug(
+  base: string,
+  counts: Map<string, number>,
+  taken: Set<string>,
+): string {
+  let seen = counts.get(base) ?? 0;
+  let candidate = seen === 0 ? base : `${base}-${seen + 1}`;
+  // A literal heading may already own the suffixed form ("Setup" + "Setup 2"),
+  // so keep bumping until the candidate is genuinely free.
+  while (taken.has(candidate)) {
+    seen += 1;
+    candidate = `${base}-${seen + 1}`;
+  }
+  counts.set(base, seen + 1);
+  taken.add(candidate);
+  return candidate;
+}
+
+/**
+ * Extract the heading outline of a markdown document.
+ *
+ * Parsing (rather than scanning for `^#`) is what makes `#` lines inside
+ * fenced code blocks, front matter, and indented code disappear for free —
+ * they never become `heading` nodes.
+ */
+export function parseHeadings(source: string): HeadingEntry[] {
+  let tree: MdastNode;
+  try {
+    tree = fromMarkdown(source, {
+      extensions: [gfm()],
+      mdastExtensions: [gfmFromMarkdown()],
+    }) as MdastNode;
+  } catch {
+    return [];
+  }
+
+  const nodes: MdastNode[] = [];
+  collectHeadingNodes(tree, nodes);
+
+  const entries: HeadingEntry[] = [];
+  const slugCounts = new Map<string, number>();
+  const takenSlugs = new Set<string>();
+  for (const node of nodes) {
+    const offset = node.position?.start?.offset;
+    const line = node.position?.start?.line;
+    if (offset === undefined || line === undefined) continue;
+    const text = headingText(node);
+    entries.push({
+      depth: node.depth ?? 1,
+      text,
+      offset,
+      line,
+      slug: uniqueSlug(slugify(text), slugCounts, takenSlugs),
+    });
+  }
+  return entries;
+}

--- a/src/stores/reports.ts
+++ b/src/stores/reports.ts
@@ -97,6 +97,10 @@ export interface ReportFindingWithAtom {
   atom: {
     id: string;
     content: string;
+    /// Server-derived plain-text first line (markdown stripped). Findings
+    /// open with their headline, so this is the row label everywhere a
+    /// finding is listed compactly.
+    title: string;
     source_url: string | null;
     created_at: string;
     updated_at: string;
@@ -331,6 +335,11 @@ export const useReportsStore = create<ReportsStore>((set, get) => {
     hasSubscription: false,
 
     fetchAll: async () => {
+      // The reports view and the sidebar's findings panel both load on
+      // mount and they mount together — collapse that pair into one round
+      // trip (the per-report last-finding fan-out it chains into is the
+      // expensive half).
+      if (get().isLoadingList) return;
       set({ isLoadingList: true, loadError: null });
       try {
         const reports = await getTransport().invoke<Report[]>('list_reports');

--- a/src/stores/toc.ts
+++ b/src/stores/toc.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+import type { TocItem } from '../components/toc/useTocItems';
+
+export type { TocItem };
+
+/// Which reader an outline came from — the same set `SidebarContext`'s `toc`
+/// kind carries, so the sidebar can tell whether what's published belongs to
+/// the reader it is currently rendering for.
+export type TocSource = 'atom' | 'wiki' | 'finding';
+
+interface TocPublication {
+  source: TocSource;
+  items: TocItem[];
+  scrollToItem: (item: TocItem) => void;
+}
+
+interface TocStore {
+  /// The reader that owns the outline. `null` when no reader is mounted, in
+  /// which case `items` is empty and `scrollToItem` does nothing.
+  source: TocSource | null;
+  items: TocItem[];
+  activeId: string | null;
+  scrollToItem: (item: TocItem) => void;
+
+  publish: (publication: TocPublication) => void;
+  setActiveId: (id: string | null) => void;
+  clear: () => void;
+}
+
+const NO_ITEMS: TocItem[] = [];
+const noScroll = () => {};
+
+/// The channel between the mounted reader and the left sidebar's table of
+/// contents. Deliberately not persisted: an outline only means anything while
+/// the document it describes is on screen.
+///
+/// Readers publish through `useTocPublisher`, which also clears on unmount.
+/// React runs an unmounting subtree's cleanups before the replacing subtree's
+/// effects, so switching documents always clears before the next publish.
+export const useTocStore = create<TocStore>()((set) => ({
+  source: null,
+  items: NO_ITEMS,
+  activeId: null,
+  scrollToItem: noScroll,
+
+  publish: ({ source, items, scrollToItem }) => set({ source, items, scrollToItem }),
+  setActiveId: (activeId) => set({ activeId }),
+  clear: () => set({ source: null, items: NO_ITEMS, activeId: null, scrollToItem: noScroll }),
+}));

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -103,7 +103,6 @@ interface UIStore {
   loadingOperations: LoadingOperation[];
   // Panel state
   leftPanelOpen: boolean;
-  wikiSidebarOpen: boolean;
   // Chat sidebar state
   chatSidebarOpen: boolean;
   chatSidebarWidth: number;
@@ -126,8 +125,6 @@ interface UIStore {
   setServerConnected: (connected: boolean) => void;
   setLeftPanelOpen: (open: boolean) => void;
   toggleLeftPanel: () => void;
-  setWikiSidebarOpen: (open: boolean) => void;
-  toggleWikiSidebar: () => void;
   setSelectedTag: (tagId: string | null) => void;
   expandTagPath: (tagIds: string[]) => void;
   toggleTagExpanded: (tagId: string) => void;
@@ -344,7 +341,6 @@ export const useUIStore = create<UIStore>()(
       },
       highlightedAtomId: null,
       leftPanelOpen: true,
-      wikiSidebarOpen: true,
       chatSidebarOpen: false,
       chatSidebarWidth: 480,
       chatSidebarConversationId: null,
@@ -359,8 +355,6 @@ export const useUIStore = create<UIStore>()(
 
       setLeftPanelOpen: (open: boolean) => set({ leftPanelOpen: open }),
       toggleLeftPanel: () => set((state) => ({ leftPanelOpen: !state.leftPanelOpen })),
-      setWikiSidebarOpen: (open: boolean) => set({ wikiSidebarOpen: open }),
-      toggleWikiSidebar: () => set((state) => ({ wikiSidebarOpen: !state.wikiSidebarOpen })),
       setServerConnected: (connected: boolean) => set({ serverConnected: connected }),
 
       setSelectedTag: (tagId: string | null) => {

--- a/src/stores/wiki.ts
+++ b/src/stores/wiki.ts
@@ -205,6 +205,10 @@ export const useWikiStore = create<WikiStore>((set, get) => ({
   error: null,
 
   fetchAllArticles: async () => {
+    // The wiki view and the sidebar's article list both load on mount and they
+    // mount together — collapse that pair into one round trip (the suggestion
+    // query it chains into is the expensive half).
+    if (get().isLoadingList) return;
     set({ isLoadingList: true, error: null });
     try {
       const articles = await getTransport().invoke<WikiArticleSummary[]>('get_all_wiki_articles');


### PR DESCRIPTION
The left sidebar's content now derives from navigation state instead of always showing the tag tree (which only did real work on atoms/canvas):

- atoms/canvas/local graph -> tag tree (unchanged)
- atom/wiki/finding readers -> table of contents parsed from the markdown source, with scrollspy and click-to-scroll; live-updates while editing
- wiki view -> article list (revives the unused WikiArticlesList)
- dashboard -> recently updated atoms
- reports/report detail -> latest findings, scoped on detail

Open/closed state stays fully manual — content swaps, never auto-hide. Derivation (sidebar-context.ts) mirrors MainView's reader precedence and is unit-tested. DatabaseSwitcher + SettingsButton move to the top bar; Layout keeps the single SettingsModal, reachable via the open-settings event with an optional tab.

TOC infrastructure: mdast-based parseHeadings (offsets + unique slugs, zero new deps), a CM6 view-capture extension for offset-exact scrolling under virtualization, DOM/CM6 scrollspy hooks, and a /toc-harness page proving both scroll stacks against fixtures. Wiki headings get offset-keyed ids so duplicate titles resolve correctly; findings parse raw source since the rendered DOM demotes heading levels.

Also: in-flight guards on wiki fetchAllArticles and reports fetchAll (both double-fetched on view entry), WikiFullView no longer wipes the wiki store on unmount, and dead wikiSidebarOpen state is removed.