### PR TITLE
chat: streaming, cancel, auto-titles, unified agent runtime, KB tools, citations, boolean scope

### DIFF
--- a/crates/atomic-cloud/src/chat_streams.rs
+++ b/crates/atomic-cloud/src/chat_streams.rs
@@ -253,6 +253,13 @@ mod tests {
             "/api/conversations//messages",
             "/api/conversations/abc/scope",
             "/api/atoms",
+            // Cancelling is the *opposite* of starting a stream: it is a
+            // tiny write that ends one. Gating it behind the same cap would
+            // make the cap self-sealing — an account at its limit could
+            // neither start a stream nor stop one, and the only way out
+            // would be to wait. It must stay open by construction, not by
+            // the handler happening to be fast.
+            "/api/conversations/abc/messages/cancel",
         ] {
             assert!(!chat_stream_route(&post, open), "{open} must stay open");
         }
@@ -458,5 +465,74 @@ mod tests {
         )
         .await;
         assert_eq!(reopened.status(), StatusCode::OK);
+    }
+
+    /// The escape hatch, end to end through the guard: an account holding
+    /// every slot can still cancel. A saturated account whose cancels were
+    /// also refused would have no way to free a slot except waiting out the
+    /// streams it was trying to stop — the cap would trap the user inside
+    /// exactly the situation it exists to prevent.
+    #[actix_web::test]
+    async fn cancel_is_reachable_while_the_account_is_at_its_stream_cap() {
+        let limiter = ChatStreamLimiter::new(1);
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(web::Data::new(limiter.clone()))
+                .route(
+                    "/api/conversations/{id}/messages",
+                    web::post().to(|| async { HttpResponse::Ok().body("reply") }),
+                )
+                .route(
+                    "/api/conversations/{id}/messages/cancel",
+                    web::post().to(|| async {
+                        HttpResponse::Accepted().json(serde_json::json!({ "cancelled": true }))
+                    }),
+                )
+                .wrap(from_fn(chat_stream_guard))
+                .wrap(from_fn(install_tenant)),
+        )
+        .await;
+
+        // Saturate the account by holding an unconsumed response.
+        let held = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::post()
+                .uri("/api/conversations/c1/messages")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(held.status(), StatusCode::OK);
+        assert_eq!(limiter.in_flight("acct-1"), 1);
+
+        // A second stream is refused...
+        let denied = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::post()
+                .uri("/api/conversations/c2/messages")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(denied.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // ...but the cancel for the stream that is holding the slot reaches
+        // its handler, and consumes no slot of its own.
+        let cancelled = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::post()
+                .uri("/api/conversations/c1/messages/cancel")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(cancelled.status(), StatusCode::ACCEPTED);
+        assert_eq!(
+            limiter.in_flight("acct-1"),
+            1,
+            "cancelling must not take a stream slot"
+        );
+        let body: serde_json::Value = actix_test::read_body_json(cancelled).await;
+        assert_eq!(body["cancelled"], true);
+
+        drop(held);
+        assert_eq!(limiter.in_flight("acct-1"), 0);
     }
 }

--- a/crates/atomic-cloud/src/demo_plane.rs
+++ b/crates/atomic-cloud/src/demo_plane.rs
@@ -370,10 +370,22 @@ mod tests {
             (&Method::DELETE, "/api/atoms/abc-123"),
             (&Method::PUT, "/api/settings/onboarding_completed"),
             (&Method::POST, "/api/tags"),
-            // Chat / conversations — closed by decision.
+            // Chat / conversations — closed by decision. The whole surface,
+            // not just the collection: an anonymous visitor must not be able
+            // to spend a turn, stop someone else's, or reshape a scope, and
+            // the whitelist is what closes routes the chat era added after
+            // this table was written.
             (&Method::GET, "/api/conversations"),
             (&Method::POST, "/api/conversations"),
             (&Method::GET, "/api/conversations/c-1"),
+            (&Method::PUT, "/api/conversations/c-1"),
+            (&Method::DELETE, "/api/conversations/c-1"),
+            (&Method::GET, "/api/conversations/c-1/messages"),
+            (&Method::POST, "/api/conversations/c-1/messages"),
+            (&Method::POST, "/api/conversations/c-1/messages/cancel"),
+            (&Method::PUT, "/api/conversations/c-1/scope"),
+            (&Method::POST, "/api/conversations/c-1/scope/tags"),
+            (&Method::DELETE, "/api/conversations/c-1/scope/tags/t-1"),
             // Exports — the billing guard's egress exemption must NOT
             // carry over to anonymous visitors.
             (&Method::POST, "/api/databases/default/exports/markdown"),

--- a/crates/atomic-cloud/src/server.rs
+++ b/crates/atomic-cloud/src/server.rs
@@ -215,6 +215,7 @@ impl FallbackAppState {
             dangerously_skip_setup_token: false,
             setup_claim_lock: tokio::sync::Mutex::new(()),
             setup_claim_limiter: SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
         });
         Ok(Self {
             data,

--- a/crates/atomic-cloud/tests/demo_plane_e2e.rs
+++ b/crates/atomic-cloud/tests/demo_plane_e2e.rs
@@ -326,6 +326,12 @@ async fn demo_whitelist_serves_reads_and_refuses_everything_else() {
             (Method::PUT, "/api/settings/onboarding_completed"),
             (Method::GET, "/api/conversations"),
             (Method::POST, "/api/conversations"),
+            // The whole chat surface, not just its collection: spending a
+            // turn is the demo's most expensive possible action, and
+            // cancelling reaches into a process-wide registry.
+            (Method::POST, "/api/conversations/c-1/messages"),
+            (Method::POST, "/api/conversations/c-1/messages/cancel"),
+            (Method::POST, "/api/conversations/c-1/scope/tags"),
             (Method::POST, "/api/databases/default/exports/markdown"),
             (Method::GET, "/api/feeds"),
             (Method::GET, "/api/auth/tokens"),

--- a/crates/atomic-core/src/agent.rs
+++ b/crates/atomic-core/src/agent.rs
@@ -21,10 +21,19 @@ use crate::storage::StorageBackend;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use uuid::Uuid;
 
-type ChatEventCallback = Arc<dyn Fn(ChatEvent) + Send + Sync + 'static>;
+pub(crate) type ChatEventCallback = Arc<dyn Fn(ChatEvent) + Send + Sync + 'static>;
+
+/// Cooperative cancellation handle for one in-flight chat turn. Raise the
+/// flag and the agent loop stops at its next checkpoint — between iterations,
+/// between sequential tool executions, and mid-stream — then persists and
+/// returns whatever text it had already produced. Hosts own the registry
+/// (see `atomic-server`'s cancellation registry); the loop only reads it.
+pub type ChatCancel = Arc<AtomicBool>;
 
 // ==================== Chat Events ====================
 
@@ -33,7 +42,9 @@ type ChatEventCallback = Arc<dyn Fn(ChatEvent) + Send + Sync + 'static>;
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type")]
 pub enum ChatEvent {
-    /// Streaming content delta (accumulated)
+    /// One incremental chunk of assistant text, emitted as the provider
+    /// streams it. Consumers append; the authoritative full text arrives with
+    /// [`ChatEvent::Complete`].
     StreamDelta {
         conversation_id: String,
         content: String,
@@ -45,11 +56,14 @@ pub enum ChatEvent {
         tool_name: String,
         tool_input: serde_json::Value,
     },
-    /// Tool execution completed
+    /// Tool execution completed. `failed` mirrors the persisted
+    /// `chat_tool_calls.status`, so a tool that errored reads as failed while
+    /// the turn is still streaming — not only after the final message lands.
     ToolComplete {
         conversation_id: String,
         tool_call_id: String,
         results_count: i32,
+        failed: bool,
     },
     /// Full message completed
     Complete {
@@ -76,6 +90,12 @@ pub enum ChatEvent {
     AtomPipelineEvent {
         conversation_id: String,
         event: EmbeddingEvent,
+    },
+    /// Conversation metadata changed outside a request/response cycle —
+    /// today, the auto-generated title landing after the turn completed.
+    ConversationUpdated {
+        conversation_id: String,
+        title: String,
     },
     /// Error during chat
     Error {
@@ -417,7 +437,6 @@ async fn execute_search_atoms(
             .map_err(|e| e.to_string())?,
     };
     let config = ProviderConfig::from_settings(&settings);
-    let tag_id = scope_tag_ids.first().map(|s| s.as_str());
 
     // Generate query embedding
     let provider = crate::providers::get_embedding_provider(&config).map_err(|e| e.to_string())?;
@@ -436,12 +455,19 @@ async fn execute_search_atoms(
     // its default KindFilter::All).
     let kinds = crate::models::KindFilter::All;
     let keyword = storage
-        .keyword_search_sync(query, limit * 2, tag_id, cutoff_ref, &kinds)
+        .keyword_search_sync(query, limit * 2, scope_tag_ids, cutoff_ref, &kinds)
         .await
         .map_err(|e| e.to_string())?;
     let semantic = if !embeddings.is_empty() && !embeddings[0].is_empty() {
         storage
-            .vector_search_sync(&embeddings[0], limit * 2, 0.3, tag_id, cutoff_ref, &kinds)
+            .vector_search_sync(
+                &embeddings[0],
+                limit * 2,
+                0.3,
+                scope_tag_ids,
+                cutoff_ref,
+                &kinds,
+            )
             .await
             .map_err(|e| e.to_string())?
     } else {
@@ -913,6 +939,110 @@ struct AgentContext {
     tool_calls_record: Vec<ChatToolCall>,
 }
 
+/// Outcome of a single tool execution. `failed` is tracked separately from
+/// `output` because the error text still has to reach the model (and the UI's
+/// tool card), while `chat_tool_calls.status` must say what actually happened.
+struct ToolOutcome {
+    output: String,
+    results_count: i32,
+    failed: bool,
+}
+
+impl ToolOutcome {
+    fn ok(output: impl Into<String>, results_count: i32) -> Self {
+        Self {
+            output: output.into(),
+            results_count,
+            failed: false,
+        }
+    }
+
+    fn failed(error: impl std::fmt::Display) -> Self {
+        Self {
+            output: format!("Error: {}", error),
+            results_count: 0,
+            failed: true,
+        }
+    }
+}
+
+/// Tool-calling rounds a single turn may take before the loop gives up and
+/// salvages whatever answer it has.
+const MAX_ITERATIONS: usize = 10;
+
+/// How often the loop samples the cancellation flag while a provider stream
+/// is in flight. Cancellation is cooperative and user-facing, so the bound
+/// only has to be imperceptible, not instant.
+const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Appended to the assistant message when the user stopped the turn.
+const STOPPED_MARKER: &str = "*(stopped)*";
+
+/// Appended to the assistant message when the tool-call budget ran out.
+const ITERATION_CAP_NOTE: &str = "*(reached tool-call limit — answer may be incomplete)*";
+
+fn is_cancelled(cancel: &Option<ChatCancel>) -> bool {
+    cancel
+        .as_ref()
+        .is_some_and(|flag| flag.load(Ordering::Relaxed))
+}
+
+/// Resolves once `cancel` is raised; never resolves when there is no flag.
+/// Polling keeps cancellation out of the provider traits — the loop races
+/// this against the in-flight request and drops the request future on cancel.
+async fn cancellation_raised(cancel: &Option<ChatCancel>) {
+    match cancel {
+        Some(flag) => {
+            while !flag.load(Ordering::Relaxed) {
+                tokio::time::sleep(CANCEL_POLL_INTERVAL).await;
+            }
+        }
+        None => std::future::pending().await,
+    }
+}
+
+/// Attach a trailing note to a partial answer, keeping the note readable when
+/// there is no text to attach it to.
+fn with_note(text: &str, note: &str) -> String {
+    let text = text.trim_end();
+    if text.is_empty() {
+        note.to_string()
+    } else {
+        format!("{}\n\n{}", text, note)
+    }
+}
+
+/// Turn the accumulated agent context into the assistant message to persist.
+fn build_result(ctx: AgentContext, content: String) -> ChatMessageWithContext {
+    let citations: Vec<ChatCitation> = ctx
+        .citations
+        .iter()
+        .enumerate()
+        .map(|(i, (atom_id, chunk_index, excerpt))| ChatCitation {
+            id: Uuid::new_v4().to_string(),
+            message_id: String::new(), // Set when saving
+            citation_index: (i + 1) as i32,
+            atom_id: atom_id.clone(),
+            chunk_index: *chunk_index,
+            excerpt: excerpt.clone(),
+            relevance_score: None,
+        })
+        .collect();
+
+    ChatMessageWithContext {
+        message: ChatMessage {
+            id: Uuid::new_v4().to_string(),
+            conversation_id: ctx.conversation_id.clone(),
+            role: "assistant".to_string(),
+            content,
+            created_at: Utc::now().to_rfc3339(),
+            message_index: 0, // Set when saving
+        },
+        tool_calls: ctx.tool_calls_record,
+        citations,
+    }
+}
+
 #[allow(clippy::too_many_arguments)] // Internal loop entry; each argument is a distinct context channel.
 async fn run_agent_loop(
     on_event: ChatEventCallback,
@@ -925,6 +1055,7 @@ async fn run_agent_loop(
     page_context: Option<&PageContext>,
     canvas_context: Option<&CanvasContext>,
     canvas_cache: Option<&crate::CanvasCache>,
+    cancel: Option<ChatCancel>,
 ) -> Result<ChatMessageWithContext, String> {
     let provider = create_streaming_llm_provider(&provider_config)
         .map_err(|e| format!("Failed to create streaming provider: {}", e))?;
@@ -945,27 +1076,30 @@ async fn run_agent_loop(
             });
         })
     };
-    let max_iterations = 10;
+    let config = LlmConfig::new(&model).with_params(
+        GenerationParams::new()
+            .with_temperature(0.7)
+            .with_max_tokens(4000),
+    );
 
-    for _iteration in 0..max_iterations {
-        let config = LlmConfig::new(&model).with_params(
-            GenerationParams::new()
-                .with_temperature(0.7)
-                .with_max_tokens(4000),
+    // Every token the model streams this turn, across all iterations — the
+    // same text the UI has been rendering. Only used when the turn ends
+    // without a clean final answer (stopped, or out of tool-call budget).
+    let streamed = Arc::new(Mutex::new(String::new()));
+    let mut stopped = false;
+
+    for _iteration in 0..MAX_ITERATIONS {
+        if is_cancelled(&cancel) {
+            stopped = true;
+            break;
+        }
+
+        let on_delta = make_delta_callback(
+            Arc::clone(&on_event),
+            Arc::clone(&streamed),
+            ctx.conversation_id.clone(),
+            cancel.clone(),
         );
-
-        // Accumulate streaming content. The Box callback captures an Arc<Mutex<String>>
-        // because we can't capture `on_event` (lifetime/Send issues with Box<dyn Fn>).
-        // We emit the accumulated content as a StreamDelta after the call completes.
-        let accumulated_content = Arc::new(Mutex::new(String::new()));
-        let accumulated_clone = Arc::clone(&accumulated_content);
-
-        let on_delta = Box::new(move |delta: StreamDelta| {
-            if let StreamDelta::Content(text) = delta {
-                let mut content = accumulated_clone.lock().unwrap();
-                content.push_str(&text);
-            }
-        });
 
         // Truncate messages if they've grown beyond context window (from tool results)
         let call_messages = truncate_messages_to_context(
@@ -973,20 +1107,29 @@ async fn run_agent_loop(
             provider_config.context_length_for_model(&model),
         );
 
-        let response = provider
-            .complete_streaming_with_tools(&call_messages, &tools, &config, on_delta)
-            .await
-            .map_err(|e| format!("API request failed: {}", e))?;
-
-        // Emit the accumulated content as a stream delta
-        if let Ok(content) = accumulated_content.lock() {
-            if !content.is_empty() {
-                on_event(ChatEvent::StreamDelta {
-                    conversation_id: ctx.conversation_id.clone(),
-                    content: content.clone(),
-                });
+        // Racing the request against the cancel flag drops the request future
+        // on cancel, which tears down the in-flight HTTP stream instead of
+        // paying for tokens nobody will read.
+        let response = tokio::select! {
+            biased;
+            result = provider.complete_streaming_with_tools(&call_messages, &tools, &config, on_delta) => {
+                match result {
+                    Ok(response) => response,
+                    Err(e) => {
+                        let error = format!("API request failed: {}", e);
+                        on_event(ChatEvent::Error {
+                            conversation_id: ctx.conversation_id.clone(),
+                            error: error.clone(),
+                        });
+                        return Err(error);
+                    }
+                }
             }
-        }
+            _ = cancellation_raised(&cancel) => {
+                stopped = true;
+                break;
+            }
+        };
 
         // Check if there are tool calls
         if let Some(tool_calls) = &response.tool_calls {
@@ -1002,6 +1145,10 @@ async fn run_agent_loop(
 
             // Execute each tool call
             for tool_call in tool_calls {
+                if is_cancelled(&cancel) {
+                    stopped = true;
+                    break;
+                }
                 let tool_name = tool_call.get_name().unwrap_or_default();
                 let tool_args_str = tool_call.get_arguments().unwrap_or_default();
                 let tool_args: serde_json::Value =
@@ -1016,7 +1163,7 @@ async fn run_agent_loop(
                 });
 
                 // Execute tool
-                let (tool_result, results_count) = match tool_name {
+                let outcome = match tool_name {
                     "search_atoms" => {
                         let query = tool_args["query"].as_str().unwrap_or("");
                         let limit = tool_args["limit"].as_i64().unwrap_or(5) as i32;
@@ -1058,9 +1205,9 @@ async fn run_agent_loop(
                                     })
                                     .collect::<Vec<_>>()
                                     .join("\n\n");
-                                (result_text, count)
+                                ToolOutcome::ok(result_text, count)
                             }
-                            Err(e) => (format!("Error: {}", e), 0),
+                            Err(e) => ToolOutcome::failed(e),
                         }
                     }
                     "get_atom" => {
@@ -1083,7 +1230,7 @@ async fn run_agent_loop(
                                     None,
                                     content.chars().take(200).collect(),
                                 ));
-                                (
+                                ToolOutcome::ok(
                                     format!(
                                         "[{}] (atom_id: {})\n{}",
                                         citation_index, atom_id, content
@@ -1091,8 +1238,8 @@ async fn run_agent_loop(
                                     1,
                                 )
                             }
-                            Ok(None) => ("Atom not found".to_string(), 0),
-                            Err(e) => (format!("Error: {}", e), 0),
+                            Ok(None) => ToolOutcome::ok("Atom not found", 0),
+                            Err(e) => ToolOutcome::failed(e),
                         }
                     }
                     "get_current_page_context" => {
@@ -1128,14 +1275,14 @@ async fn run_agent_loop(
                                     }
                                 }
 
-                                (
+                                ToolOutcome::ok(
                                     serde_json::to_string_pretty(&context)
                                         .unwrap_or_else(|_| context.to_string()),
                                     1,
                                 )
                             }
-                            Ok(None) => ("No current page context was provided.".to_string(), 0),
-                            Err(e) => (format!("Error: {}", e), 0),
+                            Ok(None) => ToolOutcome::ok("No current page context was provided.", 0),
+                            Err(e) => ToolOutcome::failed(e),
                         }
                     }
                     "create_atom" => {
@@ -1159,7 +1306,7 @@ async fn run_agent_loop(
                                     None,
                                     atom.atom.snippet.chars().take(200).collect(),
                                 ));
-                                (
+                                ToolOutcome::ok(
                                     serde_json::to_string_pretty(&json!({
                                         "atom_id": atom.atom.id,
                                         "title": atom.atom.title,
@@ -1170,7 +1317,7 @@ async fn run_agent_loop(
                                     1,
                                 )
                             }
-                            Err(e) => (format!("Error: {}", e), 0),
+                            Err(e) => ToolOutcome::failed(e),
                         }
                     }
                     "edit_atom" => {
@@ -1194,7 +1341,7 @@ async fn run_agent_loop(
                                     None,
                                     atom.atom.snippet.chars().take(200).collect(),
                                 ));
-                                (
+                                ToolOutcome::ok(
                                     serde_json::to_string_pretty(&json!({
                                         "atom_id": atom.atom.id,
                                         "title": atom.atom.title,
@@ -1205,8 +1352,8 @@ async fn run_agent_loop(
                                     1,
                                 )
                             }
-                            Ok(None) => ("Atom not found".to_string(), 0),
-                            Err(e) => (format!("Error: {}", e), 0),
+                            Ok(None) => ToolOutcome::ok("Atom not found", 0),
+                            Err(e) => ToolOutcome::failed(e),
                         }
                     }
                     "zoom_to_cluster" => {
@@ -1216,7 +1363,7 @@ async fn run_agent_loop(
                             action: "zoom_to_cluster".to_string(),
                             params: json!({ "cluster_label": cluster_label }),
                         });
-                        (format!("Zoomed canvas to cluster '{}'", cluster_label), 1)
+                        ToolOutcome::ok(format!("Zoomed canvas to cluster '{}'", cluster_label), 1)
                     }
                     "focus_atom" => {
                         let atom_id = tool_args["atom_id"].as_str().unwrap_or("");
@@ -1225,9 +1372,11 @@ async fn run_agent_loop(
                             action: "focus_atom".to_string(),
                             params: json!({ "atom_id": atom_id }),
                         });
-                        (format!("Focused canvas on atom '{}'", atom_id), 1)
+                        ToolOutcome::ok(format!("Focused canvas on atom '{}'", atom_id), 1)
                     }
-                    _ => (format!("Unknown tool: {}", tool_name), 0),
+                    // The model asked for a tool this build doesn't have —
+                    // a failed call, not an empty result.
+                    _ => ToolOutcome::failed(format!("Unknown tool: {}", tool_name)),
                 };
 
                 // Record tool call
@@ -1236,8 +1385,12 @@ async fn run_agent_loop(
                     message_id: String::new(), // Set when saving
                     tool_name: tool_name.to_string(),
                     tool_input: tool_args,
-                    tool_output: Some(serde_json::Value::String(tool_result.clone())),
-                    status: "complete".to_string(),
+                    tool_output: Some(serde_json::Value::String(outcome.output.clone())),
+                    status: if outcome.failed {
+                        "failed".to_string()
+                    } else {
+                        "complete".to_string()
+                    },
                     created_at: Utc::now().to_rfc3339(),
                     completed_at: Some(Utc::now().to_rfc3339()),
                 });
@@ -1246,49 +1399,85 @@ async fn run_agent_loop(
                 on_event(ChatEvent::ToolComplete {
                     conversation_id: ctx.conversation_id.clone(),
                     tool_call_id: tool_call.id.clone(),
-                    results_count,
+                    results_count: outcome.results_count,
+                    failed: outcome.failed,
                 });
 
                 // Add tool result to messages
                 ctx.messages
-                    .push(Message::tool_result(&tool_call.id, tool_result));
+                    .push(Message::tool_result(&tool_call.id, outcome.output));
+            }
+
+            if stopped {
+                break;
             }
         } else {
             // No tool calls - we have the final answer
-            let content = response.content;
-
-            // Build citations from collected data
-            let citations: Vec<ChatCitation> = ctx
-                .citations
-                .iter()
-                .enumerate()
-                .map(|(i, (atom_id, chunk_index, excerpt))| ChatCitation {
-                    id: Uuid::new_v4().to_string(),
-                    message_id: String::new(), // Set when saving
-                    citation_index: (i + 1) as i32,
-                    atom_id: atom_id.clone(),
-                    chunk_index: *chunk_index,
-                    excerpt: excerpt.clone(),
-                    relevance_score: None,
-                })
-                .collect();
-
-            return Ok(ChatMessageWithContext {
-                message: ChatMessage {
-                    id: Uuid::new_v4().to_string(),
-                    conversation_id: ctx.conversation_id.clone(),
-                    role: "assistant".to_string(),
-                    content,
-                    created_at: Utc::now().to_rfc3339(),
-                    message_index: 0, // Set when saving
-                },
-                tool_calls: ctx.tool_calls_record,
-                citations,
-            });
+            return Ok(build_result(ctx, response.content));
         }
     }
 
-    Err("Max iterations reached without completing".to_string())
+    let partial = streamed.lock().map(|text| text.clone()).unwrap_or_default();
+
+    if stopped {
+        return Ok(build_result(ctx, with_note(&partial, STOPPED_MARKER)));
+    }
+
+    // Out of tool-call budget. Salvage rather than discard: whatever the model
+    // already said stands as the answer, and when it said nothing at all we
+    // spend one more call — without tools, so it has to answer in prose from
+    // the context it gathered.
+    let salvaged = if partial.trim().is_empty() {
+        let call_messages = truncate_messages_to_context(
+            ctx.messages.clone(),
+            provider_config.context_length_for_model(&model),
+        );
+        let on_delta = make_delta_callback(
+            Arc::clone(&on_event),
+            Arc::clone(&streamed),
+            ctx.conversation_id.clone(),
+            cancel.clone(),
+        );
+        match provider
+            .complete_streaming_with_tools(&call_messages, &[], &config, on_delta)
+            .await
+        {
+            Ok(response) => response.content,
+            Err(e) => {
+                tracing::warn!(error = %e, "chat: iteration-cap salvage completion failed");
+                String::new()
+            }
+        }
+    } else {
+        partial
+    };
+
+    Ok(build_result(ctx, with_note(&salvaged, ITERATION_CAP_NOTE)))
+}
+
+/// Build the provider stream callback: forward every chunk to the UI as it
+/// arrives and keep a copy for the salvage paths.
+fn make_delta_callback(
+    on_event: ChatEventCallback,
+    streamed: Arc<Mutex<String>>,
+    conversation_id: String,
+    cancel: Option<ChatCancel>,
+) -> crate::providers::traits::StreamCallback {
+    Box::new(move |delta: StreamDelta| {
+        let StreamDelta::Content(text) = delta else {
+            return;
+        };
+        if text.is_empty() || is_cancelled(&cancel) {
+            return;
+        }
+        if let Ok(mut accumulated) = streamed.lock() {
+            accumulated.push_str(&text);
+        }
+        on_event(ChatEvent::StreamDelta {
+            conversation_id: conversation_id.clone(),
+            content: text,
+        });
+    })
 }
 
 // ==================== Public API ====================
@@ -1308,7 +1497,16 @@ pub async fn send_chat_message<F>(
 where
     F: Fn(ChatEvent) + Send + Sync + 'static,
 {
-    send_chat_message_with_settings(storage, conversation_id, content, on_event, None, true).await
+    send_chat_message_with_settings(
+        storage,
+        conversation_id,
+        content,
+        on_event,
+        None,
+        true,
+        None,
+    )
+    .await
 }
 
 /// Like `send_chat_message` but with externally-provided settings (from
@@ -1316,6 +1514,9 @@ where
 /// agent's tools execute their embedding/tagging jobs in-process (`true`,
 /// the default behavior) or leave them in the durable ledger for the host's
 /// dedicated pipeline worker (see `AtomicCore::set_inline_pipeline`).
+/// `cancel`, when supplied, lets the host stop the turn mid-flight; the
+/// partial answer is still persisted and returned.
+#[allow(clippy::too_many_arguments)] // Public chat entry; each argument is a distinct context channel.
 pub async fn send_chat_message_with_settings<F>(
     storage: StorageBackend,
     conversation_id: &str,
@@ -1323,6 +1524,7 @@ pub async fn send_chat_message_with_settings<F>(
     on_event: F,
     external_settings: Option<std::collections::HashMap<String, String>>,
     inline_pipeline: bool,
+    cancel: Option<ChatCancel>,
 ) -> Result<ChatMessageWithContext, String>
 where
     F: Fn(ChatEvent) + Send + Sync + 'static,
@@ -1385,9 +1587,14 @@ where
         .get_conversation_sync(conversation_id)
         .await
         .map_err(|e| e.to_string())?;
-    let messages = match conversation {
-        Some(conv) => chat_messages_to_provider_messages(conv.messages),
-        None => Vec::new(),
+    // A conversation with no title yet is a candidate for one once this turn
+    // lands; anything already titled skips the work entirely.
+    let (messages, untitled) = match conversation {
+        Some(conv) => (
+            chat_messages_to_provider_messages(conv.messages),
+            conv.conversation.title.is_none(),
+        ),
+        None => (Vec::new(), false),
     };
 
     // Build message history for API
@@ -1419,6 +1626,7 @@ where
     };
 
     // Run agent loop (storage is Clone, so no separate connection needed)
+    let title_settings = untitled.then(|| settings_map.clone());
     let mut result = run_agent_loop(
         Arc::clone(&on_event),
         storage.clone(),
@@ -1430,43 +1638,75 @@ where
         None,
         None,
         None,
+        cancel,
     )
     .await?;
 
-    // Save assistant message
-    {
-        let saved_msg = storage
-            .save_message_sync(conversation_id, "assistant", &result.message.content)
-            .await
-            .map_err(|e| e.to_string())?;
+    finish_turn(
+        &storage,
+        conversation_id,
+        &mut result,
+        &on_event,
+        title_settings,
+    )
+    .await?;
 
-        result.message.id = saved_msg.id.clone();
-        result.message.message_index = saved_msg.message_index;
+    Ok(result)
+}
 
-        for tool_call in &mut result.tool_calls {
-            tool_call.message_id = saved_msg.id.clone();
-        }
-        storage
-            .save_tool_calls_sync(&saved_msg.id, &result.tool_calls)
-            .await
-            .map_err(|e| e.to_string())?;
+/// Persist the assistant turn, tell the caller it landed, and name the
+/// conversation if it still has no title.
+///
+/// Shared by both public entrypoints: the tail of a turn is identical
+/// whatever context went into it, and the title hook has to hang off every
+/// path a first exchange can take. `title_settings` is `None` when the
+/// conversation was already titled when the turn started.
+async fn finish_turn(
+    storage: &StorageBackend,
+    conversation_id: &str,
+    result: &mut ChatMessageWithContext,
+    on_event: &ChatEventCallback,
+    title_settings: Option<std::collections::HashMap<String, String>>,
+) -> Result<(), String> {
+    let saved_msg = storage
+        .save_message_sync(conversation_id, "assistant", &result.message.content)
+        .await
+        .map_err(|e| e.to_string())?;
 
-        for citation in &mut result.citations {
-            citation.message_id = saved_msg.id.clone();
-        }
-        storage
-            .save_citations_sync(&saved_msg.id, &result.citations)
-            .await
-            .map_err(|e| e.to_string())?;
+    result.message.id = saved_msg.id.clone();
+    result.message.message_index = saved_msg.message_index;
+
+    for tool_call in &mut result.tool_calls {
+        tool_call.message_id = saved_msg.id.clone();
     }
+    storage
+        .save_tool_calls_sync(&saved_msg.id, &result.tool_calls)
+        .await
+        .map_err(|e| e.to_string())?;
 
-    // Emit completion event
+    for citation in &mut result.citations {
+        citation.message_id = saved_msg.id.clone();
+    }
+    storage
+        .save_citations_sync(&saved_msg.id, &result.citations)
+        .await
+        .map_err(|e| e.to_string())?;
+
     on_event(ChatEvent::Complete {
         conversation_id: conversation_id.to_string(),
         message: result.clone(),
     });
 
-    Ok(result)
+    if let Some(settings) = title_settings {
+        crate::chat_title::spawn_generation(
+            storage.clone(),
+            settings,
+            conversation_id.to_string(),
+            Arc::clone(on_event),
+        );
+    }
+
+    Ok(())
 }
 
 /// Like `send_chat_message_with_settings` but with optional UI context for
@@ -1482,6 +1722,7 @@ pub async fn send_chat_message_with_canvas<F>(
     canvas_context: Option<CanvasContext>,
     page_context: Option<PageContext>,
     canvas_cache: Option<crate::CanvasCache>,
+    cancel: Option<ChatCancel>,
 ) -> Result<ChatMessageWithContext, String>
 where
     F: Fn(ChatEvent) + Send + Sync + 'static,
@@ -1544,9 +1785,14 @@ where
         .get_conversation_sync(conversation_id)
         .await
         .map_err(|e| e.to_string())?;
-    let messages = match conversation {
-        Some(conv) => chat_messages_to_provider_messages(conv.messages),
-        None => Vec::new(),
+    // A conversation with no title yet is a candidate for one once this turn
+    // lands; anything already titled skips the work entirely.
+    let (messages, untitled) = match conversation {
+        Some(conv) => (
+            chat_messages_to_provider_messages(conv.messages),
+            conv.conversation.title.is_none(),
+        ),
+        None => (Vec::new(), false),
     };
 
     // Build message history for API, with canvas context appended to system prompt
@@ -1584,6 +1830,7 @@ where
     };
 
     // Run agent loop with canvas context
+    let title_settings = untitled.then(|| settings_map.clone());
     let mut result = run_agent_loop(
         Arc::clone(&on_event),
         storage.clone(),
@@ -1595,41 +1842,18 @@ where
         page_context.as_ref(),
         canvas_context.as_ref(),
         canvas_cache.as_ref(),
+        cancel,
     )
     .await?;
 
-    // Save assistant message
-    {
-        let saved_msg = storage
-            .save_message_sync(conversation_id, "assistant", &result.message.content)
-            .await
-            .map_err(|e| e.to_string())?;
-
-        result.message.id = saved_msg.id.clone();
-        result.message.message_index = saved_msg.message_index;
-
-        for tool_call in &mut result.tool_calls {
-            tool_call.message_id = saved_msg.id.clone();
-        }
-        storage
-            .save_tool_calls_sync(&saved_msg.id, &result.tool_calls)
-            .await
-            .map_err(|e| e.to_string())?;
-
-        for citation in &mut result.citations {
-            citation.message_id = saved_msg.id.clone();
-        }
-        storage
-            .save_citations_sync(&saved_msg.id, &result.citations)
-            .await
-            .map_err(|e| e.to_string())?;
-    }
-
-    // Emit completion event
-    on_event(ChatEvent::Complete {
-        conversation_id: conversation_id.to_string(),
-        message: result.clone(),
-    });
+    finish_turn(
+        &storage,
+        conversation_id,
+        &mut result,
+        &on_event,
+        title_settings,
+    )
+    .await?;
 
     Ok(result)
 }

--- a/crates/atomic-core/src/agent.rs
+++ b/crates/atomic-core/src/agent.rs
@@ -1,29 +1,28 @@
-//! Chat agent loop with tool calling and streaming
+//! Chat: the conversational surface over the knowledge base.
 //!
-//! Provides the agentic chat loop that searches the knowledge base,
-//! retrieves atoms, and generates responses with citations.
-//! Uses a callback-based event system (same pattern as EmbeddingEvent).
+//! This module owns what makes a chat turn a *chat* turn — the events a
+//! caller sees, the UI context a turn can carry, the system prompt, and the
+//! persistence tail. The loop itself, the tool registry, and citations live
+//! in [`crate::agent_runtime`]; chat's tools live in [`crate::chat_tools`].
+//! Events reach consumers (Tauri, HTTP server) through a callback, the same
+//! pattern `EmbeddingEvent` uses.
 
-use crate::atom_edit::{apply_atom_edits, AtomEditOperation};
-use crate::chunking::count_tokens;
+use crate::agent_runtime::{
+    truncate_messages_to_context, AgentRun, CitationAdmission, CitationLedger, CitationSource,
+    RunConfig, RunError, RunEvent, RunEventSink, StopReason, Termination, ToolCallRecord,
+};
+use crate::chat_tools::ChatToolset;
 use crate::embedding::EmbeddingEvent;
 use crate::models::{
     AtomWithTags, ChatCitation, ChatMessage, ChatMessageWithContext, ChatToolCall,
-    SemanticSearchResult,
 };
-use crate::providers::traits::LlmConfig;
-use crate::providers::types::{
-    GenerationParams, Message, MessageRole, StreamDelta, ToolDefinition,
-};
-use crate::providers::{create_streaming_llm_provider, ProviderConfig, ProviderType};
-use crate::search::{SearchMode, SearchOptions};
+use crate::providers::types::{GenerationParams, Message, MessageRole};
+use crate::providers::{ProviderConfig, ProviderType};
 use crate::storage::StorageBackend;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::collections::HashMap;
+use std::sync::Arc;
 use uuid::Uuid;
 
 pub(crate) type ChatEventCallback = Arc<dyn Fn(ChatEvent) + Send + Sync + 'static>;
@@ -33,7 +32,7 @@ pub(crate) type ChatEventCallback = Arc<dyn Fn(ChatEvent) + Send + Sync + 'stati
 /// between sequential tool executions, and mid-stream — then persists and
 /// returns whatever text it had already produced. Hosts own the registry
 /// (see `atomic-server`'s cancellation registry); the loop only reads it.
-pub type ChatCancel = Arc<AtomicBool>;
+pub type ChatCancel = crate::agent_runtime::CancelFlag;
 
 // ==================== Chat Events ====================
 
@@ -104,142 +103,6 @@ pub enum ChatEvent {
     },
 }
 
-// ==================== Tool Definitions ====================
-
-fn get_tools() -> Vec<ToolDefinition> {
-    vec![
-        ToolDefinition::new(
-            "search_atoms",
-            "Search for relevant atoms using hybrid keyword and semantic search. Use this to find information related to a specific topic or question. Set since_days when the user is asking about recent notes (e.g., 7 for last week, 30 for last month).",
-            json!({
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "The search query to find relevant atoms"
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Maximum number of results to return (default: 5)",
-                        "default": 5
-                    },
-                    "since_days": {
-                        "type": "integer",
-                        "description": "Optional recency filter: only return atoms created within the last N days. Use when the user's question is time-sensitive (e.g., 7 for last week, 30 for last month).",
-                        "minimum": 1
-                    }
-                },
-                "required": ["query"]
-            }),
-        ),
-        ToolDefinition::new(
-            "get_atom",
-            "Get the content of a specific atom by its ID. Returns up to `limit` lines starting at `offset` (defaults: offset=0, limit=500). If the atom has more content, the response includes a line-count header indicating how to continue reading via a follow-up call with a higher offset.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "atom_id": {
-                        "type": "string",
-                        "description": "The ID of the atom to retrieve"
-                    },
-                    "offset": {
-                        "type": "integer",
-                        "description": "Line number to start reading from (0-indexed). Use the value from a prior response's header to continue reading a truncated atom.",
-                        "minimum": 0,
-                        "default": 0
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Maximum number of lines to return. Defaults to 500; prefer the default unless you know you need more.",
-                        "minimum": 1,
-                        "maximum": 2000,
-                        "default": 500
-                    }
-                },
-                "required": ["atom_id"]
-            }),
-        ),
-        ToolDefinition::new(
-            "create_atom",
-            "Create a new atom with markdown content. Only use this when the user explicitly asks you to create, save, draft, or add a new atom/note. Do not call this for ordinary answers. After creating an atom, mention it in your final response using [[atom_id]] so the UI can link to it.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "content": {
-                        "type": "string",
-                        "description": "Full markdown content for the new atom"
-                    },
-                    "source_url": {
-                        "type": "string",
-                        "description": "Optional source URL for the atom"
-                    },
-                    "published_at": {
-                        "type": "string",
-                        "description": "Optional ISO 8601 publication date"
-                    },
-                    "tag_ids": {
-                        "type": "array",
-                        "description": "Optional existing tag IDs to assign",
-                        "items": { "type": "string" },
-                        "default": []
-                    }
-                },
-                "required": ["content"]
-            }),
-        ),
-        ToolDefinition::new(
-            "edit_atom",
-            "Apply edits to an existing atom. Only use this when the user explicitly asks you to modify an atom. Supports replace, insert_after, append, and replace_all operations. Prefer targeted edits. Use replace_all only when the user explicitly asks for a full rewrite or provides complete replacement content. replace and insert_after require exact text that appears exactly once in the current atom; call get_atom first if you need context.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "atom_id": {
-                        "type": "string",
-                        "description": "The ID of the atom to edit"
-                    },
-                    "edits": {
-                        "type": "array",
-                        "description": "One or more edits applied in order to the atom content. The whole operation fails without saving if any edit is invalid.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "operation": {
-                                    "type": "string",
-                                    "enum": ["replace", "insert_after", "append", "replace_all"],
-                                    "description": "replace swaps exact old_text for new_text; insert_after inserts text after exact anchor_text; append adds text to the end of the atom; replace_all replaces the full atom content."
-                                },
-                                "old_text": {
-                                    "type": "string",
-                                    "description": "Exact text to replace. Required for replace and must occur exactly once."
-                                },
-                                "new_text": {
-                                    "type": "string",
-                                    "description": "Replacement text for replace."
-                                },
-                                "anchor_text": {
-                                    "type": "string",
-                                    "description": "Exact text to insert after. Required for insert_after and must occur exactly once."
-                                },
-                                "text": {
-                                    "type": "string",
-                                    "description": "Text to insert for insert_after or append. Include leading newlines/spaces exactly as desired."
-                                },
-                                "content": {
-                                    "type": "string",
-                                    "description": "Full replacement markdown content. Required for replace_all."
-                                }
-                            },
-                            "required": ["operation"]
-                        },
-                        "minItems": 1
-                    }
-                },
-                "required": ["atom_id", "edits"]
-            }),
-        ),
-    ]
-}
-
 // ==================== UI Context ====================
 
 /// Context about the user's current app view, passed from the frontend with a
@@ -264,70 +127,11 @@ pub struct PageContext {
     pub selected_tag_id: Option<String>,
 }
 
-fn get_page_context_tools() -> Vec<ToolDefinition> {
-    vec![ToolDefinition::new(
-        "get_current_page_context",
-        "Get compact context about what the user is currently viewing in Atomic, such as the visible atom, wiki page, selected tag, and a short atom snippet. Use this first when the user says things like \"this atom\", \"the note I'm reading\", \"this page\", \"what I'm looking at\", or otherwise refers to visible UI context.",
-        json!({
-            "type": "object",
-            "properties": {},
-            "additionalProperties": false
-        }),
-    )]
-}
-
 fn get_page_context_system_prompt() -> &'static str {
     r#"
 
 You can inspect the user's current Atomic UI context with get_current_page_context.
 Use it before answering when the user refers to "this", "current", "open", "visible", or the note/page they are reading. If it returns an atom_id and you need more than the snippet, call get_atom with that atom_id before answering."#
-}
-
-async fn execute_get_current_page_context(
-    storage: &StorageBackend,
-    page_context: Option<&PageContext>,
-) -> Result<Option<serde_json::Value>, String> {
-    let Some(ctx) = page_context else {
-        return Ok(None);
-    };
-
-    let mut visible_atom = serde_json::Value::Null;
-    if let Some(atom_id) = ctx.atom_id.as_deref().filter(|id| !id.is_empty()) {
-        let stored_atom = storage
-            .get_atom_impl(atom_id)
-            .await
-            .map_err(|e| e.to_string())?;
-
-        visible_atom = match stored_atom {
-            Some(atom_with_tags) => json!({
-                "id": atom_with_tags.atom.id,
-                "title": atom_with_tags.atom.title,
-                "snippet": atom_with_tags.atom.snippet,
-                "source_url": atom_with_tags.atom.source_url,
-                "tags": atom_with_tags
-                    .tags
-                    .into_iter()
-                    .map(|tag| json!({ "id": tag.id, "name": tag.name }))
-                    .collect::<Vec<_>>(),
-            }),
-            None => json!({
-                "id": atom_id,
-                "title": ctx.atom_title.as_deref(),
-                "snippet": ctx.atom_snippet.as_deref(),
-                "not_found": true,
-            }),
-        };
-    }
-
-    Ok(Some(json!({
-        "view": ctx.view.as_deref(),
-        "visible_atom": visible_atom,
-        "wiki": {
-            "tag_id": ctx.wiki_tag_id.as_deref(),
-            "tag_name": ctx.wiki_tag_name.as_deref(),
-        },
-        "selected_tag_id": ctx.selected_tag_id.as_deref(),
-    })))
 }
 
 // ==================== Canvas Context ====================
@@ -344,39 +148,6 @@ pub struct CanvasContext {
 pub struct CanvasClusterSummary {
     pub label: String,
     pub atom_count: i32,
-}
-
-fn get_canvas_tools() -> Vec<ToolDefinition> {
-    vec![
-        ToolDefinition::new(
-            "zoom_to_cluster",
-            "Zoom the canvas camera to center on a single cluster of related atoms. The canvas can only show one view at a time — each call replaces the previous view. Use this when the user asks about a topic area visible on their knowledge graph.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "cluster_label": {
-                        "type": "string",
-                        "description": "The label of the cluster to zoom to"
-                    }
-                },
-                "required": ["cluster_label"]
-            }),
-        ),
-        ToolDefinition::new(
-            "focus_atom",
-            "Zoom to a specific atom on the canvas and show its preview. The canvas can only focus on one atom at a time. Use this after searching to highlight a specific result on the graph.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "atom_id": {
-                        "type": "string",
-                        "description": "The ID of the atom to focus on"
-                    }
-                },
-                "required": ["atom_id"]
-            }),
-        ),
-    ]
 }
 
 const MAX_CANVAS_CLUSTERS: usize = 30;
@@ -407,355 +178,6 @@ Use these tools proactively when they would help the user navigate their knowled
     )
 }
 
-// ==================== Tool Execution ====================
-
-async fn execute_search_atoms(
-    storage: &StorageBackend,
-    query: &str,
-    limit: i32,
-    since_days: Option<i32>,
-    scope_tag_ids: &[String],
-    external_settings: Option<std::collections::HashMap<String, String>>,
-) -> Result<Vec<SemanticSearchResult>, String> {
-    // Try SQLite path first (uses full search module with settings resolution)
-    if let Some(sqlite) = storage.as_sqlite() {
-        let options = SearchOptions::new(query, SearchMode::Hybrid, limit)
-            .with_threshold(0.3)
-            .with_scope(scope_tag_ids.to_vec())
-            .with_since_days(since_days);
-        return crate::search::search_atoms_with_settings(&sqlite.db, options, external_settings)
-            .await;
-    }
-
-    // Postgres path: use storage dispatch methods. Provider config is
-    // deployment-wide, so the fallback reads the global settings tier.
-    let settings = match external_settings {
-        Some(s) => s,
-        None => storage
-            .get_global_settings_sync()
-            .await
-            .map_err(|e| e.to_string())?,
-    };
-    let config = ProviderConfig::from_settings(&settings);
-
-    // Generate query embedding
-    let provider = crate::providers::get_embedding_provider(&config).map_err(|e| e.to_string())?;
-    let embed_config = config.embedding_config();
-    let embeddings = provider
-        .embed_batch(&[query.to_string()], &embed_config)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let cutoff = since_days.map(crate::search::since_days_cutoff);
-    let cutoff_ref = cutoff.as_deref();
-
-    // Chat is an in-app conversational surface over the user's own KB;
-    // finding atoms participate as first-class context just like captured
-    // ones (mirrors the SQLite path that goes through SearchOptions with
-    // its default KindFilter::All).
-    let kinds = crate::models::KindFilter::All;
-    let keyword = storage
-        .keyword_search_sync(query, limit * 2, scope_tag_ids, cutoff_ref, &kinds)
-        .await
-        .map_err(|e| e.to_string())?;
-    let semantic = if !embeddings.is_empty() && !embeddings[0].is_empty() {
-        storage
-            .vector_search_sync(
-                &embeddings[0],
-                limit * 2,
-                0.3,
-                scope_tag_ids,
-                cutoff_ref,
-                &kinds,
-            )
-            .await
-            .map_err(|e| e.to_string())?
-    } else {
-        vec![]
-    };
-
-    Ok(crate::search::merge_search_results_rrf(
-        semantic, keyword, limit,
-    ))
-}
-
-/// Default line limit for a single `get_atom` call. Chosen to keep context
-/// usage bounded on long atoms (imports, pasted articles) while being large
-/// enough that most notes fit in one call.
-const GET_ATOM_DEFAULT_LIMIT: usize = 500;
-const GET_ATOM_MAX_LIMIT: usize = 2000;
-
-async fn execute_get_atom(
-    storage: &StorageBackend,
-    atom_id: &str,
-    offset: usize,
-    limit: usize,
-) -> Result<Option<String>, String> {
-    let Some(content) = storage
-        .get_atom_content_impl(atom_id)
-        .await
-        .map_err(|e| e.to_string())?
-    else {
-        return Ok(None);
-    };
-
-    let lines: Vec<&str> = content.lines().collect();
-    let total = lines.len();
-
-    // Empty atom — return empty before the range math, otherwise a nonzero
-    // offset would produce lines[offset..0] and panic.
-    if total == 0 {
-        return Ok(Some(String::new()));
-    }
-
-    if offset >= total {
-        return Ok(Some(format!(
-            "[offset={} is past end of atom ({} total lines)]",
-            offset, total
-        )));
-    }
-
-    let end = (offset + limit).min(total);
-    let slice = lines[offset..end].join("\n");
-
-    // Only annotate when we truncated or started partway through, so short
-    // atoms (the common case) read clean without metadata noise.
-    if offset == 0 && end == total {
-        return Ok(Some(slice));
-    }
-
-    let header = if end < total {
-        format!(
-            "[lines {}-{} of {}. {} more lines. Call get_atom again with offset={} to continue.]\n",
-            offset + 1,
-            end,
-            total,
-            total - end,
-            end,
-        )
-    } else {
-        format!(
-            "[lines {}-{} of {} (end of atom).]\n",
-            offset + 1,
-            end,
-            total,
-        )
-    };
-
-    Ok(Some(format!("{}{}", header, slice)))
-}
-
-fn parse_optional_string_arg(args: &serde_json::Value, key: &str) -> Option<String> {
-    args.get(key)
-        .and_then(|value| value.as_str())
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-}
-
-fn parse_tag_ids_arg(args: &serde_json::Value) -> Vec<String> {
-    args.get("tag_ids")
-        .and_then(|value| value.as_array())
-        .map(|values| {
-            values
-                .iter()
-                .filter_map(|value| value.as_str())
-                .filter(|value| !value.is_empty())
-                .map(str::to_string)
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-async fn execute_create_atom(
-    storage: &StorageBackend,
-    tool_args: &serde_json::Value,
-    external_settings: Option<std::collections::HashMap<String, String>>,
-    inline_pipeline: bool,
-    canvas_cache: Option<&crate::CanvasCache>,
-    on_embedding_event: Arc<dyn Fn(EmbeddingEvent) + Send + Sync + 'static>,
-) -> Result<AtomWithTags, String> {
-    let content = tool_args["content"].as_str().unwrap_or("").to_string();
-    if content.trim().is_empty() {
-        return Err("Cannot create an empty atom".to_string());
-    }
-
-    let id = Uuid::new_v4().to_string();
-    let now = Utc::now().to_rfc3339();
-    let request = crate::CreateAtomRequest {
-        content: content.clone(),
-        source_url: parse_optional_string_arg(tool_args, "source_url"),
-        published_at: parse_optional_string_arg(tool_args, "published_at"),
-        tag_ids: parse_tag_ids_arg(tool_args),
-        skip_if_source_exists: false,
-    };
-
-    let atom = storage
-        .insert_atom_impl(&id, &request, &now)
-        .await
-        .map_err(|e| e.to_string())?;
-    if let Some(cache) = canvas_cache {
-        cache.invalidate();
-    }
-
-    enqueue_agent_pipeline_in_background(
-        storage.clone(),
-        id.clone(),
-        "agent_create_atom".to_string(),
-        external_settings,
-        inline_pipeline,
-        canvas_cache.cloned(),
-        on_embedding_event,
-    );
-
-    Ok(atom)
-}
-
-async fn enqueue_and_process_agent_pipeline(
-    storage: &StorageBackend,
-    atom_id: &str,
-    reason: &str,
-    external_settings: Option<std::collections::HashMap<String, String>>,
-    inline_pipeline: bool,
-    canvas_cache: Option<&crate::CanvasCache>,
-    on_embedding_event: Arc<dyn Fn(EmbeddingEvent) + Send + Sync + 'static>,
-) -> Result<(), String> {
-    let job = crate::models::AtomPipelineJobRequest {
-        atom_id: atom_id.to_string(),
-        embed_requested: true,
-        tag_requested: true,
-        not_before: None,
-        reason: reason.to_string(),
-        replace_existing: false,
-    };
-    storage
-        .enqueue_pipeline_jobs_sync(&[job])
-        .await
-        .map_err(|e| e.to_string())?;
-    if !inline_pipeline {
-        // The job persists in the durable ledger; the host's dedicated
-        // pipeline worker executes it (see AtomicCore::set_inline_pipeline).
-        return Ok(());
-    }
-    let callback = {
-        let on_embedding_event = Arc::clone(&on_embedding_event);
-        move |event| on_embedding_event(event)
-    };
-    match external_settings {
-        Some(settings) => {
-            crate::embedding::process_queued_pipeline_jobs_with_settings(
-                storage.clone(),
-                callback,
-                settings,
-                canvas_cache.cloned(),
-            )
-            .await?;
-        }
-        None => {
-            crate::embedding::process_queued_pipeline_jobs(
-                storage.clone(),
-                callback,
-                canvas_cache.cloned(),
-            )
-            .await?;
-        }
-    }
-    Ok(())
-}
-
-fn enqueue_agent_pipeline_in_background(
-    storage: StorageBackend,
-    atom_id: String,
-    reason: String,
-    external_settings: Option<std::collections::HashMap<String, String>>,
-    inline_pipeline: bool,
-    canvas_cache: Option<crate::CanvasCache>,
-    on_embedding_event: Arc<dyn Fn(EmbeddingEvent) + Send + Sync + 'static>,
-) {
-    let failure_callback = Arc::clone(&on_embedding_event);
-    tokio::spawn(async move {
-        let result = enqueue_and_process_agent_pipeline(
-            &storage,
-            &atom_id,
-            &reason,
-            external_settings,
-            inline_pipeline,
-            canvas_cache.as_ref(),
-            on_embedding_event,
-        )
-        .await;
-
-        if let Err(error) = result {
-            tracing::warn!(
-                atom_id = %atom_id,
-                reason = %reason,
-                error = %error,
-                "Agent mutation pipeline failed"
-            );
-            failure_callback(EmbeddingEvent::EmbeddingFailed { atom_id, error });
-        }
-    });
-}
-
-async fn execute_edit_atom(
-    storage: &StorageBackend,
-    tool_args: &serde_json::Value,
-    external_settings: Option<std::collections::HashMap<String, String>>,
-    inline_pipeline: bool,
-    canvas_cache: Option<&crate::CanvasCache>,
-    on_embedding_event: Arc<dyn Fn(EmbeddingEvent) + Send + Sync + 'static>,
-) -> Result<Option<AtomWithTags>, String> {
-    let atom_id = tool_args["atom_id"].as_str().unwrap_or("");
-    let Some(existing) = storage
-        .get_atom_impl(atom_id)
-        .await
-        .map_err(|e| e.to_string())?
-    else {
-        return Ok(None);
-    };
-
-    let edits: Vec<AtomEditOperation> = serde_json::from_value(
-        tool_args
-            .get("edits")
-            .cloned()
-            .ok_or_else(|| "edits must be an array".to_string())?,
-    )
-    .map_err(|e| format!("edits must be valid edit operations: {}", e))?;
-    let content = apply_atom_edits(&existing.atom.content, &edits)?;
-    if content == existing.atom.content {
-        return Err("Edits did not change the atom content".to_string());
-    }
-    if content.trim().is_empty() {
-        return Err("Cannot update an atom to empty content".to_string());
-    }
-
-    let request = crate::UpdateAtomRequest {
-        content: content.clone(),
-        source_url: existing.atom.source_url,
-        published_at: existing.atom.published_at,
-        tag_ids: None,
-    };
-    let now = Utc::now().to_rfc3339();
-    let atom = storage
-        .update_atom_if_unchanged_impl(atom_id, &request, &now, &existing.atom.updated_at)
-        .await
-        .map_err(|e| e.to_string())?;
-    if let Some(cache) = canvas_cache {
-        cache.invalidate();
-    }
-
-    enqueue_agent_pipeline_in_background(
-        storage.clone(),
-        atom_id.to_string(),
-        "agent_edit_atom".to_string(),
-        external_settings,
-        inline_pipeline,
-        canvas_cache.cloned(),
-        on_embedding_event,
-    );
-
-    Ok(Some(atom))
-}
-
 // ==================== System Prompt ====================
 
 fn get_system_prompt(scope_description: &str) -> String {
@@ -766,144 +188,26 @@ fn get_system_prompt(scope_description: &str) -> String {
 
 Guidelines:
 - Use search_atoms to find relevant information before answering, unless another available tool more directly addresses the user's request
+- The knowledge base has structure beyond individual atoms: list_tags shows how it is organized, get_wiki reads the synthesized article for a tag, and list_reports/get_finding surface what scheduled research has already turned up. Reach for these when the question is about a topic as a whole rather than a specific note
 - Only call create_atom or edit_atom when the user explicitly asks you to create or modify an atom
 - Prefer targeted edit_atom operations. Use replace_all only for intentional full-content replacement
 - When you create a new atom, include [[atom_id]] in the final response so the user can open it
 - If the initial search doesn't find enough, try different search queries
-- When you find relevant information, cite it using [N] notation where N is a sequential number
+- When you use information from a tool result, cite it with the [N] number that result gave you
 - Be honest if you cannot find information - do not make things up
 - Keep responses concise but informative
 - If the user asks about something not in their knowledge base, say so
 
 When citing sources:
-- Use [1], [2], etc. for each unique source
+- Use the exact [N] numbers the tools gave you. Never renumber them, and never cite a number no tool showed you
 - Place citations immediately after the relevant claim
-- You can cite the same source multiple times if needed"#,
+- You can cite the same source multiple times if needed
+- The user only sees the sources you cite, so cite everything your answer relies on"#,
         scope_description
     )
 }
 
-// ==================== Context Window Management ====================
-
-/// Estimate token count for a message, including tool call content.
-fn estimate_message_tokens(m: &Message) -> usize {
-    let content_tokens = count_tokens(m.content.as_deref().unwrap_or(""));
-    let tool_call_tokens = m.tool_calls.as_ref().map_or(0, |tcs| {
-        tcs.iter()
-            .map(|tc| {
-                let args = tc.get_arguments().unwrap_or("");
-                let name = tc.get_name().unwrap_or("");
-                count_tokens(name) + count_tokens(args) + 10
-            })
-            .sum()
-    });
-    content_tokens + tool_call_tokens
-}
-
-/// A group of messages that must be kept together for API validity.
-/// Either a single user/system message, or an assistant message followed
-/// by its tool-result messages.
-struct MessageGroup {
-    start: usize,
-    end: usize, // exclusive
-    tokens: usize,
-}
-
-/// Group messages into atomic units that can't be split.
-/// An assistant message with tool_calls and its subsequent tool-result messages
-/// form one group. Everything else is its own group.
-fn group_messages(messages: &[Message], message_tokens: &[usize]) -> Vec<MessageGroup> {
-    let mut groups = Vec::new();
-    let mut i = 0;
-    while i < messages.len() {
-        if messages[i].role == MessageRole::Assistant && messages[i].tool_calls.is_some() {
-            // Start of a tool round: assistant + following tool results
-            let start = i;
-            let mut tokens = message_tokens[i];
-            i += 1;
-            while i < messages.len() && messages[i].role == MessageRole::Tool {
-                tokens += message_tokens[i];
-                i += 1;
-            }
-            groups.push(MessageGroup {
-                start,
-                end: i,
-                tokens,
-            });
-        } else {
-            groups.push(MessageGroup {
-                start: i,
-                end: i + 1,
-                tokens: message_tokens[i],
-            });
-            i += 1;
-        }
-    }
-    groups
-}
-
-/// Truncate message history to fit within the provider's context window.
-/// Keeps the system prompt (first group) and the most recent group,
-/// then includes as many recent groups as fit in the remaining budget.
-/// Never splits assistant+tool-result pairs to maintain API validity.
-/// Reserves ~30% of context for the assistant's response and tool results.
-fn truncate_messages_to_context(
-    messages: Vec<Message>,
-    context_length: Option<usize>,
-) -> Vec<Message> {
-    let max_tokens = match context_length {
-        Some(ctx_len) => (ctx_len as f64 * 0.7) as usize,
-        None => return messages,
-    };
-
-    if messages.len() <= 2 {
-        return messages;
-    }
-
-    let message_tokens: Vec<usize> = messages.iter().map(estimate_message_tokens).collect();
-    let total: usize = message_tokens.iter().sum();
-    if total <= max_tokens {
-        return messages;
-    }
-
-    let groups = group_messages(&messages, &message_tokens);
-    if groups.len() <= 2 {
-        return messages; // System + one group, nothing safe to drop
-    }
-
-    // Always keep first group (system) and last group (most recent)
-    let first_tokens = groups[0].tokens;
-    let last_tokens = groups[groups.len() - 1].tokens;
-    let mut budget = max_tokens.saturating_sub(first_tokens + last_tokens);
-
-    // Work backwards through middle groups, keeping as many as fit
-    let mut keep_from_group = groups.len() - 1;
-    for gi in (1..groups.len() - 1).rev() {
-        if groups[gi].tokens > budget {
-            break;
-        }
-        budget -= groups[gi].tokens;
-        keep_from_group = gi;
-    }
-
-    // Build result from kept groups
-    let mut result: Vec<Message> = messages[groups[0].start..groups[0].end].to_vec();
-    for g in &groups[keep_from_group..] {
-        result.extend(messages[g.start..g.end].to_vec());
-    }
-
-    tracing::info!(
-        original_messages = messages.len(),
-        truncated_messages = result.len(),
-        groups_kept = groups.len() - keep_from_group + 1,
-        max_tokens,
-        "[chat] Truncated message history to fit context window"
-    );
-
-    result
-}
-
-// ==================== Helper: Convert stored messages to provider format ====================
+// ==================== Turn Assembly ====================
 
 /// Convert ChatMessage models from storage into provider Message format for the API.
 fn chat_messages_to_provider_messages(
@@ -929,77 +233,15 @@ fn chat_messages_to_provider_messages(
         .collect()
 }
 
-// ==================== Agent Loop ====================
-
-struct AgentContext {
-    conversation_id: String,
-    scope_tag_ids: Vec<String>,
-    messages: Vec<Message>,
-    citations: Vec<(String, Option<i32>, String)>, // (atom_id, chunk_index, excerpt)
-    tool_calls_record: Vec<ChatToolCall>,
-}
-
-/// Outcome of a single tool execution. `failed` is tracked separately from
-/// `output` because the error text still has to reach the model (and the UI's
-/// tool card), while `chat_tool_calls.status` must say what actually happened.
-struct ToolOutcome {
-    output: String,
-    results_count: i32,
-    failed: bool,
-}
-
-impl ToolOutcome {
-    fn ok(output: impl Into<String>, results_count: i32) -> Self {
-        Self {
-            output: output.into(),
-            results_count,
-            failed: false,
-        }
-    }
-
-    fn failed(error: impl std::fmt::Display) -> Self {
-        Self {
-            output: format!("Error: {}", error),
-            results_count: 0,
-            failed: true,
-        }
-    }
-}
-
 /// Tool-calling rounds a single turn may take before the loop gives up and
 /// salvages whatever answer it has.
 const MAX_ITERATIONS: usize = 10;
-
-/// How often the loop samples the cancellation flag while a provider stream
-/// is in flight. Cancellation is cooperative and user-facing, so the bound
-/// only has to be imperceptible, not instant.
-const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Appended to the assistant message when the user stopped the turn.
 const STOPPED_MARKER: &str = "*(stopped)*";
 
 /// Appended to the assistant message when the tool-call budget ran out.
 const ITERATION_CAP_NOTE: &str = "*(reached tool-call limit — answer may be incomplete)*";
-
-fn is_cancelled(cancel: &Option<ChatCancel>) -> bool {
-    cancel
-        .as_ref()
-        .is_some_and(|flag| flag.load(Ordering::Relaxed))
-}
-
-/// Resolves once `cancel` is raised; never resolves when there is no flag.
-/// Polling keeps cancellation out of the provider traits — the loop races
-/// this against the in-flight request and drops the request future on cancel.
-async fn cancellation_raised(cancel: &Option<ChatCancel>) {
-    match cancel {
-        Some(flag) => {
-            while !flag.load(Ordering::Relaxed) {
-                tokio::time::sleep(CANCEL_POLL_INTERVAL).await;
-            }
-        }
-        None => std::future::pending().await,
-    }
-}
 
 /// Attach a trailing note to a partial answer, keeping the note readable when
 /// there is no text to attach it to.
@@ -1012,472 +254,343 @@ fn with_note(text: &str, note: &str) -> String {
     }
 }
 
-/// Turn the accumulated agent context into the assistant message to persist.
-fn build_result(ctx: AgentContext, content: String) -> ChatMessageWithContext {
-    let citations: Vec<ChatCitation> = ctx
-        .citations
-        .iter()
-        .enumerate()
-        .map(|(i, (atom_id, chunk_index, excerpt))| ChatCitation {
+/// UI context a turn can carry. Absent for headless callers, which is also
+/// what decides whether the page and canvas tools are registered at all.
+#[derive(Default)]
+struct TurnContext {
+    page: Option<PageContext>,
+    canvas: Option<CanvasContext>,
+    canvas_cache: Option<crate::CanvasCache>,
+}
+
+/// Provider config and model for a chat turn. OpenRouter has a dedicated
+/// chat-model setting; local providers use their single configured LLM.
+fn resolve_chat_model(
+    settings: &HashMap<String, String>,
+) -> Result<(ProviderConfig, String), String> {
+    let provider_config = ProviderConfig::from_settings(settings);
+
+    if provider_config.provider_type == ProviderType::OpenRouter
+        && provider_config.openrouter_api_key.is_none()
+    {
+        return Err("OpenRouter API key not configured. Please set it in Settings.".to_string());
+    }
+
+    let model = match provider_config.provider_type {
+        ProviderType::Ollama => provider_config.llm_model().to_string(),
+        ProviderType::OpenAICompat => provider_config.llm_model().to_string(),
+        ProviderType::OpenRouter => settings
+            .get("chat_model")
+            .cloned()
+            .unwrap_or_else(|| crate::providers::DEFAULT_AGENTIC_MODEL.to_string()),
+    };
+
+    Ok((provider_config, model))
+}
+
+/// Bridge runtime progress onto the conversation's event stream.
+fn chat_event_sink(on_event: &ChatEventCallback, conversation_id: &str) -> RunEventSink {
+    let on_event = Arc::clone(on_event);
+    let conversation_id = conversation_id.to_string();
+    Arc::new(move |event| {
+        let conversation_id = conversation_id.clone();
+        on_event(match event {
+            RunEvent::Delta { text } => ChatEvent::StreamDelta {
+                conversation_id,
+                content: text,
+            },
+            RunEvent::ToolStart {
+                tool_call_id,
+                tool_name,
+                input,
+            } => ChatEvent::ToolStart {
+                conversation_id,
+                tool_call_id,
+                tool_name,
+                tool_input: input,
+            },
+            RunEvent::ToolComplete {
+                tool_call_id,
+                results_count,
+                failed,
+                ..
+            } => ChatEvent::ToolComplete {
+                conversation_id,
+                tool_call_id,
+                results_count,
+                failed,
+            },
+        });
+    })
+}
+
+fn to_chat_tool_calls(records: Vec<ToolCallRecord>) -> Vec<ChatToolCall> {
+    records
+        .into_iter()
+        .map(|record| ChatToolCall {
+            id: record.id,
+            message_id: String::new(), // Set when saving
+            tool_name: record.name,
+            tool_input: record.input,
+            tool_output: Some(serde_json::Value::String(record.output)),
+            status: if record.failed { "failed" } else { "complete" }.to_string(),
+            created_at: record.started_at,
+            completed_at: Some(record.completed_at),
+        })
+        .collect()
+}
+
+/// Turn the run's cited evidence into the citation rows to persist. Only
+/// what the answer actually cites is stored — the Sources row is what the
+/// answer rests on, not a log of everything the agent read.
+///
+/// Wiki citations carry their tag's name so the message this turn returns
+/// can open the article straight away; reloading the conversation resolves
+/// the same name through the read path's join.
+async fn to_chat_citations(
+    storage: &StorageBackend,
+    ledger: &CitationLedger,
+    content: &str,
+) -> Vec<ChatCitation> {
+    let mut citations = Vec::new();
+    for citable in ledger.cited_in(content) {
+        let source_title = match citable.source {
+            CitationSource::Wiki => storage
+                .get_tag_sync(&citable.source_id)
+                .await
+                .unwrap_or_default()
+                .map(|tag| tag.name),
+            CitationSource::Atom | CitationSource::Finding => None,
+        };
+        citations.push(ChatCitation {
             id: Uuid::new_v4().to_string(),
             message_id: String::new(), // Set when saving
-            citation_index: (i + 1) as i32,
-            atom_id: atom_id.clone(),
-            chunk_index: *chunk_index,
-            excerpt: excerpt.clone(),
+            citation_index: citable.number,
+            atom_id: citable.source_id,
+            chunk_index: citable.chunk_index,
+            excerpt: citable.excerpt,
             relevance_score: None,
-        })
-        .collect();
+            source_type: citable.source.as_str().to_string(),
+            source_title,
+        });
+    }
+    citations
+}
 
-    ChatMessageWithContext {
+/// Run one chat turn end to end: persist the user message, assemble the
+/// prompt and tools, run the agent, then persist and announce the answer.
+#[allow(clippy::too_many_arguments)] // One turn; each argument is a distinct context channel.
+async fn send_turn(
+    storage: StorageBackend,
+    conversation_id: &str,
+    content: &str,
+    on_event: ChatEventCallback,
+    external_settings: Option<HashMap<String, String>>,
+    inline_pipeline: bool,
+    ui: TurnContext,
+    cancel: Option<ChatCancel>,
+) -> Result<ChatMessageWithContext, String> {
+    // Resolve settings (from the caller's resolved map if provided,
+    // otherwise the storage layer's global tier — provider config is
+    // deployment-wide)
+    let settings_map = match external_settings {
+        Some(s) => s,
+        None => storage
+            .get_global_settings_sync()
+            .await
+            .map_err(|e| e.to_string())?,
+    };
+    let (provider_config, model) = resolve_chat_model(&settings_map)?;
+
+    // Save user message
+    storage
+        .save_message_sync(conversation_id, "user", content)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // Get conversation context
+    let scope = storage
+        .get_conversation_scope_sync(conversation_id)
+        .await
+        .map_err(|e| e.to_string())?;
+    let scope_description = storage
+        .get_scope_description_sync(&scope)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // Get conversation messages via get_conversation_sync and convert to provider format
+    let conversation = storage
+        .get_conversation_sync(conversation_id)
+        .await
+        .map_err(|e| e.to_string())?;
+    // A conversation with no title yet is a candidate for one once this turn
+    // lands; anything already titled skips the work entirely.
+    let (messages, untitled) = match conversation {
+        Some(conv) => (
+            chat_messages_to_provider_messages(conv.messages),
+            conv.conversation.title.is_none(),
+        ),
+        None => (Vec::new(), false),
+    };
+
+    // Build message history for API, with UI context appended to the system prompt
+    let custom_chat_prefix = settings_map
+        .get("chat_prompt")
+        .filter(|s| !s.is_empty())
+        .map(|s| s.as_str());
+    let base_system = get_system_prompt(&scope_description);
+    let mut system_prompt = match custom_chat_prefix {
+        Some(prefix) => format!("{prefix}\n\n{base_system}"),
+        None => base_system,
+    };
+    if ui.page.is_some() {
+        system_prompt.push_str(get_page_context_system_prompt());
+    }
+    if let Some(ref canvas) = ui.canvas {
+        system_prompt.push_str(&get_canvas_system_prompt(canvas));
+    }
+    let mut api_messages = vec![Message::system(system_prompt)];
+    api_messages.extend(messages);
+
+    // Truncate to fit context window for providers with limited context
+    let context_length = provider_config.context_length_for_model(&model);
+    let api_messages = truncate_messages_to_context(api_messages, context_length);
+
+    let tools = ChatToolset {
+        storage: storage.clone(),
+        conversation_id: conversation_id.to_string(),
+        scope,
+        settings: Some(settings_map.clone()),
+        inline_pipeline,
+        canvas_cache: ui.canvas_cache,
+        page_context: ui.page,
+        canvas_context: ui.canvas,
+        on_event: Arc::clone(&on_event),
+    }
+    .into_registry();
+    // Chat lets any tool make what it surfaces citable; the answer's markers
+    // decide what survives.
+    let ledger = CitationLedger::new(CitationAdmission::Open);
+
+    let title_settings = untitled.then(|| settings_map.clone());
+    let outcome = AgentRun {
+        config: RunConfig {
+            model,
+            params: GenerationParams::new()
+                .with_temperature(0.7)
+                .with_max_tokens(4000),
+            max_iterations: MAX_ITERATIONS,
+            termination: Termination::NoToolCalls,
+            streaming: true,
+            salvage_on_cap: true,
+            context_length,
+        },
+        provider_config: &provider_config,
+        tools: &tools,
+        citations: &ledger,
+        messages: api_messages,
+        cancel,
+        events: Some(chat_event_sink(&on_event, conversation_id)),
+    }
+    .execute()
+    .await
+    .map_err(|error| match error {
+        // A dead provider has to reach the UI over the event stream, not
+        // only as the failed return of a request nobody may be reading.
+        RunError::Provider(error) => {
+            let error = format!("API request failed: {}", error);
+            on_event(ChatEvent::Error {
+                conversation_id: conversation_id.to_string(),
+                error: error.clone(),
+            });
+            error
+        }
+        RunError::Setup(error) => format!("Failed to create streaming provider: {}", error),
+    })?;
+
+    let content = match outcome.stop {
+        StopReason::Answered | StopReason::Sentinel => outcome.content,
+        StopReason::Cancelled => with_note(&outcome.content, STOPPED_MARKER),
+        StopReason::IterationCap => with_note(&outcome.content, ITERATION_CAP_NOTE),
+    };
+    let mut result = ChatMessageWithContext {
+        citations: to_chat_citations(&storage, &ledger, &content).await,
         message: ChatMessage {
             id: Uuid::new_v4().to_string(),
-            conversation_id: ctx.conversation_id.clone(),
+            conversation_id: conversation_id.to_string(),
             role: "assistant".to_string(),
             content,
             created_at: Utc::now().to_rfc3339(),
             message_index: 0, // Set when saving
         },
-        tool_calls: ctx.tool_calls_record,
-        citations,
-    }
-}
-
-#[allow(clippy::too_many_arguments)] // Internal loop entry; each argument is a distinct context channel.
-async fn run_agent_loop(
-    on_event: ChatEventCallback,
-    storage: StorageBackend,
-    provider_config: ProviderConfig,
-    model: String,
-    mut ctx: AgentContext,
-    external_settings: Option<std::collections::HashMap<String, String>>,
-    inline_pipeline: bool,
-    page_context: Option<&PageContext>,
-    canvas_context: Option<&CanvasContext>,
-    canvas_cache: Option<&crate::CanvasCache>,
-    cancel: Option<ChatCancel>,
-) -> Result<ChatMessageWithContext, String> {
-    let provider = create_streaming_llm_provider(&provider_config)
-        .map_err(|e| format!("Failed to create streaming provider: {}", e))?;
-    let mut tools = get_tools();
-    if page_context.is_some() {
-        tools.extend(get_page_context_tools());
-    }
-    if canvas_context.is_some() {
-        tools.extend(get_canvas_tools());
-    }
-    let on_embedding_event: Arc<dyn Fn(EmbeddingEvent) + Send + Sync + 'static> = {
-        let on_event = Arc::clone(&on_event);
-        let conversation_id = ctx.conversation_id.clone();
-        Arc::new(move |event| {
-            on_event(ChatEvent::AtomPipelineEvent {
-                conversation_id: conversation_id.clone(),
-                event,
-            });
-        })
-    };
-    let config = LlmConfig::new(&model).with_params(
-        GenerationParams::new()
-            .with_temperature(0.7)
-            .with_max_tokens(4000),
-    );
-
-    // Every token the model streams this turn, across all iterations — the
-    // same text the UI has been rendering. Only used when the turn ends
-    // without a clean final answer (stopped, or out of tool-call budget).
-    let streamed = Arc::new(Mutex::new(String::new()));
-    let mut stopped = false;
-
-    for _iteration in 0..MAX_ITERATIONS {
-        if is_cancelled(&cancel) {
-            stopped = true;
-            break;
-        }
-
-        let on_delta = make_delta_callback(
-            Arc::clone(&on_event),
-            Arc::clone(&streamed),
-            ctx.conversation_id.clone(),
-            cancel.clone(),
-        );
-
-        // Truncate messages if they've grown beyond context window (from tool results)
-        let call_messages = truncate_messages_to_context(
-            ctx.messages.clone(),
-            provider_config.context_length_for_model(&model),
-        );
-
-        // Racing the request against the cancel flag drops the request future
-        // on cancel, which tears down the in-flight HTTP stream instead of
-        // paying for tokens nobody will read.
-        let response = tokio::select! {
-            biased;
-            result = provider.complete_streaming_with_tools(&call_messages, &tools, &config, on_delta) => {
-                match result {
-                    Ok(response) => response,
-                    Err(e) => {
-                        let error = format!("API request failed: {}", e);
-                        on_event(ChatEvent::Error {
-                            conversation_id: ctx.conversation_id.clone(),
-                            error: error.clone(),
-                        });
-                        return Err(error);
-                    }
-                }
-            }
-            _ = cancellation_raised(&cancel) => {
-                stopped = true;
-                break;
-            }
-        };
-
-        // Check if there are tool calls
-        if let Some(tool_calls) = &response.tool_calls {
-            // Add assistant message with tool calls to history
-            if response.content.is_empty() {
-                ctx.messages
-                    .push(Message::assistant_with_tool_calls(tool_calls.clone()));
-            } else {
-                let mut msg = Message::assistant(&response.content);
-                msg.tool_calls = Some(tool_calls.clone());
-                ctx.messages.push(msg);
-            }
-
-            // Execute each tool call
-            for tool_call in tool_calls {
-                if is_cancelled(&cancel) {
-                    stopped = true;
-                    break;
-                }
-                let tool_name = tool_call.get_name().unwrap_or_default();
-                let tool_args_str = tool_call.get_arguments().unwrap_or_default();
-                let tool_args: serde_json::Value =
-                    serde_json::from_str(tool_args_str).unwrap_or(serde_json::Value::Null);
-
-                // Emit tool start event
-                on_event(ChatEvent::ToolStart {
-                    conversation_id: ctx.conversation_id.clone(),
-                    tool_call_id: tool_call.id.clone(),
-                    tool_name: tool_name.to_string(),
-                    tool_input: tool_args.clone(),
-                });
-
-                // Execute tool
-                let outcome = match tool_name {
-                    "search_atoms" => {
-                        let query = tool_args["query"].as_str().unwrap_or("");
-                        let limit = tool_args["limit"].as_i64().unwrap_or(5) as i32;
-                        let since_days = tool_args
-                            .get("since_days")
-                            .and_then(|v| v.as_f64())
-                            .map(|v| v as i32)
-                            .filter(|d| *d > 0);
-                        match execute_search_atoms(
-                            &storage,
-                            query,
-                            limit,
-                            since_days,
-                            &ctx.scope_tag_ids,
-                            external_settings.clone(),
-                        )
-                        .await
-                        {
-                            Ok(results) => {
-                                let count = results.len() as i32;
-                                for result in results.iter() {
-                                    ctx.citations.push((
-                                        result.atom.atom.id.clone(),
-                                        Some(result.matching_chunk_index),
-                                        result.matching_chunk_content.chars().take(200).collect(),
-                                    ));
-                                }
-                                let result_text = results
-                                    .iter()
-                                    .enumerate()
-                                    .map(|(i, r)| {
-                                        format!(
-                                            "[{}] (atom_id: {}, similarity: {:.2})\n{}",
-                                            ctx.citations.len() - results.len() + i + 1,
-                                            r.atom.atom.id,
-                                            r.similarity_score,
-                                            r.matching_chunk_content
-                                        )
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join("\n\n");
-                                ToolOutcome::ok(result_text, count)
-                            }
-                            Err(e) => ToolOutcome::failed(e),
-                        }
-                    }
-                    "get_atom" => {
-                        let atom_id = tool_args["atom_id"].as_str().unwrap_or("");
-                        let offset = tool_args
-                            .get("offset")
-                            .and_then(|v| v.as_u64())
-                            .map(|v| v as usize)
-                            .unwrap_or(0);
-                        let limit = tool_args
-                            .get("limit")
-                            .and_then(|v| v.as_u64())
-                            .map(|v| (v as usize).clamp(1, GET_ATOM_MAX_LIMIT))
-                            .unwrap_or(GET_ATOM_DEFAULT_LIMIT);
-                        match execute_get_atom(&storage, atom_id, offset, limit).await {
-                            Ok(Some(content)) => {
-                                let citation_index = ctx.citations.len() + 1;
-                                ctx.citations.push((
-                                    atom_id.to_string(),
-                                    None,
-                                    content.chars().take(200).collect(),
-                                ));
-                                ToolOutcome::ok(
-                                    format!(
-                                        "[{}] (atom_id: {})\n{}",
-                                        citation_index, atom_id, content
-                                    ),
-                                    1,
-                                )
-                            }
-                            Ok(None) => ToolOutcome::ok("Atom not found", 0),
-                            Err(e) => ToolOutcome::failed(e),
-                        }
-                    }
-                    "get_current_page_context" => {
-                        match execute_get_current_page_context(&storage, page_context).await {
-                            Ok(Some(mut context)) => {
-                                let visible_atom_id = context
-                                    .get("visible_atom")
-                                    .and_then(|atom| atom.get("id"))
-                                    .and_then(|id| id.as_str())
-                                    .map(str::to_string);
-
-                                if let Some(atom_id) = visible_atom_id {
-                                    let excerpt: String = context
-                                        .get("visible_atom")
-                                        .and_then(|atom| atom.get("snippet"))
-                                        .and_then(|snippet| snippet.as_str())
-                                        .unwrap_or("")
-                                        .chars()
-                                        .take(200)
-                                        .collect();
-                                    if !excerpt.is_empty() {
-                                        let citation_index = ctx.citations.len() + 1;
-                                        ctx.citations.push((atom_id, None, excerpt));
-                                        if let Some(atom) = context
-                                            .get_mut("visible_atom")
-                                            .and_then(|atom| atom.as_object_mut())
-                                        {
-                                            atom.insert(
-                                                "citation_index".to_string(),
-                                                json!(citation_index),
-                                            );
-                                        }
-                                    }
-                                }
-
-                                ToolOutcome::ok(
-                                    serde_json::to_string_pretty(&context)
-                                        .unwrap_or_else(|_| context.to_string()),
-                                    1,
-                                )
-                            }
-                            Ok(None) => ToolOutcome::ok("No current page context was provided.", 0),
-                            Err(e) => ToolOutcome::failed(e),
-                        }
-                    }
-                    "create_atom" => {
-                        match execute_create_atom(
-                            &storage,
-                            &tool_args,
-                            external_settings.clone(),
-                            inline_pipeline,
-                            canvas_cache,
-                            Arc::clone(&on_embedding_event),
-                        )
-                        .await
-                        {
-                            Ok(atom) => {
-                                on_event(ChatEvent::AtomCreated {
-                                    conversation_id: ctx.conversation_id.clone(),
-                                    atom: atom.clone(),
-                                });
-                                ctx.citations.push((
-                                    atom.atom.id.clone(),
-                                    None,
-                                    atom.atom.snippet.chars().take(200).collect(),
-                                ));
-                                ToolOutcome::ok(
-                                    serde_json::to_string_pretty(&json!({
-                                        "atom_id": atom.atom.id,
-                                        "title": atom.atom.title,
-                                        "snippet": atom.atom.snippet,
-                                        "reference": format!("[[{}]]", atom.atom.id),
-                                    }))
-                                    .unwrap_or_else(|_| atom.atom.id),
-                                    1,
-                                )
-                            }
-                            Err(e) => ToolOutcome::failed(e),
-                        }
-                    }
-                    "edit_atom" => {
-                        match execute_edit_atom(
-                            &storage,
-                            &tool_args,
-                            external_settings.clone(),
-                            inline_pipeline,
-                            canvas_cache,
-                            Arc::clone(&on_embedding_event),
-                        )
-                        .await
-                        {
-                            Ok(Some(atom)) => {
-                                on_event(ChatEvent::AtomUpdated {
-                                    conversation_id: ctx.conversation_id.clone(),
-                                    atom: atom.clone(),
-                                });
-                                ctx.citations.push((
-                                    atom.atom.id.clone(),
-                                    None,
-                                    atom.atom.snippet.chars().take(200).collect(),
-                                ));
-                                ToolOutcome::ok(
-                                    serde_json::to_string_pretty(&json!({
-                                        "atom_id": atom.atom.id,
-                                        "title": atom.atom.title,
-                                        "snippet": atom.atom.snippet,
-                                        "reference": format!("[[{}]]", atom.atom.id),
-                                    }))
-                                    .unwrap_or_else(|_| atom.atom.id),
-                                    1,
-                                )
-                            }
-                            Ok(None) => ToolOutcome::ok("Atom not found", 0),
-                            Err(e) => ToolOutcome::failed(e),
-                        }
-                    }
-                    "zoom_to_cluster" => {
-                        let cluster_label = tool_args["cluster_label"].as_str().unwrap_or("");
-                        on_event(ChatEvent::CanvasAction {
-                            conversation_id: ctx.conversation_id.clone(),
-                            action: "zoom_to_cluster".to_string(),
-                            params: json!({ "cluster_label": cluster_label }),
-                        });
-                        ToolOutcome::ok(format!("Zoomed canvas to cluster '{}'", cluster_label), 1)
-                    }
-                    "focus_atom" => {
-                        let atom_id = tool_args["atom_id"].as_str().unwrap_or("");
-                        on_event(ChatEvent::CanvasAction {
-                            conversation_id: ctx.conversation_id.clone(),
-                            action: "focus_atom".to_string(),
-                            params: json!({ "atom_id": atom_id }),
-                        });
-                        ToolOutcome::ok(format!("Focused canvas on atom '{}'", atom_id), 1)
-                    }
-                    // The model asked for a tool this build doesn't have —
-                    // a failed call, not an empty result.
-                    _ => ToolOutcome::failed(format!("Unknown tool: {}", tool_name)),
-                };
-
-                // Record tool call
-                ctx.tool_calls_record.push(ChatToolCall {
-                    id: tool_call.id.clone(),
-                    message_id: String::new(), // Set when saving
-                    tool_name: tool_name.to_string(),
-                    tool_input: tool_args,
-                    tool_output: Some(serde_json::Value::String(outcome.output.clone())),
-                    status: if outcome.failed {
-                        "failed".to_string()
-                    } else {
-                        "complete".to_string()
-                    },
-                    created_at: Utc::now().to_rfc3339(),
-                    completed_at: Some(Utc::now().to_rfc3339()),
-                });
-
-                // Emit tool complete event
-                on_event(ChatEvent::ToolComplete {
-                    conversation_id: ctx.conversation_id.clone(),
-                    tool_call_id: tool_call.id.clone(),
-                    results_count: outcome.results_count,
-                    failed: outcome.failed,
-                });
-
-                // Add tool result to messages
-                ctx.messages
-                    .push(Message::tool_result(&tool_call.id, outcome.output));
-            }
-
-            if stopped {
-                break;
-            }
-        } else {
-            // No tool calls - we have the final answer
-            return Ok(build_result(ctx, response.content));
-        }
-    }
-
-    let partial = streamed.lock().map(|text| text.clone()).unwrap_or_default();
-
-    if stopped {
-        return Ok(build_result(ctx, with_note(&partial, STOPPED_MARKER)));
-    }
-
-    // Out of tool-call budget. Salvage rather than discard: whatever the model
-    // already said stands as the answer, and when it said nothing at all we
-    // spend one more call — without tools, so it has to answer in prose from
-    // the context it gathered.
-    let salvaged = if partial.trim().is_empty() {
-        let call_messages = truncate_messages_to_context(
-            ctx.messages.clone(),
-            provider_config.context_length_for_model(&model),
-        );
-        let on_delta = make_delta_callback(
-            Arc::clone(&on_event),
-            Arc::clone(&streamed),
-            ctx.conversation_id.clone(),
-            cancel.clone(),
-        );
-        match provider
-            .complete_streaming_with_tools(&call_messages, &[], &config, on_delta)
-            .await
-        {
-            Ok(response) => response.content,
-            Err(e) => {
-                tracing::warn!(error = %e, "chat: iteration-cap salvage completion failed");
-                String::new()
-            }
-        }
-    } else {
-        partial
+        tool_calls: to_chat_tool_calls(outcome.tool_calls),
     };
 
-    Ok(build_result(ctx, with_note(&salvaged, ITERATION_CAP_NOTE)))
+    finish_turn(
+        &storage,
+        conversation_id,
+        &mut result,
+        &on_event,
+        title_settings,
+    )
+    .await?;
+
+    Ok(result)
 }
 
-/// Build the provider stream callback: forward every chunk to the UI as it
-/// arrives and keep a copy for the salvage paths.
-fn make_delta_callback(
-    on_event: ChatEventCallback,
-    streamed: Arc<Mutex<String>>,
-    conversation_id: String,
-    cancel: Option<ChatCancel>,
-) -> crate::providers::traits::StreamCallback {
-    Box::new(move |delta: StreamDelta| {
-        let StreamDelta::Content(text) = delta else {
-            return;
-        };
-        if text.is_empty() || is_cancelled(&cancel) {
-            return;
-        }
-        if let Ok(mut accumulated) = streamed.lock() {
-            accumulated.push_str(&text);
-        }
-        on_event(ChatEvent::StreamDelta {
-            conversation_id: conversation_id.clone(),
-            content: text,
-        });
-    })
+/// Persist the assistant turn, tell the caller it landed, and name the
+/// conversation if it still has no title.
+///
+/// The tail of a turn is identical whatever context went into it, and the
+/// title hook has to hang off every path a first exchange can take.
+/// `title_settings` is `None` when the conversation was already titled when
+/// the turn started.
+async fn finish_turn(
+    storage: &StorageBackend,
+    conversation_id: &str,
+    result: &mut ChatMessageWithContext,
+    on_event: &ChatEventCallback,
+    title_settings: Option<HashMap<String, String>>,
+) -> Result<(), String> {
+    let saved_msg = storage
+        .save_message_sync(conversation_id, "assistant", &result.message.content)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    result.message.id = saved_msg.id.clone();
+    result.message.message_index = saved_msg.message_index;
+
+    for tool_call in &mut result.tool_calls {
+        tool_call.message_id = saved_msg.id.clone();
+    }
+    storage
+        .save_tool_calls_sync(&saved_msg.id, &result.tool_calls)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    for citation in &mut result.citations {
+        citation.message_id = saved_msg.id.clone();
+    }
+    storage
+        .save_citations_sync(&saved_msg.id, &result.citations)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    on_event(ChatEvent::Complete {
+        conversation_id: conversation_id.to_string(),
+        message: result.clone(),
+    });
+
+    if let Some(settings) = title_settings {
+        crate::chat_title::spawn_generation(
+            storage.clone(),
+            settings,
+            conversation_id.to_string(),
+            Arc::clone(on_event),
+        );
+    }
+
+    Ok(())
 }
 
 // ==================== Public API ====================
@@ -1522,191 +635,24 @@ pub async fn send_chat_message_with_settings<F>(
     conversation_id: &str,
     content: &str,
     on_event: F,
-    external_settings: Option<std::collections::HashMap<String, String>>,
+    external_settings: Option<HashMap<String, String>>,
     inline_pipeline: bool,
     cancel: Option<ChatCancel>,
 ) -> Result<ChatMessageWithContext, String>
 where
     F: Fn(ChatEvent) + Send + Sync + 'static,
 {
-    let on_event: ChatEventCallback = Arc::new(on_event);
-
-    // Resolve settings (from the caller's resolved map if provided,
-    // otherwise the storage layer's global tier — provider config is
-    // deployment-wide)
-    let settings_map = match external_settings {
-        Some(s) => s,
-        None => storage
-            .get_global_settings_sync()
-            .await
-            .map_err(|e| e.to_string())?,
-    };
-
-    // Get provider config and model from settings
-    let (provider_config, model) = {
-        let provider_config = ProviderConfig::from_settings(&settings_map);
-
-        if provider_config.provider_type == ProviderType::OpenRouter
-            && provider_config.openrouter_api_key.is_none()
-        {
-            return Err(
-                "OpenRouter API key not configured. Please set it in Settings.".to_string(),
-            );
-        }
-
-        let model = match provider_config.provider_type {
-            ProviderType::Ollama => provider_config.llm_model().to_string(),
-            ProviderType::OpenAICompat => provider_config.llm_model().to_string(),
-            ProviderType::OpenRouter => settings_map
-                .get("chat_model")
-                .cloned()
-                .unwrap_or_else(|| crate::providers::DEFAULT_AGENTIC_MODEL.to_string()),
-        };
-
-        (provider_config, model)
-    };
-
-    // Save user message
-    storage
-        .save_message_sync(conversation_id, "user", content)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    // Get conversation context
-    let scope_tag_ids = storage
-        .get_scope_tag_ids_sync(conversation_id)
-        .await
-        .map_err(|e| e.to_string())?;
-    let scope_description = storage
-        .get_scope_description_sync(&scope_tag_ids)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    // Get conversation messages via get_conversation_sync and convert to provider format
-    let conversation = storage
-        .get_conversation_sync(conversation_id)
-        .await
-        .map_err(|e| e.to_string())?;
-    // A conversation with no title yet is a candidate for one once this turn
-    // lands; anything already titled skips the work entirely.
-    let (messages, untitled) = match conversation {
-        Some(conv) => (
-            chat_messages_to_provider_messages(conv.messages),
-            conv.conversation.title.is_none(),
-        ),
-        None => (Vec::new(), false),
-    };
-
-    // Build message history for API
-    let custom_chat_prefix = settings_map
-        .get("chat_prompt")
-        .filter(|s| !s.is_empty())
-        .map(|s| s.as_str());
-    let base_system = get_system_prompt(&scope_description);
-    let system_prompt = match custom_chat_prefix {
-        Some(prefix) => format!("{prefix}\n\n{base_system}"),
-        None => base_system,
-    };
-    let mut api_messages = vec![Message::system(system_prompt)];
-    api_messages.extend(messages);
-
-    // Truncate to fit context window for providers with limited context
-    let api_messages = truncate_messages_to_context(
-        api_messages,
-        provider_config.context_length_for_model(&model),
-    );
-
-    // Create agent context
-    let ctx = AgentContext {
-        conversation_id: conversation_id.to_string(),
-        scope_tag_ids,
-        messages: api_messages,
-        citations: Vec::new(),
-        tool_calls_record: Vec::new(),
-    };
-
-    // Run agent loop (storage is Clone, so no separate connection needed)
-    let title_settings = untitled.then(|| settings_map.clone());
-    let mut result = run_agent_loop(
-        Arc::clone(&on_event),
-        storage.clone(),
-        provider_config,
-        model,
-        ctx,
-        Some(settings_map),
+    send_turn(
+        storage,
+        conversation_id,
+        content,
+        Arc::new(on_event),
+        external_settings,
         inline_pipeline,
-        None,
-        None,
-        None,
+        TurnContext::default(),
         cancel,
     )
-    .await?;
-
-    finish_turn(
-        &storage,
-        conversation_id,
-        &mut result,
-        &on_event,
-        title_settings,
-    )
-    .await?;
-
-    Ok(result)
-}
-
-/// Persist the assistant turn, tell the caller it landed, and name the
-/// conversation if it still has no title.
-///
-/// Shared by both public entrypoints: the tail of a turn is identical
-/// whatever context went into it, and the title hook has to hang off every
-/// path a first exchange can take. `title_settings` is `None` when the
-/// conversation was already titled when the turn started.
-async fn finish_turn(
-    storage: &StorageBackend,
-    conversation_id: &str,
-    result: &mut ChatMessageWithContext,
-    on_event: &ChatEventCallback,
-    title_settings: Option<std::collections::HashMap<String, String>>,
-) -> Result<(), String> {
-    let saved_msg = storage
-        .save_message_sync(conversation_id, "assistant", &result.message.content)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    result.message.id = saved_msg.id.clone();
-    result.message.message_index = saved_msg.message_index;
-
-    for tool_call in &mut result.tool_calls {
-        tool_call.message_id = saved_msg.id.clone();
-    }
-    storage
-        .save_tool_calls_sync(&saved_msg.id, &result.tool_calls)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    for citation in &mut result.citations {
-        citation.message_id = saved_msg.id.clone();
-    }
-    storage
-        .save_citations_sync(&saved_msg.id, &result.citations)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    on_event(ChatEvent::Complete {
-        conversation_id: conversation_id.to_string(),
-        message: result.clone(),
-    });
-
-    if let Some(settings) = title_settings {
-        crate::chat_title::spawn_generation(
-            storage.clone(),
-            settings,
-            conversation_id.to_string(),
-            Arc::clone(on_event),
-        );
-    }
-
-    Ok(())
+    .await
 }
 
 /// Like `send_chat_message_with_settings` but with optional UI context for
@@ -1717,7 +663,7 @@ pub async fn send_chat_message_with_canvas<F>(
     conversation_id: &str,
     content: &str,
     on_event: F,
-    external_settings: Option<std::collections::HashMap<String, String>>,
+    external_settings: Option<HashMap<String, String>>,
     inline_pipeline: bool,
     canvas_context: Option<CanvasContext>,
     page_context: Option<PageContext>,
@@ -1727,133 +673,19 @@ pub async fn send_chat_message_with_canvas<F>(
 where
     F: Fn(ChatEvent) + Send + Sync + 'static,
 {
-    let on_event: ChatEventCallback = Arc::new(on_event);
-
-    // Resolve settings (from the caller's resolved map if provided,
-    // otherwise the storage layer's global tier — provider config is
-    // deployment-wide)
-    let settings_map = match external_settings {
-        Some(s) => s,
-        None => storage
-            .get_global_settings_sync()
-            .await
-            .map_err(|e| e.to_string())?,
-    };
-
-    // Get provider config and model from settings
-    let (provider_config, model) = {
-        let provider_config = ProviderConfig::from_settings(&settings_map);
-
-        if provider_config.provider_type == ProviderType::OpenRouter
-            && provider_config.openrouter_api_key.is_none()
-        {
-            return Err(
-                "OpenRouter API key not configured. Please set it in Settings.".to_string(),
-            );
-        }
-
-        let model = match provider_config.provider_type {
-            ProviderType::Ollama => provider_config.llm_model().to_string(),
-            ProviderType::OpenAICompat => provider_config.llm_model().to_string(),
-            ProviderType::OpenRouter => settings_map
-                .get("chat_model")
-                .cloned()
-                .unwrap_or_else(|| crate::providers::DEFAULT_AGENTIC_MODEL.to_string()),
-        };
-
-        (provider_config, model)
-    };
-
-    // Save user message
-    storage
-        .save_message_sync(conversation_id, "user", content)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    // Get conversation context
-    let scope_tag_ids = storage
-        .get_scope_tag_ids_sync(conversation_id)
-        .await
-        .map_err(|e| e.to_string())?;
-    let scope_description = storage
-        .get_scope_description_sync(&scope_tag_ids)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    // Get conversation messages via get_conversation_sync and convert to provider format
-    let conversation = storage
-        .get_conversation_sync(conversation_id)
-        .await
-        .map_err(|e| e.to_string())?;
-    // A conversation with no title yet is a candidate for one once this turn
-    // lands; anything already titled skips the work entirely.
-    let (messages, untitled) = match conversation {
-        Some(conv) => (
-            chat_messages_to_provider_messages(conv.messages),
-            conv.conversation.title.is_none(),
-        ),
-        None => (Vec::new(), false),
-    };
-
-    // Build message history for API, with canvas context appended to system prompt
-    let custom_chat_prefix = settings_map
-        .get("chat_prompt")
-        .filter(|s| !s.is_empty())
-        .map(|s| s.as_str());
-    let base_system = get_system_prompt(&scope_description);
-    let mut system_prompt = match custom_chat_prefix {
-        Some(prefix) => format!("{prefix}\n\n{base_system}"),
-        None => base_system,
-    };
-    if page_context.is_some() {
-        system_prompt.push_str(get_page_context_system_prompt());
-    }
-    if let Some(ref ctx) = canvas_context {
-        system_prompt.push_str(&get_canvas_system_prompt(ctx));
-    }
-    let mut api_messages = vec![Message::system(system_prompt)];
-    api_messages.extend(messages);
-
-    // Truncate to fit context window for providers with limited context
-    let api_messages = truncate_messages_to_context(
-        api_messages,
-        provider_config.context_length_for_model(&model),
-    );
-
-    // Create agent context
-    let ctx = AgentContext {
-        conversation_id: conversation_id.to_string(),
-        scope_tag_ids,
-        messages: api_messages,
-        citations: Vec::new(),
-        tool_calls_record: Vec::new(),
-    };
-
-    // Run agent loop with canvas context
-    let title_settings = untitled.then(|| settings_map.clone());
-    let mut result = run_agent_loop(
-        Arc::clone(&on_event),
-        storage.clone(),
-        provider_config,
-        model,
-        ctx,
-        Some(settings_map),
+    send_turn(
+        storage,
+        conversation_id,
+        content,
+        Arc::new(on_event),
+        external_settings,
         inline_pipeline,
-        page_context.as_ref(),
-        canvas_context.as_ref(),
-        canvas_cache.as_ref(),
+        TurnContext {
+            page: page_context,
+            canvas: canvas_context,
+            canvas_cache,
+        },
         cancel,
     )
-    .await?;
-
-    finish_turn(
-        &storage,
-        conversation_id,
-        &mut result,
-        &on_event,
-        title_settings,
-    )
-    .await?;
-
-    Ok(result)
+    .await
 }

--- a/crates/atomic-core/src/agent_runtime/citations.rs
+++ b/crates/atomic-core/src/agent_runtime/citations.rs
@@ -1,0 +1,325 @@
+//! Numbered citation ledger — the runtime's single citation system.
+//!
+//! The contract (ported from the reports agent, now shared by every run):
+//! a tool registers the evidence it surfaces and gets a number back, the
+//! tool's own output shows the model that number, and the `[N]` markers in
+//! the run's final text decide which citables are actually stored. Evidence
+//! the model never cites leaves no trace, so a Sources list says what an
+//! answer rests on instead of logging everything the agent touched.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use regex::Regex;
+
+/// What a citation points at. The variant decides how `source_id` is read,
+/// both here and in the `chat_citations.source_type` column it is stored as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CitationSource {
+    /// An atom — `source_id` is the atom id.
+    Atom,
+    /// A wiki article — `source_id` is the *tag* id the article belongs to,
+    /// which is how wiki articles are addressed everywhere else.
+    Wiki,
+    /// A report finding — `source_id` is the finding atom's id. Distinct
+    /// from [`CitationSource::Atom`] because a finding opens in its own
+    /// reader, not the atom reader.
+    Finding,
+}
+
+impl CitationSource {
+    /// Stable name for storage and the wire. Kept explicit (rather than
+    /// derived from the variant) because it becomes a persisted column
+    /// value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CitationSource::Atom => "atom",
+            CitationSource::Wiki => "wiki",
+            CitationSource::Finding => "finding",
+        }
+    }
+}
+
+/// One numbered piece of evidence the model was shown and may cite.
+#[derive(Debug, Clone)]
+pub struct Citable {
+    /// The `[N]` the model must use to cite this.
+    pub number: i32,
+    pub source: CitationSource,
+    /// Id of the cited thing, interpreted per [`CitationSource`].
+    pub source_id: String,
+    /// Which chunk of the source matched, when the tool knows.
+    pub chunk_index: Option<i32>,
+    pub excerpt: String,
+}
+
+/// Whether tools may mint new citation numbers while a run is in flight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CitationAdmission {
+    /// Anything a tool surfaces becomes citable (chat).
+    Open,
+    /// Only evidence seeded before the run starts is citable. Tools may
+    /// still surface other material, but it gets no number and must be
+    /// presented as background the model can read and not cite (reports'
+    /// `source_only` policy).
+    SeededOnly,
+}
+
+/// The run's citable-evidence map: `(source, source_id)` → number, plus the
+/// `[N]` resolution that turns a finished answer into stored citations.
+///
+/// Shared immutably with tools (`&CitationLedger` on the tool context), so
+/// numbering is behind a lock rather than `&mut`.
+pub struct CitationLedger {
+    admission: CitationAdmission,
+    inner: Mutex<LedgerInner>,
+}
+
+#[derive(Default)]
+struct LedgerInner {
+    by_key: HashMap<(CitationSource, String), Citable>,
+    next_number: i32,
+}
+
+impl CitationLedger {
+    pub fn new(admission: CitationAdmission) -> Self {
+        Self {
+            admission,
+            inner: Mutex::new(LedgerInner {
+                by_key: HashMap::new(),
+                next_number: 1,
+            }),
+        }
+    }
+
+    /// Number a piece of evidence up front, bypassing admission — the
+    /// pre-run source list a `SeededOnly` run is allowed to cite.
+    pub fn seed(
+        &self,
+        source: CitationSource,
+        source_id: &str,
+        chunk_index: Option<i32>,
+        excerpt: impl Into<String>,
+    ) -> i32 {
+        self.insert(source, source_id, chunk_index, excerpt, true)
+            .expect("seeding always admits")
+    }
+
+    /// Number evidence a tool just surfaced, reusing the number when this
+    /// source has been seen before. `None` means the run's admission policy
+    /// refuses new evidence, and the tool must present it as uncitable
+    /// background.
+    pub fn register(
+        &self,
+        source: CitationSource,
+        source_id: &str,
+        chunk_index: Option<i32>,
+        excerpt: impl Into<String>,
+    ) -> Option<i32> {
+        self.insert(
+            source,
+            source_id,
+            chunk_index,
+            excerpt,
+            self.admission == CitationAdmission::Open,
+        )
+    }
+
+    fn insert(
+        &self,
+        source: CitationSource,
+        source_id: &str,
+        chunk_index: Option<i32>,
+        excerpt: impl Into<String>,
+        admit: bool,
+    ) -> Option<i32> {
+        let mut inner = self.lock();
+        let key = (source, source_id.to_string());
+        // First sighting wins: the excerpt the model was shown alongside the
+        // number is the one a reader should get back.
+        if let Some(existing) = inner.by_key.get(&key) {
+            return Some(existing.number);
+        }
+        if !admit {
+            return None;
+        }
+        let number = inner.next_number;
+        inner.next_number += 1;
+        inner.by_key.insert(
+            key,
+            Citable {
+                number,
+                source,
+                source_id: source_id.to_string(),
+                chunk_index,
+                excerpt: excerpt.into(),
+            },
+        );
+        Some(number)
+    }
+
+    /// The citables named by `[N]` markers in `text`, in the order the
+    /// markers appear.
+    ///
+    /// The parsing contract, which every consumer of stored citations
+    /// depends on:
+    /// - A citation's stored index is the **marker number N**, not its
+    ///   position in the text. Readers render `[N]` and look the citation
+    ///   up by that same N, so `[3]` before `[1]` must not renumber.
+    /// - Repeated markers collapse to one citable — one row per marker,
+    ///   however many times the model wrote it.
+    /// - Markers with no matching citable are dropped with a warning: the
+    ///   model invented a number, and a dangling citation is worse than a
+    ///   missing one.
+    pub fn cited_in(&self, text: &str) -> Vec<Citable> {
+        static MARKER: OnceLock<Option<Regex>> = OnceLock::new();
+        let Some(marker) = MARKER
+            .get_or_init(|| Regex::new(r"\[(\d+)\]").ok())
+            .as_ref()
+        else {
+            tracing::error!("[agent_runtime] citation marker regex failed to compile");
+            return Vec::new();
+        };
+
+        let by_number = self.by_number();
+        let mut seen: HashSet<i32> = HashSet::new();
+        let mut cited = Vec::new();
+        for capture in marker.captures_iter(text) {
+            let Some(digits) = capture.get(1) else {
+                continue;
+            };
+            let Ok(number) = digits.as_str().parse::<i32>() else {
+                continue;
+            };
+            if !seen.insert(number) {
+                continue;
+            }
+            match by_number.get(&number) {
+                Some(citable) => cited.push(citable.clone()),
+                None => tracing::warn!(
+                    citation_number = number,
+                    "[agent_runtime] agent cited an unknown number; dropping"
+                ),
+            }
+        }
+        cited
+    }
+
+    /// The citables named by an explicit list of numbers — the
+    /// `CITATIONS_USED:` trailer of the long-form markdown contract.
+    /// Unknown numbers are dropped, same as [`Self::cited_in`].
+    pub fn resolve(&self, numbers: &[i32]) -> Vec<Citable> {
+        let by_number = self.by_number();
+        let mut seen: HashSet<i32> = HashSet::new();
+        numbers
+            .iter()
+            .filter(|number| seen.insert(**number))
+            .filter_map(|number| by_number.get(number).cloned())
+            .collect()
+    }
+
+    /// Every citable registered so far, ordered by number.
+    pub fn snapshot(&self) -> Vec<Citable> {
+        let mut all: Vec<Citable> = self.lock().by_key.values().cloned().collect();
+        all.sort_by_key(|citable| citable.number);
+        all
+    }
+
+    fn by_number(&self) -> HashMap<i32, Citable> {
+        self.lock()
+            .by_key
+            .values()
+            .map(|citable| (citable.number, citable.clone()))
+            .collect()
+    }
+
+    /// A panic while a tool held the ledger must not poison the rest of the
+    /// turn: the map is append-only, so whatever landed before the panic is
+    /// still coherent.
+    fn lock(&self) -> MutexGuard<'_, LedgerInner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open() -> CitationLedger {
+        CitationLedger::new(CitationAdmission::Open)
+    }
+
+    #[test]
+    fn numbers_are_assigned_on_first_sighting_and_reused() {
+        let ledger = open();
+        assert_eq!(
+            ledger.register(CitationSource::Atom, "a1", Some(0), "first"),
+            Some(1)
+        );
+        assert_eq!(
+            ledger.register(CitationSource::Atom, "a2", None, "second"),
+            Some(2)
+        );
+        // Same source again — same number, original excerpt.
+        assert_eq!(
+            ledger.register(CitationSource::Atom, "a1", None, "rewritten"),
+            Some(1)
+        );
+        let snapshot = ledger.snapshot();
+        assert_eq!(snapshot.len(), 2);
+        assert_eq!(snapshot[0].excerpt, "first");
+    }
+
+    #[test]
+    fn seeded_only_refuses_evidence_the_run_did_not_start_with() {
+        let ledger = CitationLedger::new(CitationAdmission::SeededOnly);
+        assert_eq!(ledger.seed(CitationSource::Atom, "a1", None, "source"), 1);
+        assert_eq!(
+            ledger.register(CitationSource::Atom, "a1", None, "source"),
+            Some(1),
+            "seeded evidence stays citable"
+        );
+        assert_eq!(
+            ledger.register(CitationSource::Atom, "a2", None, "context"),
+            None,
+            "new evidence is background only"
+        );
+        assert_eq!(ledger.snapshot().len(), 1);
+    }
+
+    #[test]
+    fn only_cited_numbers_are_returned_and_markers_keep_their_number() {
+        let ledger = open();
+        for id in ["a1", "a2", "a3"] {
+            ledger.register(CitationSource::Atom, id, None, id);
+        }
+        // Out of sequence, one marker repeated, one never cited.
+        let cited = ledger.cited_in("First [3]. Then [1]. Again [1].");
+        assert_eq!(cited.len(), 2);
+        assert_eq!(cited[0].number, 3);
+        assert_eq!(cited[0].source_id, "a3");
+        assert_eq!(cited[1].number, 1);
+        assert_eq!(cited[1].source_id, "a1");
+    }
+
+    #[test]
+    fn invented_markers_are_dropped() {
+        let ledger = open();
+        ledger.register(CitationSource::Atom, "a1", None, "only source");
+        let cited = ledger.cited_in("Real [1]. Hallucinated [9].");
+        assert_eq!(cited.len(), 1);
+        assert_eq!(cited[0].source_id, "a1");
+    }
+
+    #[test]
+    fn resolve_maps_an_explicit_trailer_list() {
+        let ledger = open();
+        ledger.register(CitationSource::Atom, "a1", None, "one");
+        ledger.register(CitationSource::Atom, "a2", None, "two");
+        let cited = ledger.resolve(&[2, 2, 7]);
+        assert_eq!(cited.len(), 1);
+        assert_eq!(cited[0].source_id, "a2");
+    }
+}

--- a/crates/atomic-core/src/agent_runtime/context.rs
+++ b/crates/atomic-core/src/agent_runtime/context.rs
@@ -1,0 +1,130 @@
+//! Context-window management for the agent loop.
+//!
+//! Tool results make a run's prompt grow without bound, so every call is
+//! trimmed to what the model can actually hold. Trimming works on groups —
+//! an assistant message and the tool results answering it are one unit,
+//! because splitting them produces an API-invalid request.
+
+use crate::chunking::count_tokens;
+use crate::providers::types::{Message, MessageRole};
+
+/// Estimate token count for a message, including tool call content.
+fn estimate_message_tokens(m: &Message) -> usize {
+    let content_tokens = count_tokens(m.content.as_deref().unwrap_or(""));
+    let tool_call_tokens = m.tool_calls.as_ref().map_or(0, |tcs| {
+        tcs.iter()
+            .map(|tc| {
+                let args = tc.get_arguments().unwrap_or("");
+                let name = tc.get_name().unwrap_or("");
+                count_tokens(name) + count_tokens(args) + 10
+            })
+            .sum()
+    });
+    content_tokens + tool_call_tokens
+}
+
+/// A group of messages that must be kept together for API validity.
+/// Either a single user/system message, or an assistant message followed
+/// by its tool-result messages.
+struct MessageGroup {
+    start: usize,
+    end: usize, // exclusive
+    tokens: usize,
+}
+
+/// Group messages into atomic units that can't be split.
+/// An assistant message with tool_calls and its subsequent tool-result messages
+/// form one group. Everything else is its own group.
+fn group_messages(messages: &[Message], message_tokens: &[usize]) -> Vec<MessageGroup> {
+    let mut groups = Vec::new();
+    let mut i = 0;
+    while i < messages.len() {
+        if messages[i].role == MessageRole::Assistant && messages[i].tool_calls.is_some() {
+            // Start of a tool round: assistant + following tool results
+            let start = i;
+            let mut tokens = message_tokens[i];
+            i += 1;
+            while i < messages.len() && messages[i].role == MessageRole::Tool {
+                tokens += message_tokens[i];
+                i += 1;
+            }
+            groups.push(MessageGroup {
+                start,
+                end: i,
+                tokens,
+            });
+        } else {
+            groups.push(MessageGroup {
+                start: i,
+                end: i + 1,
+                tokens: message_tokens[i],
+            });
+            i += 1;
+        }
+    }
+    groups
+}
+
+/// Truncate message history to fit within the provider's context window.
+/// Keeps the system prompt (first group) and the most recent group,
+/// then includes as many recent groups as fit in the remaining budget.
+/// Never splits assistant+tool-result pairs to maintain API validity.
+/// Reserves ~30% of context for the assistant's response and tool results.
+///
+/// `context_length` of `None` — an unknown model, or a caller that opts out
+/// — returns the history untouched.
+pub fn truncate_messages_to_context(
+    messages: Vec<Message>,
+    context_length: Option<usize>,
+) -> Vec<Message> {
+    let max_tokens = match context_length {
+        Some(ctx_len) => (ctx_len as f64 * 0.7) as usize,
+        None => return messages,
+    };
+
+    if messages.len() <= 2 {
+        return messages;
+    }
+
+    let message_tokens: Vec<usize> = messages.iter().map(estimate_message_tokens).collect();
+    let total: usize = message_tokens.iter().sum();
+    if total <= max_tokens {
+        return messages;
+    }
+
+    let groups = group_messages(&messages, &message_tokens);
+    if groups.len() <= 2 {
+        return messages; // System + one group, nothing safe to drop
+    }
+
+    // Always keep first group (system) and last group (most recent)
+    let first_tokens = groups[0].tokens;
+    let last_tokens = groups[groups.len() - 1].tokens;
+    let mut budget = max_tokens.saturating_sub(first_tokens + last_tokens);
+
+    // Work backwards through middle groups, keeping as many as fit
+    let mut keep_from_group = groups.len() - 1;
+    for gi in (1..groups.len() - 1).rev() {
+        if groups[gi].tokens > budget {
+            break;
+        }
+        budget -= groups[gi].tokens;
+        keep_from_group = gi;
+    }
+
+    // Build result from kept groups
+    let mut result: Vec<Message> = messages[groups[0].start..groups[0].end].to_vec();
+    for g in &groups[keep_from_group..] {
+        result.extend(messages[g.start..g.end].to_vec());
+    }
+
+    tracing::info!(
+        original_messages = messages.len(),
+        truncated_messages = result.len(),
+        groups_kept = groups.len() - keep_from_group + 1,
+        max_tokens,
+        "[agent_runtime] Truncated message history to fit context window"
+    );
+
+    result
+}

--- a/crates/atomic-core/src/agent_runtime/mod.rs
+++ b/crates/atomic-core/src/agent_runtime/mod.rs
@@ -1,0 +1,29 @@
+//! The agent runtime: one tool-calling loop, one citation system, shared by
+//! every agentic surface in Atomic.
+//!
+//! A caller assembles three things and runs them:
+//!
+//! - a [`ToolRegistry`] — the capabilities this run has, registered
+//!   conditionally rather than branched on inside a dispatch match;
+//! - a [`CitationLedger`] — numbered evidence, where tools register what
+//!   they surface and the final text's `[N]` markers decide what is stored;
+//! - a [`RunConfig`] — model, budget, termination mode, and whether text
+//!   streams back as it is produced.
+//!
+//! The runtime knows nothing about transports or storage. Progress leaves it
+//! through a [`RunEventSink`] callback (the pattern `EmbeddingEvent` uses),
+//! and hosts map those events onto their own systems — `ChatEvent` for chat,
+//! nothing at all for a scheduled report.
+
+pub mod citations;
+mod context;
+pub mod run;
+pub mod tools;
+
+pub use citations::{Citable, CitationAdmission, CitationLedger, CitationSource};
+pub use context::truncate_messages_to_context;
+pub use run::{
+    AgentRun, CancelFlag, RunConfig, RunError, RunEvent, RunEventSink, RunOutcome, StopReason,
+    Termination, ToolCallRecord,
+};
+pub use tools::{AgentTool, ToolContext, ToolRegistry, ToolResult};

--- a/crates/atomic-core/src/agent_runtime/mod.rs
+++ b/crates/atomic-core/src/agent_runtime/mod.rs
@@ -23,7 +23,7 @@ pub mod tools;
 pub use citations::{Citable, CitationAdmission, CitationLedger, CitationSource};
 pub use context::truncate_messages_to_context;
 pub use run::{
-    AgentRun, CancelFlag, RunConfig, RunError, RunEvent, RunEventSink, RunOutcome, StopReason,
-    Termination, ToolCallRecord,
+    messages_are_balanced, AgentRun, CancelFlag, RunConfig, RunError, RunEvent, RunEventSink,
+    RunOutcome, StopReason, Termination, ToolCallRecord,
 };
 pub use tools::{AgentTool, ToolContext, ToolRegistry, ToolResult};

--- a/crates/atomic-core/src/agent_runtime/run.rs
+++ b/crates/atomic-core/src/agent_runtime/run.rs
@@ -129,6 +129,16 @@ pub struct RunOutcome {
     pub content: String,
     /// The full message history including every tool round — the input to a
     /// caller's final pass.
+    ///
+    /// **Balanced only when the run wasn't cancelled.** The loop checks its
+    /// cancel flag between tool executions, so a cancel landing partway
+    /// through a round leaves an assistant message requesting N tool calls
+    /// followed by fewer than N `tool` results. Providers reject that history:
+    /// every `tool_calls` entry must be answered. Callers that replay these
+    /// messages — a final synthesis pass, a resumed run — must therefore skip
+    /// [`StopReason::Cancelled`] outcomes, or balance the history themselves
+    /// with [`messages_are_balanced`]. Chat doesn't replay them at all, and
+    /// reports pass no cancel flag, which is why nothing does today.
     pub messages: Vec<Message>,
     /// Every tool call made, in order.
     pub tool_calls: Vec<ToolCallRecord>,
@@ -322,6 +332,10 @@ impl AgentRun<'_> {
             };
         }
 
+        debug_assert!(
+            stop == StopReason::Cancelled || messages_are_balanced(&messages),
+            "a run that wasn't cancelled must leave every requested tool call answered"
+        );
         Ok(RunOutcome {
             content,
             messages,
@@ -329,6 +343,21 @@ impl AgentRun<'_> {
             stop,
         })
     }
+}
+
+/// Whether every tool call requested in `messages` has a matching `tool`
+/// result — the precondition providers impose on a replayed history. See
+/// [`RunOutcome::messages`] for when it can fail to hold.
+pub fn messages_are_balanced(messages: &[Message]) -> bool {
+    let answered: std::collections::HashSet<&str> = messages
+        .iter()
+        .filter_map(|message| message.tool_call_id.as_deref())
+        .collect();
+    messages
+        .iter()
+        .filter_map(|message| message.tool_calls.as_ref())
+        .flatten()
+        .all(|call| answered.contains(call.id.as_str()))
 }
 
 /// One tool-free completion to turn a run's gathered context into an answer.
@@ -461,5 +490,418 @@ impl Completer {
             }
         }
         .map_err(|e| RunError::Provider(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The loop's provider-facing contract, proven against **every** wire
+    //! dialect rather than only the OpenAI-compatible SSE shape the
+    //! integration suite drives.
+    //!
+    //! This matters because the three providers diverge exactly where this
+    //! module is most load-bearing. OpenRouter and OpenAI-compat stream SSE
+    //! frames and rebuild each tool call from string-valued `arguments`
+    //! deltas keyed by `index`; Ollama streams newline-delimited JSON, emits
+    //! each tool call whole with **object**-valued arguments, sends no id and
+    //! no index, and leaves the assembled response's `finish_reason` unset. A
+    //! loop that only ever saw the first shape could depend on any of those
+    //! accidents. Every test below therefore runs its assertions once per
+    //! dialect against a mock server that speaks all three.
+
+    use std::time::{Duration, Instant};
+
+    use async_trait::async_trait;
+    use atomic_test_support::{InjectedFailure, MockAiServer};
+    use serde_json::json;
+
+    use super::*;
+    use crate::agent_runtime::citations::CitationAdmission;
+    use crate::agent_runtime::AgentTool;
+    use crate::providers::types::ToolDefinition;
+    use crate::providers::ProviderType;
+
+    /// A tool that always succeeds, so a run can get past its first turn.
+    struct Echo;
+
+    #[async_trait]
+    impl AgentTool for Echo {
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition::new(
+                "echo",
+                "Echo the note back",
+                json!({
+                    "type": "object",
+                    "properties": { "note": { "type": "string" } },
+                    "required": ["note"],
+                    "additionalProperties": false,
+                }),
+            )
+        }
+
+        async fn execute(&self, args: &serde_json::Value, _ctx: &ToolContext<'_>) -> ToolResult {
+            ToolResult::ok(
+                format!("echo: {}", args["note"].as_str().unwrap_or("<missing>")),
+                1,
+            )
+        }
+    }
+
+    /// The three provider dialects, each pointed at the same mock server.
+    /// Iterated by every test so a divergence shows up as a named failure.
+    fn dialects(mock: &MockAiServer) -> Vec<(&'static str, ProviderConfig)> {
+        let base = ProviderConfig::from_settings(&std::collections::HashMap::new());
+
+        let mut openrouter = base.clone();
+        openrouter.provider_type = ProviderType::OpenRouter;
+        openrouter.openrouter_api_key = Some("mock-openrouter-key".to_string());
+        // Deliberately the bare mock URL: the provider's own normalization
+        // has to append `/v1` for this to reach the mock at all.
+        openrouter.openrouter_base_url = mock.base_url();
+
+        let mut compat = base.clone();
+        compat.provider_type = ProviderType::OpenAICompat;
+        compat.openai_compat_base_url = mock.base_url();
+        compat.openai_compat_api_key = Some("mock-compat-key".to_string());
+
+        let mut ollama = base;
+        ollama.provider_type = ProviderType::Ollama;
+        ollama.ollama_host = mock.base_url();
+
+        vec![
+            ("openrouter", openrouter),
+            ("openai_compat", compat),
+            ("ollama", ollama),
+        ]
+    }
+
+    /// Collect every [`RunEvent`] a run emits.
+    fn event_sink() -> (RunEventSink, Arc<Mutex<Vec<RunEvent>>>) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&events);
+        (
+            Arc::new(move |event| sink.lock().expect("event sink").push(event)),
+            events,
+        )
+    }
+
+    fn deltas(events: &Arc<Mutex<Vec<RunEvent>>>) -> Vec<String> {
+        events
+            .lock()
+            .expect("event sink")
+            .iter()
+            .filter_map(|event| match event {
+                RunEvent::Delta { text } => Some(text.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// A streaming chat-shaped run: the configuration `agent::chat` uses,
+    /// with the caps a test can afford.
+    fn chat_config(max_iterations: usize, salvage_on_cap: bool) -> RunConfig {
+        RunConfig {
+            model: "mock-model".to_string(),
+            params: GenerationParams::new()
+                .with_temperature(0.7)
+                .with_max_tokens(4000),
+            max_iterations,
+            termination: Termination::NoToolCalls,
+            streaming: true,
+            salvage_on_cap,
+            context_length: None,
+        }
+    }
+
+    /// Reset every knob and counter so each dialect's pass starts clean.
+    fn reset(mock: &MockAiServer) {
+        mock.reset_counts();
+        mock.set_chat_failure(None);
+        mock.set_chat_delay(None);
+        mock.set_chat_force_tool_calls(false);
+        mock.set_chat_tool_call(None);
+    }
+
+    /// Text streams back chunk by chunk on every dialect, and the chunks
+    /// concatenate to the answer rather than repeating it. NDJSON framing
+    /// has to yield the same per-fragment cadence as SSE.
+    #[tokio::test]
+    async fn streamed_text_arrives_one_event_per_chunk_on_every_dialect() {
+        let mock = MockAiServer::start().await;
+        for (dialect, provider_config) in dialects(&mock) {
+            reset(&mock);
+            let (sink, events) = event_sink();
+            let ledger = CitationLedger::new(CitationAdmission::Open);
+            let outcome = AgentRun {
+                config: chat_config(4, true),
+                provider_config: &provider_config,
+                tools: &ToolRegistry::new(),
+                citations: &ledger,
+                messages: vec![Message::user("what did I write about pelicans?")],
+                cancel: None,
+                events: Some(sink),
+            }
+            .execute()
+            .await
+            .unwrap_or_else(|e| panic!("{dialect}: run failed: {e}"));
+
+            assert_eq!(outcome.stop, StopReason::Answered, "{dialect}");
+            let deltas = deltas(&events);
+            assert!(
+                deltas.len() > 1,
+                "{dialect}: expected one event per provider chunk, got {deltas:?}"
+            );
+            assert_eq!(
+                deltas.concat(),
+                outcome.content,
+                "{dialect}: deltas must concatenate to the answer, not repeat it"
+            );
+        }
+    }
+
+    /// A tool call streamed by the provider reaches the loop intact — name
+    /// and arguments both — is dispatched, and its result carries the run
+    /// into a second turn that answers.
+    ///
+    /// This is the accumulation contract at its most dialect-sensitive:
+    /// OpenAI-shaped providers rebuild `arguments` from string deltas while
+    /// Ollama hands over a JSON object, and only one of those needs an id
+    /// from the wire. Either way the loop must see the same decoded input.
+    #[tokio::test]
+    async fn streamed_tool_calls_reach_the_loop_intact_on_every_dialect() {
+        let mock = MockAiServer::start().await;
+        for (dialect, provider_config) in dialects(&mock) {
+            reset(&mock);
+            mock.set_chat_tool_call(Some(("echo", json!({ "note": "pelicans" }))));
+
+            let (sink, events) = event_sink();
+            let ledger = CitationLedger::new(CitationAdmission::Open);
+            let outcome = AgentRun {
+                config: chat_config(4, true),
+                provider_config: &provider_config,
+                tools: &ToolRegistry::new().with(Echo),
+                citations: &ledger,
+                messages: vec![Message::user("echo something")],
+                cancel: None,
+                events: Some(sink),
+            }
+            .execute()
+            .await
+            .unwrap_or_else(|e| panic!("{dialect}: run failed: {e}"));
+
+            assert_eq!(outcome.stop, StopReason::Answered, "{dialect}");
+            assert_eq!(
+                outcome.tool_calls.len(),
+                1,
+                "{dialect}: exactly one tool round then an answer"
+            );
+            let call = &outcome.tool_calls[0];
+            assert_eq!(call.name, "echo", "{dialect}");
+            assert_eq!(
+                call.input,
+                json!({ "note": "pelicans" }),
+                "{dialect}: the arguments must survive the provider's encoding"
+            );
+            assert!(!call.failed, "{dialect}: {}", call.output);
+            assert_eq!(call.output, "echo: pelicans", "{dialect}");
+            assert!(
+                !call.id.is_empty(),
+                "{dialect}: every call needs an id, even where the wire sends none"
+            );
+
+            // The events a UI renders mirror the record.
+            let started: Vec<_> = events
+                .lock()
+                .expect("event sink")
+                .iter()
+                .filter_map(|event| match event {
+                    RunEvent::ToolStart {
+                        tool_name, input, ..
+                    } => Some((tool_name.clone(), input.clone())),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(
+                started,
+                vec![("echo".to_string(), json!({ "note": "pelicans" }))],
+                "{dialect}"
+            );
+
+            // And the loop went on to answer from the tool result.
+            assert!(
+                outcome.content.contains("Mock assistant reply"),
+                "{dialect}: second turn should answer, got {:?}",
+                outcome.content
+            );
+        }
+    }
+
+    /// Out of tool-call budget with nothing said, the run spends one more
+    /// completion **with no tools offered** so it yields prose instead of
+    /// silence — on every dialect, since "offered no tools" is encoded
+    /// differently by each and the mock only answers in prose when it sees
+    /// none.
+    #[tokio::test]
+    async fn iteration_cap_salvages_with_a_tool_free_call_on_every_dialect() {
+        let mock = MockAiServer::start().await;
+        for (dialect, provider_config) in dialects(&mock) {
+            reset(&mock);
+            // A model that never stops researching.
+            mock.set_chat_force_tool_calls(true);
+            mock.set_chat_tool_call(Some(("echo", json!({ "note": "again" }))));
+
+            let ledger = CitationLedger::new(CitationAdmission::Open);
+            let outcome = AgentRun {
+                config: chat_config(2, true),
+                provider_config: &provider_config,
+                tools: &ToolRegistry::new().with(Echo),
+                citations: &ledger,
+                messages: vec![Message::user("keep digging")],
+                cancel: None,
+                events: None,
+            }
+            .execute()
+            .await
+            .unwrap_or_else(|e| panic!("{dialect}: run failed: {e}"));
+
+            assert_eq!(outcome.stop, StopReason::IterationCap, "{dialect}");
+            assert_eq!(
+                outcome.tool_calls.len(),
+                2,
+                "{dialect}: the budget is spent before salvage"
+            );
+            assert!(
+                outcome.content.contains("Mock assistant reply"),
+                "{dialect}: salvage must produce prose, got {:?}",
+                outcome.content
+            );
+
+            // The salvage call is the last one, and it offered no tools —
+            // that is what forces the model to answer instead of researching.
+            let bodies = mock.chat_request_bodies();
+            assert_eq!(
+                bodies.len(),
+                3,
+                "{dialect}: two capped turns plus one salvage"
+            );
+            let salvage = bodies.last().expect("salvage request");
+            assert!(
+                salvage
+                    .get("tools")
+                    .map(|tools| tools.as_array().is_some_and(|t| t.is_empty()))
+                    .unwrap_or(true),
+                "{dialect}: the salvage call must offer no tools: {salvage}"
+            );
+        }
+    }
+
+    /// Raising the cancel flag while a request is in flight drops that
+    /// request rather than waiting it out — the `tokio::select!` race, which
+    /// the integration suite's callback-driven cancellation never reaches
+    /// (it flips the flag between tool executions instead).
+    ///
+    /// Proven by latency: the provider is held for far longer than the run
+    /// is allowed to take.
+    #[tokio::test]
+    async fn cancelling_an_in_flight_request_stops_the_run_on_every_dialect() {
+        const PROVIDER_HOLD: Duration = Duration::from_secs(30);
+        // How long the run may take to notice, measured from the flag going
+        // up. Generous against a loaded box, still an order of magnitude
+        // under the hold — a run that waited the provider out would land at
+        // ~30s and fail loudly.
+        const CANCEL_BUDGET: Duration = Duration::from_secs(3);
+
+        let mock = MockAiServer::start().await;
+        for (dialect, provider_config) in dialects(&mock) {
+            reset(&mock);
+            mock.set_chat_delay(Some(PROVIDER_HOLD));
+
+            let cancel: CancelFlag = Arc::new(AtomicBool::new(false));
+            let trigger = Arc::clone(&cancel);
+            // Stamped before the flag goes up, so a run that observes the
+            // flag always sees a stamp.
+            let raised_at: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+            let stamp = Arc::clone(&raised_at);
+            let raiser = tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(150)).await;
+                *stamp.lock().expect("raise stamp") = Some(Instant::now());
+                trigger.store(true, Ordering::Relaxed);
+            });
+
+            let ledger = CitationLedger::new(CitationAdmission::Open);
+            let outcome = AgentRun {
+                config: chat_config(4, true),
+                provider_config: &provider_config,
+                tools: &ToolRegistry::new().with(Echo),
+                citations: &ledger,
+                messages: vec![Message::user("start something slow")],
+                cancel: Some(cancel),
+                events: None,
+            }
+            .execute()
+            .await
+            .unwrap_or_else(|e| panic!("{dialect}: a cancelled run still returns: {e}"));
+            let returned_at = Instant::now();
+            raiser.await.expect("flag raiser joined");
+
+            assert_eq!(outcome.stop, StopReason::Cancelled, "{dialect}");
+
+            // Latency is measured from the flag going up, not from the start
+            // of the run: the first HTTP client a process builds can stall
+            // the runtime for seconds loading the system trust store, which
+            // has nothing to do with how fast cancellation is noticed.
+            let raised_at = raised_at
+                .lock()
+                .expect("raise stamp")
+                .expect("the flag was raised before the run returned");
+            let latency = returned_at.duration_since(raised_at);
+            assert!(
+                latency < CANCEL_BUDGET,
+                "{dialect}: the run must abandon the in-flight request, not wait \
+                 it out — noticing took {latency:?}, and the provider was only \
+                 going to answer after {PROVIDER_HOLD:?}"
+            );
+            assert!(
+                outcome.tool_calls.is_empty(),
+                "{dialect}: nothing ran, so nothing is recorded"
+            );
+        }
+    }
+
+    /// A dead provider is a `RunError::Provider` carrying the provider's own
+    /// words — the variant chat turns into a `ChatEvent::Error`. Each dialect
+    /// has its own error-decoding path; all three must classify a 401 the
+    /// same way.
+    #[tokio::test]
+    async fn a_failing_provider_is_a_run_error_on_every_dialect() {
+        let mock = MockAiServer::start().await;
+        for (dialect, provider_config) in dialects(&mock) {
+            reset(&mock);
+            mock.set_chat_failure(Some(InjectedFailure::Unauthorized));
+
+            let ledger = CitationLedger::new(CitationAdmission::Open);
+            let error = AgentRun {
+                config: chat_config(4, true),
+                provider_config: &provider_config,
+                tools: &ToolRegistry::new().with(Echo),
+                citations: &ledger,
+                messages: vec![Message::user("anything")],
+                cancel: None,
+                events: None,
+            }
+            .execute()
+            .await
+            .err()
+            .unwrap_or_else(|| panic!("{dialect}: a dead provider must fail the run"));
+
+            assert!(
+                matches!(error, RunError::Provider(_)),
+                "{dialect}: got {error:?}"
+            );
+            assert!(
+                error.to_string().contains("401"),
+                "{dialect}: the provider's status has to survive: {error}"
+            );
+        }
     }
 }

--- a/crates/atomic-core/src/agent_runtime/run.rs
+++ b/crates/atomic-core/src/agent_runtime/run.rs
@@ -1,0 +1,465 @@
+//! The agent loop: model → tools → model, until the run answers, signals
+//! it is done, is cancelled, or exhausts its tool-call budget.
+//!
+//! The loop is transport-agnostic. It reports progress through a callback
+//! (`RunEventSink`), the same pattern the embedding pipeline uses, so a host
+//! can bridge it to Tauri events, a broadcast channel, or nothing at all.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use chrono::Utc;
+
+use crate::providers::traits::{LlmConfig, LlmProvider, StreamCallback, StreamingLlmProvider};
+use crate::providers::types::{
+    CompletionResponse, GenerationParams, Message, StreamDelta, ToolCall, ToolDefinition,
+};
+use crate::providers::{create_streaming_llm_provider, get_llm_provider, ProviderConfig};
+
+use super::citations::CitationLedger;
+use super::context::truncate_messages_to_context;
+use super::tools::{ToolContext, ToolRegistry, ToolResult};
+
+/// Cooperative cancellation handle for one in-flight run. Raise the flag and
+/// the loop stops at its next checkpoint — between iterations, between
+/// sequential tool executions, and mid-stream — then returns whatever text
+/// it had already produced. Hosts own the registry of flags; the loop only
+/// reads them.
+pub type CancelFlag = Arc<AtomicBool>;
+
+/// Sink for [`RunEvent`]s. `None` on a run means nobody is watching.
+pub type RunEventSink = Arc<dyn Fn(RunEvent) + Send + Sync + 'static>;
+
+/// Progress a run makes while it is still in flight.
+#[derive(Debug, Clone)]
+pub enum RunEvent {
+    /// One incremental chunk of model text, exactly as the provider
+    /// produced it. Only emitted by streaming runs.
+    Delta { text: String },
+    /// A tool is about to execute.
+    ToolStart {
+        tool_call_id: String,
+        tool_name: String,
+        input: serde_json::Value,
+    },
+    /// A tool finished. `failed` mirrors the recorded call status, so a tool
+    /// that errored reads as failed while the run is still going.
+    ToolComplete {
+        tool_call_id: String,
+        tool_name: String,
+        results_count: i32,
+        failed: bool,
+    },
+}
+
+/// How a run decides it is finished.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Termination {
+    /// The first model turn that asks for no tools is the answer, and its
+    /// text is the run's content (chat).
+    NoToolCalls,
+    /// The model calls this sentinel tool to say research is over. The loop
+    /// stops after that round having produced no answer of its own — the
+    /// caller writes it in a separate pass over [`RunOutcome::messages`]
+    /// (reports' `done`). A turn with no tool calls still ends the run.
+    Sentinel(String),
+}
+
+impl Termination {
+    fn is_sentinel(&self, tool_name: &str) -> bool {
+        match self {
+            Termination::NoToolCalls => false,
+            Termination::Sentinel(name) => name == tool_name,
+        }
+    }
+}
+
+/// Why the loop stopped. Callers decide what a non-`Answered` ending looks
+/// like to their users — the runtime does not editorialize.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopReason {
+    /// The model answered without asking for more tools.
+    Answered,
+    /// The run's sentinel tool fired.
+    Sentinel,
+    /// The cancel flag was raised.
+    Cancelled,
+    /// The tool-call budget ran out.
+    IterationCap,
+}
+
+/// Everything about a run that is policy rather than content.
+pub struct RunConfig {
+    pub model: String,
+    pub params: GenerationParams,
+    /// Tool-calling rounds the run may take before it gives up.
+    pub max_iterations: usize,
+    pub termination: Termination,
+    /// Stream the model's text as it arrives, emitting [`RunEvent::Delta`]
+    /// per chunk. Non-streaming runs use the plain completion path.
+    pub streaming: bool,
+    /// When the cap hits with nothing said yet, spend one more completion
+    /// with no tools offered so the run still yields prose instead of
+    /// silence. Runs that write their answer in a separate final pass leave
+    /// this off.
+    pub salvage_on_cap: bool,
+    /// Per-call prompt budget: trim the oldest tool rounds to ~70% of this
+    /// many tokens. `None` sends the history as-is.
+    pub context_length: Option<usize>,
+}
+
+/// One tool call as it happened, for callers that persist a transcript.
+#[derive(Debug, Clone)]
+pub struct ToolCallRecord {
+    pub id: String,
+    pub name: String,
+    pub input: serde_json::Value,
+    pub output: String,
+    pub failed: bool,
+    pub started_at: String,
+    pub completed_at: String,
+}
+
+/// What a run produced.
+pub struct RunOutcome {
+    /// The model's answer when it gave one; the text it had streamed so far
+    /// when the run was cut short; empty when the run ended on its sentinel
+    /// and the caller writes the answer.
+    pub content: String,
+    /// The full message history including every tool round — the input to a
+    /// caller's final pass.
+    pub messages: Vec<Message>,
+    /// Every tool call made, in order.
+    pub tool_calls: Vec<ToolCallRecord>,
+    pub stop: StopReason,
+}
+
+/// Why a run could not produce anything. Callers own the user-facing
+/// wording, so the variants carry the raw provider text rather than a
+/// finished message.
+#[derive(Debug)]
+pub enum RunError {
+    /// The provider could not be built from the run's configuration.
+    Setup(String),
+    /// A model call failed.
+    Provider(String),
+}
+
+impl std::fmt::Display for RunError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RunError::Setup(error) => write!(f, "{}", error),
+            RunError::Provider(error) => write!(f, "{}", error),
+        }
+    }
+}
+
+impl std::error::Error for RunError {}
+
+/// One agent run, assembled by the caller and executed once.
+pub struct AgentRun<'a> {
+    pub config: RunConfig,
+    pub provider_config: &'a ProviderConfig,
+    pub tools: &'a ToolRegistry,
+    /// Shared with the tools for the duration of the run; the caller reads
+    /// the cited subset back out of it afterwards.
+    pub citations: &'a CitationLedger,
+    /// System prompt plus history, already assembled by the caller.
+    pub messages: Vec<Message>,
+    pub cancel: Option<CancelFlag>,
+    pub events: Option<RunEventSink>,
+}
+
+/// How often the loop samples the cancellation flag while a provider call is
+/// in flight. Cancellation is cooperative and user-facing, so the bound only
+/// has to be imperceptible, not instant.
+const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+impl AgentRun<'_> {
+    pub async fn execute(self) -> Result<RunOutcome, RunError> {
+        let AgentRun {
+            config,
+            provider_config,
+            tools,
+            citations,
+            mut messages,
+            cancel,
+            events,
+        } = self;
+
+        let completer = Completer::new(config.streaming, provider_config)?;
+        let llm_config = LlmConfig::new(&config.model).with_params(config.params.clone());
+
+        // Every token the model produced this run, across all iterations —
+        // the same text a streaming caller has been rendering. Only used
+        // when the run ends without a clean final answer.
+        let produced = Arc::new(Mutex::new(String::new()));
+        let mut tool_calls: Vec<ToolCallRecord> = Vec::new();
+        let mut content = String::new();
+        let mut stop = StopReason::IterationCap;
+
+        'iterations: for _ in 0..config.max_iterations {
+            if is_cancelled(&cancel) {
+                stop = StopReason::Cancelled;
+                break;
+            }
+
+            let call_messages =
+                truncate_messages_to_context(messages.clone(), config.context_length);
+            let on_delta = config
+                .streaming
+                .then(|| delta_callback(events.clone(), Arc::clone(&produced), cancel.clone()));
+
+            // Racing the request against the cancel flag drops the request
+            // future on cancel, which tears down the in-flight HTTP stream
+            // instead of paying for tokens nobody will read.
+            let response = tokio::select! {
+                biased;
+                result = completer.complete(&call_messages, tools.definitions(), &llm_config, on_delta) => result?,
+                _ = cancellation_raised(&cancel) => {
+                    stop = StopReason::Cancelled;
+                    break;
+                }
+            };
+
+            let requested = match response.tool_calls {
+                Some(ref calls) if !calls.is_empty() => calls.clone(),
+                _ => {
+                    content = response.content;
+                    stop = StopReason::Answered;
+                    break;
+                }
+            };
+
+            // Non-streaming runs have no deltas to accumulate, so preamble
+            // text is captured here instead.
+            if !config.streaming && !response.content.is_empty() {
+                accumulate(&produced, &response.content);
+            }
+            messages.push(assistant_turn(&response.content, requested.clone()));
+
+            let mut sentinel_fired = false;
+            for call in &requested {
+                if is_cancelled(&cancel) {
+                    stop = StopReason::Cancelled;
+                    break 'iterations;
+                }
+
+                let name = call.get_name().unwrap_or_default().to_string();
+                let args: serde_json::Value =
+                    serde_json::from_str(call.get_arguments().unwrap_or_default())
+                        .unwrap_or(serde_json::Value::Null);
+
+                emit(
+                    &events,
+                    RunEvent::ToolStart {
+                        tool_call_id: call.id.clone(),
+                        tool_name: name.clone(),
+                        input: args.clone(),
+                    },
+                );
+
+                let started_at = Utc::now().to_rfc3339();
+                let result = match tools.get(&name) {
+                    Some(tool) => tool.execute(&args, &ToolContext { citations }).await,
+                    // The model asked for a tool this run doesn't have — a
+                    // failed call, not an empty result.
+                    None => ToolResult::failed(format!("Unknown tool: {}", name)),
+                };
+                sentinel_fired |= config.termination.is_sentinel(&name);
+
+                tool_calls.push(ToolCallRecord {
+                    id: call.id.clone(),
+                    name: name.clone(),
+                    input: args,
+                    output: result.output.clone(),
+                    failed: result.failed,
+                    started_at,
+                    completed_at: Utc::now().to_rfc3339(),
+                });
+
+                emit(
+                    &events,
+                    RunEvent::ToolComplete {
+                        tool_call_id: call.id.clone(),
+                        tool_name: name,
+                        results_count: result.results_count,
+                        failed: result.failed,
+                    },
+                );
+
+                messages.push(Message::tool_result(&call.id, result.output));
+            }
+
+            if sentinel_fired {
+                stop = StopReason::Sentinel;
+                break;
+            }
+        }
+
+        if matches!(stop, StopReason::Cancelled | StopReason::IterationCap) {
+            let partial = produced.lock().map(|text| text.clone()).unwrap_or_default();
+            content = if stop == StopReason::IterationCap
+                && config.salvage_on_cap
+                && partial.trim().is_empty()
+            {
+                // Out of tool-call budget with nothing said. Salvage rather
+                // than discard: one more call, without tools, so the model
+                // has to answer in prose from the context it gathered.
+                salvage(
+                    &completer,
+                    &config,
+                    &llm_config,
+                    &messages,
+                    &produced,
+                    &events,
+                    &cancel,
+                )
+                .await
+            } else {
+                partial
+            };
+        }
+
+        Ok(RunOutcome {
+            content,
+            messages,
+            tool_calls,
+            stop,
+        })
+    }
+}
+
+/// One tool-free completion to turn a run's gathered context into an answer.
+/// A failure here is not fatal — the run returns what it has and the caller
+/// decides how to label it.
+async fn salvage(
+    completer: &Completer,
+    config: &RunConfig,
+    llm_config: &LlmConfig,
+    messages: &[Message],
+    produced: &Arc<Mutex<String>>,
+    events: &Option<RunEventSink>,
+    cancel: &Option<CancelFlag>,
+) -> String {
+    let call_messages = truncate_messages_to_context(messages.to_vec(), config.context_length);
+    let on_delta = config
+        .streaming
+        .then(|| delta_callback(events.clone(), Arc::clone(produced), cancel.clone()));
+    match completer
+        .complete(&call_messages, &[], llm_config, on_delta)
+        .await
+    {
+        Ok(response) => response.content,
+        Err(error) => {
+            tracing::warn!(%error, "[agent_runtime] iteration-cap salvage completion failed");
+            String::new()
+        }
+    }
+}
+
+/// Assistant turn carrying the tool calls it requested, keeping any text it
+/// said alongside them.
+fn assistant_turn(content: &str, tool_calls: Vec<ToolCall>) -> Message {
+    if content.is_empty() {
+        Message::assistant_with_tool_calls(tool_calls)
+    } else {
+        let mut message = Message::assistant(content);
+        message.tool_calls = Some(tool_calls);
+        message
+    }
+}
+
+/// Forward every chunk to the run's sink as it arrives and keep a copy for
+/// the salvage paths.
+fn delta_callback(
+    events: Option<RunEventSink>,
+    produced: Arc<Mutex<String>>,
+    cancel: Option<CancelFlag>,
+) -> StreamCallback {
+    Box::new(move |delta: StreamDelta| {
+        let StreamDelta::Content(text) = delta else {
+            return;
+        };
+        if text.is_empty() || is_cancelled(&cancel) {
+            return;
+        }
+        accumulate(&produced, &text);
+        emit(&events, RunEvent::Delta { text });
+    })
+}
+
+fn accumulate(produced: &Arc<Mutex<String>>, text: &str) {
+    if let Ok(mut accumulated) = produced.lock() {
+        accumulated.push_str(text);
+    }
+}
+
+fn emit(events: &Option<RunEventSink>, event: RunEvent) {
+    if let Some(sink) = events {
+        sink(event);
+    }
+}
+
+fn is_cancelled(cancel: &Option<CancelFlag>) -> bool {
+    cancel
+        .as_ref()
+        .is_some_and(|flag| flag.load(Ordering::Relaxed))
+}
+
+/// Resolves once `cancel` is raised; never resolves when there is no flag.
+/// Polling keeps cancellation out of the provider traits — the loop races
+/// this against the in-flight request and drops the request future on cancel.
+async fn cancellation_raised(cancel: &Option<CancelFlag>) {
+    match cancel {
+        Some(flag) => {
+            while !flag.load(Ordering::Relaxed) {
+                tokio::time::sleep(CANCEL_POLL_INTERVAL).await;
+            }
+        }
+        None => std::future::pending().await,
+    }
+}
+
+/// The provider a run talks to, streaming or not. Both legs return the same
+/// `CompletionResponse`, so the loop above never branches on transport.
+enum Completer {
+    Streaming(Arc<dyn StreamingLlmProvider>),
+    Blocking(Arc<dyn LlmProvider>),
+}
+
+impl Completer {
+    fn new(streaming: bool, config: &ProviderConfig) -> Result<Self, RunError> {
+        if streaming {
+            create_streaming_llm_provider(config)
+                .map(Completer::Streaming)
+                .map_err(|e| RunError::Setup(e.to_string()))
+        } else {
+            get_llm_provider(config)
+                .map(Completer::Blocking)
+                .map_err(|e| RunError::Setup(e.to_string()))
+        }
+    }
+
+    async fn complete(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        config: &LlmConfig,
+        on_delta: Option<StreamCallback>,
+    ) -> Result<CompletionResponse, RunError> {
+        match self {
+            Completer::Streaming(provider) => {
+                let on_delta = on_delta.unwrap_or_else(|| Box::new(|_| {}));
+                provider
+                    .complete_streaming_with_tools(messages, tools, config, on_delta)
+                    .await
+            }
+            Completer::Blocking(provider) => {
+                provider.complete_with_tools(messages, tools, config).await
+            }
+        }
+        .map_err(|e| RunError::Provider(e.to_string()))
+    }
+}

--- a/crates/atomic-core/src/agent_runtime/tools.rs
+++ b/crates/atomic-core/src/agent_runtime/tools.rs
@@ -1,0 +1,166 @@
+//! Tool registry — what a run is allowed to do.
+//!
+//! A tool owns its own dependencies (storage, settings, event sinks) at
+//! construction time and receives only per-run state when it executes, so
+//! conditional capabilities are conditional *registrations* rather than
+//! branches inside a dispatch match.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::providers::types::ToolDefinition;
+
+use super::citations::CitationLedger;
+
+/// Outcome of a single tool execution.
+///
+/// `failed` is tracked separately from `output` because the error text still
+/// has to reach the model (and the UI's tool card), while the recorded
+/// status must say what actually happened.
+pub struct ToolResult {
+    pub output: String,
+    /// How many things the tool found, for the caller's progress reporting.
+    pub results_count: i32,
+    pub failed: bool,
+}
+
+impl ToolResult {
+    pub fn ok(output: impl Into<String>, results_count: i32) -> Self {
+        Self {
+            output: output.into(),
+            results_count,
+            failed: false,
+        }
+    }
+
+    pub fn failed(error: impl std::fmt::Display) -> Self {
+        Self {
+            output: format!("Error: {}", error),
+            results_count: 0,
+            failed: true,
+        }
+    }
+}
+
+/// Per-run state a tool may reach into. Everything else a tool needs is
+/// captured when it is constructed.
+pub struct ToolContext<'a> {
+    /// Register surfaced evidence here to make it citable, and put the
+    /// returned number in the tool's output so the model can cite it.
+    pub citations: &'a CitationLedger,
+}
+
+/// A callable capability. Implementors are cheap handles over shared state
+/// (`StorageBackend`, `Arc` callbacks) — one instance serves the whole run.
+#[async_trait]
+pub trait AgentTool: Send + Sync {
+    /// Name, description, and JSON schema sent to the model. Called once,
+    /// at registration.
+    fn definition(&self) -> ToolDefinition;
+
+    /// Run the tool. Argument validation is the tool's job: a malformed
+    /// call is a [`ToolResult::failed`], never a panic.
+    async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult;
+}
+
+/// The tools one run may call, in the order they were registered (which is
+/// the order the model sees them).
+#[derive(Default)]
+pub struct ToolRegistry {
+    definitions: Vec<ToolDefinition>,
+    by_name: HashMap<String, Arc<dyn AgentTool>>,
+}
+
+impl ToolRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a tool, replacing any earlier registration of the same name so a
+    /// caller can override a default capability without reordering.
+    pub fn register(&mut self, tool: impl AgentTool + 'static) -> &mut Self {
+        let definition = tool.definition();
+        match self
+            .definitions
+            .iter()
+            .position(|existing| existing.name == definition.name)
+        {
+            Some(index) => self.definitions[index] = definition.clone(),
+            None => self.definitions.push(definition.clone()),
+        }
+        self.by_name.insert(definition.name, Arc::new(tool));
+        self
+    }
+
+    /// Chaining form of [`Self::register`], for conditional assembly.
+    pub fn with(mut self, tool: impl AgentTool + 'static) -> Self {
+        self.register(tool);
+        self
+    }
+
+    pub fn definitions(&self) -> &[ToolDefinition] {
+        &self.definitions
+    }
+
+    pub fn get(&self, name: &str) -> Option<&dyn AgentTool> {
+        self.by_name.get(name).map(|tool| tool.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    struct Echo {
+        name: &'static str,
+        reply: &'static str,
+    }
+
+    #[async_trait]
+    impl AgentTool for Echo {
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition::new(self.name, "echo", json!({ "type": "object" }))
+        }
+
+        async fn execute(&self, _args: &serde_json::Value, _ctx: &ToolContext<'_>) -> ToolResult {
+            ToolResult::ok(self.reply, 1)
+        }
+    }
+
+    #[tokio::test]
+    async fn registration_order_is_preserved_and_names_are_unique() {
+        let registry = ToolRegistry::new()
+            .with(Echo {
+                name: "first",
+                reply: "a",
+            })
+            .with(Echo {
+                name: "second",
+                reply: "b",
+            })
+            .with(Echo {
+                name: "first",
+                reply: "replaced",
+            });
+
+        let names: Vec<&str> = registry
+            .definitions()
+            .iter()
+            .map(|definition| definition.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["first", "second"]);
+
+        let ledger = CitationLedger::new(super::super::CitationAdmission::Open);
+        let ctx = ToolContext { citations: &ledger };
+        let result = registry
+            .get("first")
+            .expect("registered tool")
+            .execute(&json!({}), &ctx)
+            .await;
+        assert_eq!(result.output, "replaced");
+        assert!(registry.get("missing").is_none());
+    }
+}

--- a/crates/atomic-core/src/chat.rs
+++ b/crates/atomic-core/src/chat.rs
@@ -598,6 +598,26 @@ pub fn update_conversation(
     .map_err(|_| AtomicCoreError::NotFound(format!("Conversation not found: {}", id)))
 }
 
+/// Name an untitled conversation, and say whether the name landed.
+///
+/// The auto-titler reads, decides, calls a model, and only then writes — long
+/// enough for the user to have typed their own title in between. `AND title
+/// IS NULL` makes the check and the write one statement, so a rename can
+/// never be overwritten by a generation that started before it. `false` means
+/// the conversation was already named and nothing changed.
+pub fn set_title_if_unset(
+    conn: &Connection,
+    id: &str,
+    title: &str,
+) -> Result<bool, AtomicCoreError> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let updated = conn.execute(
+        "UPDATE conversations SET title = ?1, updated_at = ?2 WHERE id = ?3 AND title IS NULL",
+        rusqlite::params![title, &now, id],
+    )?;
+    Ok(updated > 0)
+}
+
 /// Delete a conversation
 pub fn delete_conversation(conn: &Connection, id: &str) -> Result<(), AtomicCoreError> {
     conn.execute("DELETE FROM conversations WHERE id = ?1", [id])?;
@@ -817,8 +837,12 @@ pub fn get_conversation_scope(
 /// Describe a scope for the system prompt, given resolved tag names.
 ///
 /// Shared by both backends so the model is told the same contract the
-/// retrieval layer enforces. Tags whose names don't resolve are dropped —
-/// naming an id back to the model teaches it nothing.
+/// retrieval layer enforces. Tags whose names don't resolve are dropped from
+/// the lists — naming an id back to the model teaches it nothing — but every
+/// branch here keys off the *filter*, never off the names that survived
+/// resolution. A scope whose tags all failed to resolve is still a scope, and
+/// telling the model it has "ALL atoms" when retrieval will hand it a subset
+/// is the one lie this paragraph must not tell.
 pub(crate) fn describe_scope(
     scope: &ScopeFilter,
     names: &std::collections::HashMap<String, String>,
@@ -834,32 +858,44 @@ pub(crate) fn describe_scope(
         named(&scope.exclude),
     );
 
-    if include.is_empty() && require.is_empty() && exclude.is_empty() {
+    if scope.is_empty() {
         return "You have access to ALL atoms in the knowledge base.".to_string();
     }
 
     let mut sentences = Vec::new();
-    if include.is_empty() {
+    if scope.include.is_empty() {
         sentences.push("You have access to all atoms in the knowledge base, with the filters below applied to every search.".to_string());
+    } else if include.is_empty() {
+        sentences.push("You have access to a narrowed set of atoms: only those under the tags the user put in scope.".to_string());
     } else {
         sentences.push(format!(
             "You have access to atoms tagged with any of: {}. Focus your search on these topics.",
             include.join(", ")
         ));
     }
-    if !require.is_empty() {
-        sentences.push(format!(
-            "Only atoms tagged with every one of: {} are in scope.",
-            require.join(", ")
-        ));
+    if !scope.require.is_empty() {
+        sentences.push(if require.is_empty() {
+            "Some atoms are further required to carry every tag the user marked as required."
+                .to_string()
+        } else {
+            format!(
+                "Only atoms tagged with every one of: {} are in scope.",
+                require.join(", ")
+            )
+        });
     }
-    if !exclude.is_empty() {
-        sentences.push(format!(
-            "Atoms tagged with any of: {} are excluded and will never appear in your search results.",
-            exclude.join(", ")
-        ));
+    if !scope.exclude.is_empty() {
+        sentences.push(if exclude.is_empty() {
+            "Atoms under the tags the user excluded will never appear in your search results."
+                .to_string()
+        } else {
+            format!(
+                "Atoms tagged with any of: {} are excluded and will never appear in your search results.",
+                exclude.join(", ")
+            )
+        });
     }
-    sentences.push("A tag also covers its child tags. This scope is enforced by search itself — you cannot widen it.".to_string());
+    sentences.push("A tag also covers its child tags. Every tool enforces this scope — search, tag listings, articles, findings and reads by id alike — so you cannot widen it, and asking for something outside it will be refused rather than answered.".to_string());
     sentences.join(" ")
 }
 
@@ -876,23 +912,21 @@ pub fn get_scope_description(conn: &Connection, scope: &ScopeFilter) -> String {
         placeholders.join(", ")
     );
 
-    let mut stmt = match conn.prepare(&query) {
-        Ok(s) => s,
-        Err(_) => return "You have access to a scoped set of atoms.".to_string(),
+    // Names are a nicety; the scope itself is not. A lookup that fails still
+    // describes the shape of the filter, because retrieval will apply it
+    // whether or not the prompt could name it.
+    let names: std::collections::HashMap<String, String> = match conn.prepare(&query) {
+        Ok(mut stmt) => {
+            let params: Vec<&dyn rusqlite::ToSql> =
+                roots.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+            stmt.query_map(params.as_slice(), |row| Ok((row.get(0)?, row.get(1)?)))
+                .map(|rows| rows.filter_map(|r| r.ok()).collect())
+                .unwrap_or_default()
+        }
+        Err(_) => std::collections::HashMap::new(),
     };
 
-    let params: Vec<&dyn rusqlite::ToSql> =
-        roots.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
-    let names: std::collections::HashMap<String, String> = stmt
-        .query_map(params.as_slice(), |row| Ok((row.get(0)?, row.get(1)?)))
-        .map(|rows| rows.filter_map(|r| r.ok()).collect())
-        .unwrap_or_default();
-
-    if names.is_empty() {
-        "You have access to a scoped set of atoms.".to_string()
-    } else {
-        describe_scope(scope, &names)
-    }
+    describe_scope(scope, &names)
 }
 
 /// Get conversation messages in provider Message format
@@ -1029,6 +1063,53 @@ mod tests {
         let updated =
             update_conversation(&conn, &conv.conversation.id, Some("Updated"), None).unwrap();
         assert_eq!(updated.title, Some("Updated".to_string()));
+    }
+
+    /// The auto-titler's write path. Its pre-flight check happens before a
+    /// model call that can take seconds, so the only thing standing between a
+    /// user's rename and a generated title clobbering it is this statement
+    /// re-checking as it writes.
+    #[test]
+    fn a_generated_title_only_lands_while_the_conversation_is_unnamed() {
+        let (db, _temp) = setup_db();
+        let conn = db.conn.lock().unwrap();
+
+        let untitled = create_conversation(&conn, &[], None).unwrap();
+        assert!(
+            set_title_if_unset(&conn, &untitled.conversation.id, "Generated").unwrap(),
+            "an untitled conversation takes the generated name"
+        );
+        assert_eq!(
+            get_conversation(&conn, &untitled.conversation.id)
+                .unwrap()
+                .unwrap()
+                .conversation
+                .title
+                .as_deref(),
+            Some("Generated")
+        );
+
+        // The rename the user typed while the model was thinking.
+        update_conversation(&conn, &untitled.conversation.id, Some("Renamed"), None).unwrap();
+        assert!(
+            !set_title_if_unset(&conn, &untitled.conversation.id, "Generated Again").unwrap(),
+            "a named conversation refuses the write, and reports that it did"
+        );
+        assert_eq!(
+            get_conversation(&conn, &untitled.conversation.id)
+                .unwrap()
+                .unwrap()
+                .conversation
+                .title
+                .as_deref(),
+            Some("Renamed"),
+            "the user's name is the one that stands"
+        );
+
+        assert!(
+            !set_title_if_unset(&conn, "no-such-conversation", "Generated").unwrap(),
+            "and a conversation that no longer exists is not an error, just a no-op"
+        );
     }
 
     #[test]

--- a/crates/atomic-core/src/chat.rs
+++ b/crates/atomic-core/src/chat.rs
@@ -6,8 +6,9 @@
 use crate::error::AtomicCoreError;
 use crate::models::{
     ChatCitation, ChatMessage, ChatMessageWithContext, ChatToolCall, Conversation,
-    ConversationWithMessages, ConversationWithTags, Tag,
+    ConversationWithMessages, ConversationWithTags, ScopeEntry, ScopeMode, ScopeTag, Tag,
 };
+use crate::search::ScopeFilter;
 use rusqlite::Connection;
 
 // ==================== Helper Functions ====================
@@ -26,13 +27,13 @@ pub(crate) fn truncate_preview(s: &str, max_chars: usize) -> String {
     }
 }
 
-/// Get tags for a conversation
+/// Get the scope tags for a conversation, each with the mode it plays.
 pub fn get_conversation_tags(
     conn: &Connection,
     conversation_id: &str,
-) -> Result<Vec<Tag>, AtomicCoreError> {
+) -> Result<Vec<ScopeTag>, AtomicCoreError> {
     let mut stmt = conn.prepare(
-        "SELECT t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target, t.autotag_description
+        "SELECT t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target, t.autotag_description, ct.mode
          FROM tags t
          JOIN conversation_tags ct ON ct.tag_id = t.id
          WHERE ct.conversation_id = ?1
@@ -41,13 +42,16 @@ pub fn get_conversation_tags(
 
     let tags = stmt
         .query_map([conversation_id], |row| {
-            Ok(Tag {
-                id: row.get(0)?,
-                name: row.get(1)?,
-                parent_id: row.get(2)?,
-                created_at: row.get(3)?,
-                is_autotag_target: row.get::<_, i32>(4)? != 0,
-                autotag_description: row.get(5)?,
+            Ok(ScopeTag {
+                tag: Tag {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    parent_id: row.get(2)?,
+                    created_at: row.get(3)?,
+                    is_autotag_target: row.get::<_, i32>(4)? != 0,
+                    autotag_description: row.get(5)?,
+                },
+                mode: ScopeMode::from_db(&row.get::<_, String>(6)?),
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -123,28 +127,39 @@ pub fn get_message_citations(
     conn: &Connection,
     message_id: &str,
 ) -> Result<Vec<ChatCitation>, AtomicCoreError> {
-    let mut stmt = conn.prepare(
-        "SELECT id, message_id, citation_index, atom_id, chunk_index, excerpt, relevance_score
-         FROM chat_citations
-         WHERE message_id = ?1
-         ORDER BY citation_index",
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "{CITATION_SELECT}
+         WHERE c.message_id = ?1
+         ORDER BY c.citation_index"
+    ))?;
 
     let citations = stmt
-        .query_map([message_id], |row| {
-            Ok(ChatCitation {
-                id: row.get(0)?,
-                message_id: row.get(1)?,
-                citation_index: row.get(2)?,
-                atom_id: row.get(3)?,
-                chunk_index: row.get(4)?,
-                excerpt: row.get(5)?,
-                relevance_score: row.get(6)?,
-            })
-        })?
+        .query_map([message_id], citation_from_row)?
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(citations)
+}
+
+/// Every citation column plus the wiki citation's tag name, which is joined
+/// rather than stored so a renamed tag reads back under its current name.
+const CITATION_SELECT: &str =
+    "SELECT c.id, c.message_id, c.citation_index, c.atom_id, c.chunk_index,
+                c.excerpt, c.relevance_score, c.source_type, t.name
+         FROM chat_citations c
+         LEFT JOIN tags t ON t.id = c.atom_id AND c.source_type = 'wiki'";
+
+fn citation_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChatCitation> {
+    Ok(ChatCitation {
+        id: row.get(0)?,
+        message_id: row.get(1)?,
+        citation_index: row.get(2)?,
+        atom_id: row.get(3)?,
+        chunk_index: row.get(4)?,
+        excerpt: row.get(5)?,
+        relevance_score: row.get(6)?,
+        source_type: row.get(7)?,
+        source_title: row.get(8)?,
+    })
 }
 
 /// Get messages with context for a conversation
@@ -256,26 +271,18 @@ fn batch_fetch_citations(
         .collect::<Vec<_>>()
         .join(",");
     let query = format!(
-        "SELECT id, message_id, citation_index, atom_id, chunk_index, excerpt, relevance_score
-         FROM chat_citations
-         WHERE message_id IN ({})
-         ORDER BY citation_index",
+        "{CITATION_SELECT}
+         WHERE c.message_id IN ({})
+         ORDER BY c.citation_index",
         placeholders
     );
     let mut stmt = conn.prepare(&query)?;
     let mut map: std::collections::HashMap<String, Vec<ChatCitation>> =
         std::collections::HashMap::new();
-    let rows = stmt.query_map(rusqlite::params_from_iter(message_ids.iter()), |row| {
-        Ok(ChatCitation {
-            id: row.get(0)?,
-            message_id: row.get(1)?,
-            citation_index: row.get(2)?,
-            atom_id: row.get(3)?,
-            chunk_index: row.get(4)?,
-            excerpt: row.get(5)?,
-            relevance_score: row.get(6)?,
-        })
-    })?;
+    let rows = stmt.query_map(
+        rusqlite::params_from_iter(message_ids.iter()),
+        citation_from_row,
+    )?;
     for row in rows {
         let c = row?;
         map.entry(c.message_id.clone()).or_default().push(c);
@@ -287,13 +294,13 @@ fn batch_fetch_citations(
 fn batch_fetch_conversation_tags(
     conn: &Connection,
     conv_ids: &[String],
-) -> Result<std::collections::HashMap<String, Vec<Tag>>, AtomicCoreError> {
+) -> Result<std::collections::HashMap<String, Vec<ScopeTag>>, AtomicCoreError> {
     if conv_ids.is_empty() {
         return Ok(std::collections::HashMap::new());
     }
     let placeholders = conv_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let query = format!(
-        "SELECT ct.conversation_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target, t.autotag_description
+        "SELECT ct.conversation_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target, t.autotag_description, ct.mode
          FROM conversation_tags ct
          JOIN tags t ON ct.tag_id = t.id
          WHERE ct.conversation_id IN ({})
@@ -301,17 +308,21 @@ fn batch_fetch_conversation_tags(
         placeholders
     );
     let mut stmt = conn.prepare(&query)?;
-    let mut map: std::collections::HashMap<String, Vec<Tag>> = std::collections::HashMap::new();
+    let mut map: std::collections::HashMap<String, Vec<ScopeTag>> =
+        std::collections::HashMap::new();
     let rows = stmt.query_map(rusqlite::params_from_iter(conv_ids.iter()), |row| {
         Ok((
             row.get::<_, String>(0)?,
-            Tag {
-                id: row.get(1)?,
-                name: row.get(2)?,
-                parent_id: row.get(3)?,
-                created_at: row.get(4)?,
-                is_autotag_target: row.get::<_, i32>(5)? != 0,
-                autotag_description: row.get(6)?,
+            ScopeTag {
+                tag: Tag {
+                    id: row.get(1)?,
+                    name: row.get(2)?,
+                    parent_id: row.get(3)?,
+                    created_at: row.get(4)?,
+                    is_autotag_target: row.get::<_, i32>(5)? != 0,
+                    autotag_description: row.get(6)?,
+                },
+                mode: ScopeMode::from_db(&row.get::<_, String>(7)?),
             },
         ))
     })?;
@@ -595,26 +606,13 @@ pub fn delete_conversation(conn: &Connection, id: &str) -> Result<(), AtomicCore
 
 // ==================== Scope Management ====================
 
-/// Set the full scope (replace all tags)
-pub fn set_conversation_scope(
+/// Touch the conversation's `updated_at` and read it back with its scope —
+/// the tail every scope mutation shares.
+fn reload_after_scope_change(
     conn: &Connection,
     conversation_id: &str,
-    tag_ids: &[String],
 ) -> Result<ConversationWithTags, AtomicCoreError> {
     let now = chrono::Utc::now().to_rfc3339();
-
-    conn.execute(
-        "DELETE FROM conversation_tags WHERE conversation_id = ?1",
-        [conversation_id],
-    )?;
-
-    for tag_id in tag_ids {
-        conn.execute(
-            "INSERT INTO conversation_tags (conversation_id, tag_id) VALUES (?1, ?2)",
-            rusqlite::params![conversation_id, tag_id],
-        )?;
-    }
-
     conn.execute(
         "UPDATE conversations SET updated_at = ?1 WHERE id = ?2",
         rusqlite::params![&now, conversation_id],
@@ -650,52 +648,43 @@ pub fn set_conversation_scope(
     })
 }
 
-/// Add a single tag to scope
+/// Set the full scope (replace all tags)
+pub fn set_conversation_scope(
+    conn: &Connection,
+    conversation_id: &str,
+    entries: &[ScopeEntry],
+) -> Result<ConversationWithTags, AtomicCoreError> {
+    conn.execute(
+        "DELETE FROM conversation_tags WHERE conversation_id = ?1",
+        [conversation_id],
+    )?;
+
+    for entry in entries {
+        conn.execute(
+            "INSERT INTO conversation_tags (conversation_id, tag_id, mode) VALUES (?1, ?2, ?3)",
+            rusqlite::params![conversation_id, &entry.tag_id, entry.mode.as_str()],
+        )?;
+    }
+
+    reload_after_scope_change(conn, conversation_id)
+}
+
+/// Put a tag in the scope under `mode`. A tag already in scope changes mode
+/// rather than erroring — cycling a chip's mode is the same operation as
+/// adding it.
 pub fn add_tag_to_scope(
     conn: &Connection,
     conversation_id: &str,
     tag_id: &str,
+    mode: ScopeMode,
 ) -> Result<ConversationWithTags, AtomicCoreError> {
-    let now = chrono::Utc::now().to_rfc3339();
-
     conn.execute(
-        "INSERT OR IGNORE INTO conversation_tags (conversation_id, tag_id) VALUES (?1, ?2)",
-        rusqlite::params![conversation_id, tag_id],
+        "INSERT INTO conversation_tags (conversation_id, tag_id, mode) VALUES (?1, ?2, ?3)
+         ON CONFLICT(conversation_id, tag_id) DO UPDATE SET mode = excluded.mode",
+        rusqlite::params![conversation_id, tag_id, mode.as_str()],
     )?;
 
-    conn.execute(
-        "UPDATE conversations SET updated_at = ?1 WHERE id = ?2",
-        rusqlite::params![&now, conversation_id],
-    )?;
-
-    let conversation = conn
-        .query_row(
-            "SELECT id, title, created_at, updated_at, is_archived
-             FROM conversations WHERE id = ?1",
-            [conversation_id],
-            |row| {
-                Ok(Conversation {
-                    id: row.get(0)?,
-                    title: row.get(1)?,
-                    created_at: row.get(2)?,
-                    updated_at: row.get(3)?,
-                    is_archived: row.get::<_, i32>(4)? != 0,
-                })
-            },
-        )
-        .map_err(|_| {
-            AtomicCoreError::NotFound(format!("Conversation not found: {}", conversation_id))
-        })?;
-
-    let tags = get_conversation_tags(conn, conversation_id)?;
-    let (message_count, last_message_preview) = get_conversation_summary(conn, conversation_id)?;
-
-    Ok(ConversationWithTags {
-        conversation,
-        tags,
-        message_count,
-        last_message_preview,
-    })
+    reload_after_scope_change(conn, conversation_id)
 }
 
 /// Remove a single tag from scope
@@ -704,46 +693,12 @@ pub fn remove_tag_from_scope(
     conversation_id: &str,
     tag_id: &str,
 ) -> Result<ConversationWithTags, AtomicCoreError> {
-    let now = chrono::Utc::now().to_rfc3339();
-
     conn.execute(
         "DELETE FROM conversation_tags WHERE conversation_id = ?1 AND tag_id = ?2",
         rusqlite::params![conversation_id, tag_id],
     )?;
 
-    conn.execute(
-        "UPDATE conversations SET updated_at = ?1 WHERE id = ?2",
-        rusqlite::params![&now, conversation_id],
-    )?;
-
-    let conversation = conn
-        .query_row(
-            "SELECT id, title, created_at, updated_at, is_archived
-             FROM conversations WHERE id = ?1",
-            [conversation_id],
-            |row| {
-                Ok(Conversation {
-                    id: row.get(0)?,
-                    title: row.get(1)?,
-                    created_at: row.get(2)?,
-                    updated_at: row.get(3)?,
-                    is_archived: row.get::<_, i32>(4)? != 0,
-                })
-            },
-        )
-        .map_err(|_| {
-            AtomicCoreError::NotFound(format!("Conversation not found: {}", conversation_id))
-        })?;
-
-    let tags = get_conversation_tags(conn, conversation_id)?;
-    let (message_count, last_message_preview) = get_conversation_summary(conn, conversation_id)?;
-
-    Ok(ConversationWithTags {
-        conversation,
-        tags,
-        message_count,
-        last_message_preview,
-    })
+    reload_after_scope_change(conn, conversation_id)
 }
 
 // ==================== Message DB Operations ====================
@@ -818,8 +773,8 @@ pub fn save_citations(
 ) -> Result<(), AtomicCoreError> {
     for citation in citations {
         conn.execute(
-            "INSERT INTO chat_citations (id, message_id, citation_index, atom_id, chunk_index, excerpt, relevance_score)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO chat_citations (id, message_id, citation_index, atom_id, chunk_index, excerpt, relevance_score, source_type)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             rusqlite::params![
                 &citation.id,
                 message_id,
@@ -828,36 +783,96 @@ pub fn save_citations(
                 citation.chunk_index,
                 &citation.excerpt,
                 citation.relevance_score,
+                &citation.source_type,
             ],
         )?;
     }
     Ok(())
 }
 
-/// Get scope tag IDs for a conversation
-pub fn get_scope_tag_ids(
+/// Get the retrieval scope for a conversation.
+pub fn get_conversation_scope(
     conn: &Connection,
     conversation_id: &str,
-) -> Result<Vec<String>, AtomicCoreError> {
+) -> Result<ScopeFilter, AtomicCoreError> {
     let mut stmt =
-        conn.prepare("SELECT tag_id FROM conversation_tags WHERE conversation_id = ?1")?;
+        conn.prepare("SELECT tag_id, mode FROM conversation_tags WHERE conversation_id = ?1")?;
 
-    let tag_ids = stmt
-        .query_map([conversation_id], |row| row.get(0))?
+    let rows = stmt
+        .query_map([conversation_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                ScopeMode::from_db(&row.get::<_, String>(1)?),
+            ))
+        })?
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(tag_ids)
+    let mut scope = ScopeFilter::default();
+    for (tag_id, mode) in rows {
+        scope.push(tag_id, mode);
+    }
+    Ok(scope)
 }
 
-/// Get scope description for system prompt
-pub fn get_scope_description(conn: &Connection, tag_ids: &[String]) -> String {
-    if tag_ids.is_empty() {
+/// Describe a scope for the system prompt, given resolved tag names.
+///
+/// Shared by both backends so the model is told the same contract the
+/// retrieval layer enforces. Tags whose names don't resolve are dropped —
+/// naming an id back to the model teaches it nothing.
+pub(crate) fn describe_scope(
+    scope: &ScopeFilter,
+    names: &std::collections::HashMap<String, String>,
+) -> String {
+    let named = |ids: &[String]| -> Vec<String> {
+        ids.iter()
+            .filter_map(|id| names.get(id).cloned())
+            .collect::<Vec<_>>()
+    };
+    let (include, require, exclude) = (
+        named(&scope.include),
+        named(&scope.require),
+        named(&scope.exclude),
+    );
+
+    if include.is_empty() && require.is_empty() && exclude.is_empty() {
         return "You have access to ALL atoms in the knowledge base.".to_string();
     }
 
-    let placeholders: Vec<String> = (0..tag_ids.len()).map(|i| format!("?{}", i + 1)).collect();
+    let mut sentences = Vec::new();
+    if include.is_empty() {
+        sentences.push("You have access to all atoms in the knowledge base, with the filters below applied to every search.".to_string());
+    } else {
+        sentences.push(format!(
+            "You have access to atoms tagged with any of: {}. Focus your search on these topics.",
+            include.join(", ")
+        ));
+    }
+    if !require.is_empty() {
+        sentences.push(format!(
+            "Only atoms tagged with every one of: {} are in scope.",
+            require.join(", ")
+        ));
+    }
+    if !exclude.is_empty() {
+        sentences.push(format!(
+            "Atoms tagged with any of: {} are excluded and will never appear in your search results.",
+            exclude.join(", ")
+        ));
+    }
+    sentences.push("A tag also covers its child tags. This scope is enforced by search itself — you cannot widen it.".to_string());
+    sentences.join(" ")
+}
+
+/// Get scope description for system prompt
+pub fn get_scope_description(conn: &Connection, scope: &ScopeFilter) -> String {
+    let roots = scope.roots();
+    if roots.is_empty() {
+        return describe_scope(scope, &std::collections::HashMap::new());
+    }
+
+    let placeholders: Vec<String> = (0..roots.len()).map(|i| format!("?{}", i + 1)).collect();
     let query = format!(
-        "SELECT name FROM tags WHERE id IN ({})",
+        "SELECT id, name FROM tags WHERE id IN ({})",
         placeholders.join(", ")
     );
 
@@ -867,19 +882,16 @@ pub fn get_scope_description(conn: &Connection, tag_ids: &[String]) -> String {
     };
 
     let params: Vec<&dyn rusqlite::ToSql> =
-        tag_ids.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
-    let names: Vec<String> = stmt
-        .query_map(params.as_slice(), |row| row.get(0))
+        roots.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+    let names: std::collections::HashMap<String, String> = stmt
+        .query_map(params.as_slice(), |row| Ok((row.get(0)?, row.get(1)?)))
         .map(|rows| rows.filter_map(|r| r.ok()).collect())
         .unwrap_or_default();
 
     if names.is_empty() {
         "You have access to a scoped set of atoms.".to_string()
     } else {
-        format!(
-            "You have access to atoms tagged with: {}. Focus your search on these topics.",
-            names.join(", ")
-        )
+        describe_scope(scope, &names)
     }
 }
 
@@ -956,7 +968,7 @@ mod tests {
 
         let result = create_conversation(&conn, &[tag_id.clone()], Some("Tagged Chat")).unwrap();
         assert_eq!(result.tags.len(), 1);
-        assert_eq!(result.tags[0].name, "TestTag");
+        assert_eq!(result.tags[0].tag.name, "TestTag");
     }
 
     #[test]
@@ -1054,12 +1066,27 @@ mod tests {
         let conv = create_conversation(&conn, &[], None).unwrap();
 
         // Add tag
-        let result = add_tag_to_scope(&conn, &conv.conversation.id, &tag1_id).unwrap();
+        let result =
+            add_tag_to_scope(&conn, &conv.conversation.id, &tag1_id, ScopeMode::Include).unwrap();
         assert_eq!(result.tags.len(), 1);
 
         // Add another tag
-        let result = add_tag_to_scope(&conn, &conv.conversation.id, &tag2_id).unwrap();
+        let result =
+            add_tag_to_scope(&conn, &conv.conversation.id, &tag2_id, ScopeMode::Exclude).unwrap();
         assert_eq!(result.tags.len(), 2);
+
+        // Re-adding a tag changes its mode instead of duplicating it
+        let result =
+            add_tag_to_scope(&conn, &conv.conversation.id, &tag2_id, ScopeMode::Require).unwrap();
+        assert_eq!(result.tags.len(), 2);
+        assert_eq!(
+            result
+                .tags
+                .iter()
+                .find(|t| t.tag.id == tag2_id)
+                .map(|t| t.mode),
+            Some(ScopeMode::Require)
+        );
 
         // Remove tag
         let result = remove_tag_from_scope(&conn, &conv.conversation.id, &tag1_id).unwrap();
@@ -1069,10 +1096,23 @@ mod tests {
         let result = set_conversation_scope(
             &conn,
             &conv.conversation.id,
-            &[tag1_id.clone(), tag2_id.clone()],
+            &[
+                ScopeEntry {
+                    tag_id: tag1_id.clone(),
+                    mode: ScopeMode::Include,
+                },
+                ScopeEntry {
+                    tag_id: tag2_id.clone(),
+                    mode: ScopeMode::Exclude,
+                },
+            ],
         )
         .unwrap();
         assert_eq!(result.tags.len(), 2);
+
+        let scope = get_conversation_scope(&conn, &conv.conversation.id).unwrap();
+        assert_eq!(scope.include, vec![tag1_id]);
+        assert_eq!(scope.exclude, vec![tag2_id]);
     }
 
     #[test]

--- a/crates/atomic-core/src/chat.rs
+++ b/crates/atomic-core/src/chat.rs
@@ -417,46 +417,53 @@ pub fn create_conversation(
     })
 }
 
-/// Get all conversations, optionally filtered by tag
+/// Get all conversations, optionally filtered by tag. Archived conversations
+/// are hidden unless `include_archived` — the comparison against
+/// `max_archived` keeps both cases on one query shape.
 pub fn get_conversations(
     conn: &Connection,
     filter_tag_id: Option<&str>,
     limit: i32,
     offset: i32,
+    include_archived: bool,
 ) -> Result<Vec<ConversationWithTags>, AtomicCoreError> {
+    let max_archived = i32::from(include_archived);
     let conversations: Vec<Conversation> = if let Some(tag_id) = filter_tag_id {
         let mut stmt = conn.prepare(
             "SELECT DISTINCT c.id, c.title, c.created_at, c.updated_at, c.is_archived
              FROM conversations c
              JOIN conversation_tags ct ON ct.conversation_id = c.id
-             WHERE ct.tag_id = ?1 AND c.is_archived = 0
+             WHERE ct.tag_id = ?1 AND c.is_archived <= ?4
              ORDER BY c.updated_at DESC
              LIMIT ?2 OFFSET ?3",
         )?;
 
         let results = stmt
-            .query_map(rusqlite::params![tag_id, limit, offset], |row| {
-                Ok(Conversation {
-                    id: row.get(0)?,
-                    title: row.get(1)?,
-                    created_at: row.get(2)?,
-                    updated_at: row.get(3)?,
-                    is_archived: row.get::<_, i32>(4)? != 0,
-                })
-            })?
+            .query_map(
+                rusqlite::params![tag_id, limit, offset, max_archived],
+                |row| {
+                    Ok(Conversation {
+                        id: row.get(0)?,
+                        title: row.get(1)?,
+                        created_at: row.get(2)?,
+                        updated_at: row.get(3)?,
+                        is_archived: row.get::<_, i32>(4)? != 0,
+                    })
+                },
+            )?
             .collect::<Result<Vec<_>, _>>()?;
         results
     } else {
         let mut stmt = conn.prepare(
             "SELECT id, title, created_at, updated_at, is_archived
              FROM conversations
-             WHERE is_archived = 0
+             WHERE is_archived <= ?3
              ORDER BY updated_at DESC
              LIMIT ?1 OFFSET ?2",
         )?;
 
         let results = stmt
-            .query_map(rusqlite::params![limit, offset], |row| {
+            .query_map(rusqlite::params![limit, offset, max_archived], |row| {
                 Ok(Conversation {
                     id: row.get(0)?,
                     title: row.get(1)?,
@@ -960,8 +967,28 @@ mod tests {
         create_conversation(&conn, &[], Some("Chat 1")).unwrap();
         create_conversation(&conn, &[], Some("Chat 2")).unwrap();
 
-        let conversations = get_conversations(&conn, None, 10, 0).unwrap();
+        let conversations = get_conversations(&conn, None, 10, 0, false).unwrap();
         assert_eq!(conversations.len(), 2);
+    }
+
+    #[test]
+    fn test_get_conversations_archive_visibility() {
+        let (db, _temp) = setup_db();
+        let conn = db.conn.lock().unwrap();
+
+        let kept = create_conversation(&conn, &[], Some("Kept")).unwrap();
+        let archived = create_conversation(&conn, &[], Some("Archived")).unwrap();
+        update_conversation(&conn, &archived.conversation.id, None, Some(true)).unwrap();
+
+        let visible = get_conversations(&conn, None, 10, 0, false).unwrap();
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].conversation.id, kept.conversation.id);
+
+        let all = get_conversations(&conn, None, 10, 0, true).unwrap();
+        assert_eq!(all.len(), 2);
+        assert!(all
+            .iter()
+            .any(|c| c.conversation.id == archived.conversation.id && c.conversation.is_archived));
     }
 
     #[test]
@@ -1093,7 +1120,7 @@ mod tests {
         .unwrap();
 
         // Must not panic.
-        let conversations = get_conversations(&conn, None, 10, 0).unwrap();
+        let conversations = get_conversations(&conn, None, 10, 0, false).unwrap();
         assert_eq!(conversations.len(), 1);
         let preview = conversations[0]
             .last_message_preview

--- a/crates/atomic-core/src/chat_title.rs
+++ b/crates/atomic-core/src/chat_title.rs
@@ -1,0 +1,214 @@
+//! Auto-generated conversation titles.
+//!
+//! A conversation is created untitled and the UI falls back to "New
+//! Conversation" for every one of them, which makes the list unreadable the
+//! moment it holds more than a couple of entries. After a turn completes,
+//! [`spawn_generation`] names the conversation from its first exchange.
+//!
+//! Three properties matter:
+//!
+//! - **It never affects the turn.** Generation runs in a detached task, so a
+//!   slow or dead title model costs the message flow nothing. Every failure
+//!   is a log line; the title simply stays `NULL` and the next turn retries.
+//! - **It never overwrites a title.** A non-`NULL` title — auto-generated
+//!   earlier or typed by the user — ends generation before the model call.
+//! - **It rides the tagging model**, not the chat model: naming a
+//!   conversation is a cheap utility completion, the same class of work as
+//!   auto-tagging, and shouldn't bill at agentic-model rates.
+
+use std::collections::HashMap;
+
+use crate::agent::{ChatEvent, ChatEventCallback};
+use crate::models::ChatMessageWithContext;
+use crate::providers::traits::LlmConfig;
+use crate::providers::types::{GenerationParams, Message};
+use crate::providers::{create_llm_provider, ProviderConfig};
+use crate::storage::StorageBackend;
+
+/// Words a generated title may keep. Titles are read in a narrow list
+/// column, so they earn their space by being scannable, not complete.
+const MAX_TITLE_WORDS: usize = 6;
+
+/// Defensive character cap for a model that answers with six very long
+/// words. Applied after the word limit.
+const MAX_TITLE_CHARS: usize = 60;
+
+/// How much of each message the model gets to name the conversation.
+/// The opening exchange establishes the subject; the rest is elaboration
+/// we don't need to pay for.
+const MAX_EXCERPT_CHARS: usize = 1000;
+
+const TITLE_SYSTEM_PROMPT: &str = "You write a conversation title: at most 6 words \
+naming what the exchange is about. Reply with the title alone — no quotes, no \
+trailing punctuation, no explanation.";
+
+/// Name `conversation_id` from its first exchange, in a detached task.
+///
+/// Fire-and-forget by construction: the caller gets no handle and no error.
+/// See the module docs for what that buys.
+pub(crate) fn spawn_generation(
+    storage: StorageBackend,
+    settings: HashMap<String, String>,
+    conversation_id: String,
+    on_event: ChatEventCallback,
+) {
+    tokio::spawn(async move {
+        let title = match generate(&storage, &settings, &conversation_id).await {
+            Ok(Some(title)) => title,
+            // Already titled, or the model produced nothing usable.
+            Ok(None) => return,
+            Err(error) => {
+                tracing::debug!(
+                    conversation_id = %conversation_id,
+                    error = %error,
+                    "chat: conversation title generation failed; leaving it untitled"
+                );
+                return;
+            }
+        };
+
+        match storage
+            .update_conversation_sync(&conversation_id, Some(&title), None)
+            .await
+        {
+            Ok(_) => on_event(ChatEvent::ConversationUpdated {
+                conversation_id,
+                title,
+            }),
+            Err(error) => tracing::warn!(
+                conversation_id = %conversation_id,
+                error = %error,
+                "chat: failed to persist generated conversation title"
+            ),
+        }
+    });
+}
+
+/// `Ok(None)` means "nothing to do" (already titled, no exchange yet, or an
+/// unusable answer); `Err` means the attempt itself failed.
+async fn generate(
+    storage: &StorageBackend,
+    settings: &HashMap<String, String>,
+    conversation_id: &str,
+) -> Result<Option<String>, String> {
+    let Some(conversation) = storage
+        .get_conversation_sync(conversation_id)
+        .await
+        .map_err(|e| e.to_string())?
+    else {
+        return Ok(None);
+    };
+
+    // The only guard that matters: a title, however it got there, is the
+    // user's to change from here on.
+    if conversation.conversation.title.is_some() {
+        return Ok(None);
+    }
+
+    let (Some(user), Some(assistant)) = (
+        first_message(&conversation.messages, "user"),
+        first_message(&conversation.messages, "assistant"),
+    ) else {
+        return Ok(None);
+    };
+
+    let provider_config = ProviderConfig::from_settings(settings);
+    let model = provider_config.llm_model().to_string();
+    let provider = create_llm_provider(&provider_config).map_err(|e| e.to_string())?;
+    let config = LlmConfig::new(&model).with_params(
+        GenerationParams::new()
+            .with_temperature(0.3)
+            .with_max_tokens(32)
+            .with_minimize_reasoning(true),
+    );
+    let messages = vec![
+        Message::system(TITLE_SYSTEM_PROMPT),
+        Message::user(format!(
+            "Message:\n{user}\n\nReply:\n{assistant}\n\nTitle:"
+        )),
+    ];
+
+    let response = provider
+        .complete(&messages, &config)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(sanitize(&response.content))
+}
+
+fn first_message(messages: &[ChatMessageWithContext], role: &str) -> Option<String> {
+    messages
+        .iter()
+        .find(|m| m.message.role == role && !m.message.content.trim().is_empty())
+        .map(|m| truncate_chars(m.message.content.trim(), MAX_EXCERPT_CHARS))
+}
+
+/// Reduce a model's answer to something that belongs in a list row, or
+/// `None` when there's nothing left worth persisting.
+fn sanitize(raw: &str) -> Option<String> {
+    let first_line = raw.lines().map(str::trim).find(|line| !line.is_empty())?;
+    // Models like to wrap titles in quotes or markdown emphasis, and to end
+    // them like sentences. All decoration, none of it wanted in a list row.
+    let trimmed = first_line
+        .trim_matches(['"', '\'', '“', '”', '‘', '’', '`', '*', '#'])
+        .trim_end_matches(['.', ',', ';', ':', '!', '?'])
+        .trim();
+
+    let title = trimmed
+        .split_whitespace()
+        .take(MAX_TITLE_WORDS)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let title = truncate_chars(&title, MAX_TITLE_CHARS);
+
+    (!title.is_empty()).then_some(title)
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    text.chars()
+        .take(max_chars)
+        .collect::<String>()
+        .trim_end()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_quotes_and_trailing_punctuation() {
+        assert_eq!(
+            sanitize("\"Pelican migration notes.\""),
+            Some("Pelican migration notes".to_string())
+        );
+        assert_eq!(
+            sanitize("**Rust ownership rules!**"),
+            Some("Rust ownership rules".to_string())
+        );
+    }
+
+    #[test]
+    fn keeps_only_the_first_line_and_six_words() {
+        assert_eq!(
+            sanitize("Seven word titles get cut down here\n\nExplanation the model added"),
+            Some("Seven word titles get cut down".to_string())
+        );
+    }
+
+    #[test]
+    fn truncates_absurdly_long_words_on_a_char_boundary() {
+        let title = sanitize(&"ü".repeat(200)).expect("a title");
+        assert_eq!(title.chars().count(), MAX_TITLE_CHARS);
+    }
+
+    #[test]
+    fn rejects_answers_with_nothing_left() {
+        assert_eq!(sanitize(""), None);
+        assert_eq!(sanitize("   \n  "), None);
+        assert_eq!(sanitize("\"...\""), None);
+    }
+}

--- a/crates/atomic-core/src/chat_title.rs
+++ b/crates/atomic-core/src/chat_title.rs
@@ -11,7 +11,9 @@
 //!   slow or dead title model costs the message flow nothing. Every failure
 //!   is a log line; the title simply stays `NULL` and the next turn retries.
 //! - **It never overwrites a title.** A non-`NULL` title — auto-generated
-//!   earlier or typed by the user — ends generation before the model call.
+//!   earlier or typed by the user — ends generation before the model call,
+//!   and the write itself is conditional on the title still being `NULL`, so
+//!   a rename that lands while the model is thinking wins.
 //! - **It rides the tagging model**, not the chat model: naming a
 //!   conversation is a cheap utility completion, the same class of work as
 //!   auto-tagging, and shouldn't bill at agentic-model rates.
@@ -67,14 +69,22 @@ pub(crate) fn spawn_generation(
             }
         };
 
+        // The pre-flight check in `generate` happens before a model call that
+        // can take seconds; the user can name the conversation inside that
+        // window. This write re-checks and skips atomically, so the rename
+        // survives — and with no row written there is nothing to announce.
         match storage
-            .update_conversation_sync(&conversation_id, Some(&title), None)
+            .set_conversation_title_if_unset_sync(&conversation_id, &title)
             .await
         {
-            Ok(_) => on_event(ChatEvent::ConversationUpdated {
+            Ok(true) => on_event(ChatEvent::ConversationUpdated {
                 conversation_id,
                 title,
             }),
+            Ok(false) => tracing::debug!(
+                conversation_id = %conversation_id,
+                "chat: conversation was named while its title was generating; keeping the existing title"
+            ),
             Err(error) => tracing::warn!(
                 conversation_id = %conversation_id,
                 error = %error,

--- a/crates/atomic-core/src/chat_tools.rs
+++ b/crates/atomic-core/src/chat_tools.rs
@@ -10,7 +10,7 @@
 //! and put the number they get back into their own output — that number is
 //! the `[N]` the model must write for the source to reach the user.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
@@ -81,6 +81,10 @@ impl ChatToolset {
             ),
             on_event: Arc::clone(&self.on_event),
         };
+        let guard = ScopeGuard {
+            storage: self.storage.clone(),
+            scope: self.scope.clone(),
+        };
 
         let mut registry = ToolRegistry::new()
             .with(SearchAtoms {
@@ -89,19 +93,19 @@ impl ChatToolset {
                 scope: self.scope,
             })
             .with(GetAtom {
-                storage: self.storage.clone(),
+                guard: guard.clone(),
             })
             .with(ListTags {
-                storage: self.storage.clone(),
+                guard: guard.clone(),
             })
             .with(GetWiki {
-                storage: self.storage.clone(),
+                guard: guard.clone(),
             })
             .with(ListReports {
-                storage: self.storage.clone(),
+                guard: guard.clone(),
             })
             .with(GetFinding {
-                storage: self.storage.clone(),
+                guard: guard.clone(),
             })
             .with(CreateAtom {
                 deps: mutations.clone(),
@@ -110,7 +114,7 @@ impl ChatToolset {
 
         if let Some(page_context) = self.page_context {
             registry.register(CurrentPageContext {
-                storage: self.storage,
+                guard,
                 page_context,
             });
         }
@@ -148,6 +152,189 @@ fn embedding_event_bridge(
 
 fn excerpt(text: &str) -> String {
     text.chars().take(EXCERPT_LEN).collect()
+}
+
+// ==================== Scope enforcement ====================
+
+/// The conversation's scope, applied to the tools that read *by id*.
+///
+/// `search_atoms` carries its scope into the query, so nothing outside it can
+/// come back. Every other reading tool is handed an id — an atom's, a tag's,
+/// a finding's — and would otherwise fetch it unconditionally, which turns
+/// the system prompt's promise that excluded tags "will never appear" into a
+/// suggestion. Each of them asks this guard first and refuses in plain
+/// language when the answer is no, so the model learns the boundary instead
+/// of retrying against it.
+#[derive(Clone)]
+struct ScopeGuard {
+    storage: StorageBackend,
+    scope: ScopeFilter,
+}
+
+impl ScopeGuard {
+    /// Which of `atom_ids` the scope admits. An empty scope admits
+    /// everything without touching storage.
+    async fn admitted_atoms(&self, atom_ids: &[String]) -> Result<HashSet<String>, String> {
+        if self.scope.is_empty() || atom_ids.is_empty() {
+            return Ok(atom_ids.iter().cloned().collect());
+        }
+        self.storage
+            .atoms_passing_scope_sync(atom_ids, &self.scope)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    async fn admits_atom(&self, atom_id: &str) -> Result<bool, String> {
+        let ids = vec![atom_id.to_string()];
+        Ok(self.admitted_atoms(&ids).await?.contains(atom_id))
+    }
+
+    /// Resolve the scope against a tag tree, once per call that needs it.
+    fn tags(&self, tree: &[TagWithCount]) -> TagScope {
+        TagScope::resolve(tree, &self.scope)
+    }
+}
+
+/// The scope as it applies to tags, resolved against one tag tree.
+///
+/// Two questions, because they have different answers. *Readable* is whether
+/// the tag's content — its wiki article — may be handed to the model:
+/// evaluated with [`ScopeFilter::admitted`], the same predicate the atom
+/// paths use, over the scope roots covering each tag. *Listable* is whether
+/// `list_tags` may name it: excluded branches are hidden outright, and an
+/// include scope narrows the listing to those branches plus the ancestors
+/// they hang from, so the model still sees where they sit.
+enum TagScope {
+    /// No scope at all — every tag is both readable and listable.
+    Open,
+    Filtered {
+        readable: HashSet<String>,
+        listable: HashSet<String>,
+    },
+}
+
+impl TagScope {
+    fn resolve(tree: &[TagWithCount], scope: &ScopeFilter) -> Self {
+        if scope.is_empty() {
+            return TagScope::Open;
+        }
+
+        let TagCoverage {
+            covering,
+            include_ancestors,
+            ..
+        } = TagCoverage::of(tree, scope);
+
+        let ids: Vec<String> = covering.keys().cloned().collect();
+        let readable = scope.admitted(ids.iter().map(String::as_str), &covering);
+
+        let covered_by = |id: &str, list: &[String]| {
+            covering
+                .get(id)
+                .is_some_and(|roots| list.iter().any(|tag| roots.contains(tag)))
+        };
+        let listable = ids
+            .iter()
+            .filter(|id| !covered_by(id, &scope.exclude))
+            .filter(|id| {
+                scope.include.is_empty()
+                    || covered_by(id, &scope.include)
+                    || include_ancestors.contains(*id)
+            })
+            .cloned()
+            .collect();
+
+        TagScope::Filtered { readable, listable }
+    }
+
+    fn readable(&self, tag_id: &str) -> bool {
+        match self {
+            TagScope::Open => true,
+            TagScope::Filtered { readable, .. } => readable.contains(tag_id),
+        }
+    }
+
+    fn listable(&self, tag_id: &str) -> bool {
+        match self {
+            TagScope::Open => true,
+            TagScope::Filtered { listable, .. } => listable.contains(tag_id),
+        }
+    }
+
+    /// The tree with every non-listable tag — and the branch beneath it —
+    /// removed. `children_total` is recounted so the "N sub-tags" pointer
+    /// doesn't advertise branches this conversation can't open.
+    fn prune(&self, nodes: &[TagWithCount]) -> Vec<TagWithCount> {
+        if matches!(self, TagScope::Open) {
+            return nodes.to_vec();
+        }
+        nodes
+            .iter()
+            .filter(|node| self.listable(&node.tag.id))
+            .map(|node| {
+                let children = self.prune(&node.children);
+                TagWithCount {
+                    tag: node.tag.clone(),
+                    atom_count: node.atom_count,
+                    children_total: children.len() as i32,
+                    children,
+                }
+            })
+            .collect()
+    }
+}
+
+/// One walk of the tag tree, recording per tag the scope roots covering it —
+/// itself or any ancestor — plus the ancestors of every include root, which a
+/// listing keeps so admitted branches still have a tree to hang from.
+struct TagCoverage {
+    roots: HashSet<String>,
+    include_roots: HashSet<String>,
+    covering: HashMap<String, HashSet<String>>,
+    include_ancestors: HashSet<String>,
+}
+
+impl TagCoverage {
+    fn of(tree: &[TagWithCount], scope: &ScopeFilter) -> Self {
+        let mut coverage = TagCoverage {
+            roots: scope.roots().into_iter().collect(),
+            include_roots: scope.include.iter().cloned().collect(),
+            covering: HashMap::new(),
+            include_ancestors: HashSet::new(),
+        };
+        coverage.walk(tree, &HashSet::new(), &[]);
+        coverage
+    }
+
+    fn walk(&mut self, nodes: &[TagWithCount], inherited: &HashSet<String>, path: &[String]) {
+        for node in nodes {
+            let id = &node.tag.id;
+            let mut mine = inherited.clone();
+            if self.roots.contains(id) {
+                mine.insert(id.clone());
+            }
+            if self.include_roots.contains(id) {
+                self.include_ancestors.extend(path.iter().cloned());
+            }
+            self.covering.insert(id.clone(), mine.clone());
+
+            let mut child_path = path.to_vec();
+            child_path.push(id.clone());
+            self.walk(&node.children, &mine, &child_path);
+        }
+    }
+}
+
+/// What a tool says when the scope won't let it read something. Names the
+/// boundary without describing what is behind it, and tells the model the
+/// refusal is final so it stops re-asking.
+fn out_of_scope(subject: &str) -> String {
+    format!(
+        "{} is outside this conversation's scope, so it can't be read here. \
+         The scope is fixed for this conversation — work from what is in scope, \
+         or tell the user what you would need them to add.",
+        subject
+    )
 }
 
 /// Lead a tool result with the number the model must cite, or with nothing
@@ -218,31 +405,53 @@ fn paging_args(args: &serde_json::Value) -> (usize, usize) {
     (offset, limit)
 }
 
+/// One window of content, split into what the model reads and what a
+/// citation quotes.
+struct LineWindow {
+    /// What the model is shown: the lines, led by a header explaining how to
+    /// read the rest whenever the content didn't fit in one call.
+    rendered: String,
+    /// The lines alone. Excerpts come from here, so a citation stored
+    /// alongside a paginated read quotes the source rather than the
+    /// bookkeeping line above it.
+    body: String,
+}
+
 /// A window of `limit` lines starting at `offset`, headed by how to read the
 /// rest through `tool`. Short content (the common case) comes back clean,
 /// with no metadata noise.
-fn line_window(content: &str, offset: usize, limit: usize, tool: &str) -> String {
+fn line_window(content: &str, offset: usize, limit: usize, tool: &str) -> LineWindow {
+    let plain = |text: String| LineWindow {
+        body: text.clone(),
+        rendered: text,
+    };
+
     let lines: Vec<&str> = content.lines().collect();
     let total = lines.len();
 
     // Empty content — return empty before the range math, otherwise a
     // nonzero offset would produce lines[offset..0] and panic.
     if total == 0 {
-        return String::new();
+        return plain(String::new());
     }
 
     if offset >= total {
-        return format!(
-            "[offset={} is past end of content ({} total lines)]",
-            offset, total
-        );
+        // Nothing was read, so there is nothing to quote: the notice is
+        // rendered but never becomes an excerpt.
+        return LineWindow {
+            rendered: format!(
+                "[offset={} is past end of content ({} total lines)]",
+                offset, total
+            ),
+            body: String::new(),
+        };
     }
 
     let end = (offset + limit).min(total);
-    let slice = lines[offset..end].join("\n");
+    let body = lines[offset..end].join("\n");
 
     if offset == 0 && end == total {
-        return slice;
+        return plain(body);
     }
 
     let header = if end < total {
@@ -264,7 +473,10 @@ fn line_window(content: &str, offset: usize, limit: usize, tool: &str) -> String
         )
     };
 
-    format!("{}{}", header, slice)
+    LineWindow {
+        rendered: format!("{}{}", header, body),
+        body,
+    }
 }
 
 /// Find a tag by id, then by exact name, then case-insensitively — the same
@@ -446,7 +658,7 @@ async fn search_atoms(
 // ==================== get_atom ====================
 
 struct GetAtom {
-    storage: StorageBackend,
+    guard: ScopeGuard,
 }
 
 #[async_trait]
@@ -471,17 +683,31 @@ impl AgentTool for GetAtom {
         let atom_id = args["atom_id"].as_str().unwrap_or("");
         let (offset, limit) = paging_args(args);
 
-        match read_atom_lines(&self.storage, atom_id, offset, limit).await {
-            Ok(Some(content)) => {
-                let number =
-                    ctx.citations
-                        .register(CitationSource::Atom, atom_id, None, excerpt(&content));
+        // Scope first: an id the model got from anywhere — a wiki article, a
+        // report listing, its own memory of an earlier conversation — must
+        // not become a way around the conversation's scope.
+        match self.guard.admits_atom(atom_id).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return ToolResult::ok(out_of_scope(&format!("Atom {}", atom_id)), 0);
+            }
+            Err(e) => return ToolResult::failed(e),
+        }
+
+        match read_atom_lines(&self.guard.storage, atom_id, offset, limit).await {
+            Ok(Some(window)) => {
+                let number = ctx.citations.register(
+                    CitationSource::Atom,
+                    atom_id,
+                    None,
+                    excerpt(&window.body),
+                );
                 ToolResult::ok(
                     format!(
                         "{}(atom_id: {})\n{}",
                         citation_marker(number),
                         atom_id,
-                        content
+                        window.rendered
                     ),
                     1,
                 )
@@ -497,7 +723,7 @@ async fn read_atom_lines(
     atom_id: &str,
     offset: usize,
     limit: usize,
-) -> Result<Option<String>, String> {
+) -> Result<Option<LineWindow>, String> {
     let Some(content) = storage
         .get_atom_content_impl(atom_id)
         .await
@@ -515,7 +741,7 @@ async fn read_atom_lines(
 /// sits under each. Purely navigational — a tag is not a source, so nothing
 /// here is citable.
 struct ListTags {
-    storage: StorageBackend,
+    guard: ScopeGuard,
 }
 
 #[async_trait]
@@ -537,21 +763,34 @@ impl AgentTool for ListTags {
     }
 
     async fn execute(&self, args: &serde_json::Value, _ctx: &ToolContext<'_>) -> ToolResult {
-        let tree = match self.storage.get_all_tags_impl().await {
+        let tree = match self.guard.storage.get_all_tags_impl().await {
             Ok(tree) => tree,
             Err(e) => return ToolResult::failed(e),
         };
+        // The listing is the map the model navigates by. Handing it branches
+        // the scope has closed invites a get_wiki or get_atom call that can
+        // only be refused, and names topics the user asked to keep out.
+        let scope = self.guard.tags(&tree);
+        let visible = scope.prune(&tree);
 
         let parent = args
             .get("parent_id")
             .and_then(|v| v.as_str())
             .filter(|value| !value.is_empty());
         let (heading, roots) = match parent {
+            // Resolved against the full tree so an in-scope name and an
+            // out-of-scope one get different answers.
             Some(needle) => match resolve_tag(&tree, needle) {
-                Some(tag) => (
-                    format!("Sub-tags of {} (counts include sub-tags):", tag.tag.name),
-                    std::slice::from_ref(tag),
-                ),
+                Some(tag) if !scope.listable(&tag.tag.id) => {
+                    return ToolResult::ok(out_of_scope(&format!("'{}'", tag.tag.name)), 0)
+                }
+                Some(tag) => match resolve_tag(&visible, &tag.tag.id) {
+                    Some(pruned) => (
+                        format!("Sub-tags of {} (counts include sub-tags):", pruned.tag.name),
+                        std::slice::from_ref(pruned),
+                    ),
+                    None => return ToolResult::ok(out_of_scope(&format!("'{}'", tag.tag.name)), 0),
+                },
                 None => {
                     return ToolResult::ok(
                         format!("No tag matches '{}'. Call list_tags with no arguments to see the top of the tree.", needle),
@@ -561,12 +800,19 @@ impl AgentTool for ListTags {
             },
             None => (
                 "Tags (counts include sub-tags):".to_string(),
-                tree.as_slice(),
+                visible.as_slice(),
             ),
         };
 
         if roots.is_empty() {
-            return ToolResult::ok("This knowledge base has no tags yet.", 0);
+            return ToolResult::ok(
+                if tree.is_empty() {
+                    "This knowledge base has no tags yet."
+                } else {
+                    "No tags are within this conversation's scope."
+                },
+                0,
+            );
         }
 
         let mut out = heading;
@@ -614,7 +860,7 @@ fn render_tags(nodes: &[TagWithCount], depth: usize, out: &mut String, rendered:
 /// The synthesized article for a tag — the one place the knowledge base
 /// already answers "what do I know about X?" in prose.
 struct GetWiki {
-    storage: StorageBackend,
+    guard: ScopeGuard,
 }
 
 #[async_trait]
@@ -641,7 +887,7 @@ impl AgentTool for GetWiki {
             return ToolResult::failed("tag is required");
         }
 
-        let tree = match self.storage.get_all_tags_impl().await {
+        let tree = match self.guard.storage.get_all_tags_impl().await {
             Ok(tree) => tree,
             Err(e) => return ToolResult::failed(e),
         };
@@ -655,7 +901,18 @@ impl AgentTool for GetWiki {
             );
         };
 
-        let wiki = match self.storage.get_wiki_sync(&tag.tag.id).await {
+        // An article is the densest read in the knowledge base — a whole
+        // tag's worth of atoms in prose. A scope that closes the tag has to
+        // close the article with it, or excluding a topic would mean nothing
+        // more than excluding its atoms from search.
+        if !self.guard.tags(&tree).readable(&tag.tag.id) {
+            return ToolResult::ok(
+                out_of_scope(&format!("The wiki article for '{}'", tag.tag.name)),
+                0,
+            );
+        }
+
+        let wiki = match self.guard.storage.get_wiki_sync(&tag.tag.id).await {
             Ok(Some(wiki)) => wiki,
             Ok(None) => {
                 return ToolResult::ok(
@@ -670,15 +927,18 @@ impl AgentTool for GetWiki {
         };
 
         let (offset, limit) = paging_args(args);
-        let content = line_window(
+        let window = line_window(
             &strip_citation_markers(&wiki.article.content),
             offset,
             limit,
             "get_wiki",
         );
-        let number =
-            ctx.citations
-                .register(CitationSource::Wiki, &tag.tag.id, None, excerpt(&content));
+        let number = ctx.citations.register(
+            CitationSource::Wiki,
+            &tag.tag.id,
+            None,
+            excerpt(&window.body),
+        );
         ToolResult::ok(
             format!(
                 "{}(wiki article for tag: {}, tag_id: {}, {} atoms, updated {})\n{}",
@@ -687,7 +947,7 @@ impl AgentTool for GetWiki {
                 tag.tag.id,
                 wiki.article.atom_count,
                 wiki.article.updated_at,
-                content
+                window.rendered
             ),
             1,
         )
@@ -699,7 +959,7 @@ impl AgentTool for GetWiki {
 /// What the user's scheduled research has been looking into, and when it
 /// last reported back.
 struct ListReports {
-    storage: StorageBackend,
+    guard: ScopeGuard,
 }
 
 #[async_trait]
@@ -717,7 +977,7 @@ impl AgentTool for ListReports {
     }
 
     async fn execute(&self, _args: &serde_json::Value, _ctx: &ToolContext<'_>) -> ToolResult {
-        let reports = match self.storage.list_reports_sync().await {
+        let reports = match self.guard.storage.list_reports_sync().await {
             Ok(reports) => reports,
             Err(e) => return ToolResult::failed(e),
         };
@@ -726,9 +986,39 @@ impl AgentTool for ListReports {
         }
 
         let total = reports.len();
+        let listed: Vec<_> = reports.into_iter().take(MAX_REPORTS).collect();
+
+        // One finding each: the list is a menu, and get_finding is how the
+        // model reads the thing it picks. Loaded up front so the scope check
+        // over all of them is a single query.
+        let mut latest = Vec::with_capacity(listed.len());
+        for report in &listed {
+            latest.push(
+                self.guard
+                    .storage
+                    .list_findings_for_report_sync(&report.id, 1)
+                    .await
+                    .map(|findings| findings.into_iter().next()),
+            );
+        }
+        let finding_atom_ids: Vec<String> = latest
+            .iter()
+            .filter_map(|result| result.as_ref().ok()?.as_ref())
+            .map(|(_, atom)| atom.atom.id.clone())
+            .collect();
+        // A report's scope and the conversation's are independent, so a
+        // finding can sit outside this conversation entirely. The report
+        // itself stays listed — its name and schedule are configuration, not
+        // knowledge — but the finding's title and id do not, or the listing
+        // becomes the index into content the scope closed.
+        let admitted = match self.guard.admitted_atoms(&finding_atom_ids).await {
+            Ok(admitted) => admitted,
+            Err(e) => return ToolResult::failed(e),
+        };
+
         let mut out = String::new();
         let mut count = 0;
-        for report in reports.into_iter().take(MAX_REPORTS) {
+        for (report, finding) in listed.into_iter().zip(latest) {
             count += 1;
             out.push_str(&format!(
                 "{} (report_id: {}, schedule: {}{})",
@@ -740,15 +1030,9 @@ impl AgentTool for ListReports {
             if let Some(description) = report.description.as_deref().filter(|d| !d.is_empty()) {
                 out.push_str(&format!("\n  {}", description));
             }
-            // One finding each: the list is a menu, and get_finding is how
-            // the model reads the thing it picks.
-            match self
-                .storage
-                .list_findings_for_report_sync(&report.id, 1)
-                .await
-            {
-                Ok(findings) => match findings.first() {
-                    Some((finding, atom)) => out.push_str(&format!(
+            match finding {
+                Ok(Some((finding, atom))) if admitted.contains(&atom.atom.id) => {
+                    out.push_str(&format!(
                         "\n  latest finding: {} ({}, atom_id: {})",
                         if atom.atom.title.is_empty() {
                             "(untitled)"
@@ -757,9 +1041,12 @@ impl AgentTool for ListReports {
                         },
                         finding.created_at,
                         atom.atom.id
-                    )),
-                    None => out.push_str("\n  no findings yet"),
-                },
+                    ))
+                }
+                Ok(Some(_)) => {
+                    out.push_str("\n  latest finding: outside this conversation's scope")
+                }
+                Ok(None) => out.push_str("\n  no findings yet"),
                 Err(e) => out.push_str(&format!("\n  (could not load findings: {})", e)),
             }
             out.push_str("\n\n");
@@ -775,7 +1062,7 @@ impl AgentTool for ListReports {
 /// One finding in full. Findings are atoms of kind `report`, so this is the
 /// atom read path with the provenance the finding reader shows.
 struct GetFinding {
-    storage: StorageBackend,
+    guard: ScopeGuard,
 }
 
 #[async_trait]
@@ -798,7 +1085,17 @@ impl AgentTool for GetFinding {
 
     async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult {
         let atom_id = args["atom_id"].as_str().unwrap_or("");
-        let finding = match self.storage.get_atom_impl(atom_id).await {
+
+        // Findings are atoms, so they are scoped like atoms — and this is the
+        // tool the list_reports menu points at, which makes it the obvious
+        // way around a scope if it doesn't check.
+        match self.guard.admits_atom(atom_id).await {
+            Ok(true) => {}
+            Ok(false) => return ToolResult::ok(out_of_scope("That finding"), 0),
+            Err(e) => return ToolResult::failed(e),
+        }
+
+        let finding = match self.guard.storage.get_atom_impl(atom_id).await {
             Ok(Some(finding)) => finding,
             Ok(None) => return ToolResult::ok("Finding not found", 0),
             Err(e) => return ToolResult::failed(e),
@@ -814,6 +1111,7 @@ impl AgentTool for GetFinding {
         }
 
         let provenance = self
+            .guard
             .storage
             .get_finding_provenance_sync(atom_id)
             .await
@@ -824,15 +1122,18 @@ impl AgentTool for GetFinding {
             .unwrap_or("(unknown report)");
 
         let (offset, limit) = paging_args(args);
-        let content = line_window(
+        let window = line_window(
             &strip_citation_markers(&finding.atom.content),
             offset,
             limit,
             "get_finding",
         );
-        let number =
-            ctx.citations
-                .register(CitationSource::Finding, atom_id, None, excerpt(&content));
+        let number = ctx.citations.register(
+            CitationSource::Finding,
+            atom_id,
+            None,
+            excerpt(&window.body),
+        );
         ToolResult::ok(
             format!(
                 "{}(finding from report: {}, atom_id: {}, created {})\n{}",
@@ -840,7 +1141,7 @@ impl AgentTool for GetFinding {
                 report_name,
                 atom_id,
                 finding.atom.created_at,
-                content
+                window.rendered
             ),
             1,
         )
@@ -1181,7 +1482,7 @@ async fn enqueue_and_process_pipeline(
 // ==================== get_current_page_context ====================
 
 struct CurrentPageContext {
-    storage: StorageBackend,
+    guard: ScopeGuard,
     page_context: PageContext,
 }
 
@@ -1203,10 +1504,11 @@ impl AgentTool for CurrentPageContext {
         let page = &self.page_context;
         let mut visible_atom = serde_json::Value::Null;
         if let Some(atom_id) = page.atom_id.as_deref().filter(|id| !id.is_empty()) {
-            let stored = match self.storage.get_atom_impl(atom_id).await {
+            let stored = match self.guard.storage.get_atom_impl(atom_id).await {
                 Ok(stored) => stored,
                 Err(e) => return ToolResult::failed(e),
             };
+            let found = stored.is_some();
             visible_atom = match stored {
                 Some(atom_with_tags) => json!({
                     "id": atom_with_tags.atom.id,
@@ -1227,11 +1529,23 @@ impl AgentTool for CurrentPageContext {
                 }),
             };
 
+            // What the user is looking at reaches the model because the user
+            // shared it — the context chip is that consent, per message. A
+            // *citation* is a different claim: it says the answer stands on a
+            // source this conversation is allowed to draw on. An atom the
+            // scope excludes isn't, and neither is one the frontend named
+            // that no longer exists — citing either would put a source in the
+            // answer that nothing can open.
+            let citable = found
+                && match self.guard.admits_atom(atom_id).await {
+                    Ok(admitted) => admitted,
+                    Err(e) => return ToolResult::failed(e),
+                };
             let snippet = visible_atom
                 .get("snippet")
                 .and_then(|snippet| snippet.as_str())
                 .unwrap_or("");
-            if !snippet.is_empty() {
+            if citable && !snippet.is_empty() {
                 let number =
                     ctx.citations
                         .register(CitationSource::Atom, atom_id, None, excerpt(snippet));

--- a/crates/atomic-core/src/chat_tools.rs
+++ b/crates/atomic-core/src/chat_tools.rs
@@ -1,0 +1,1337 @@
+//! Chat's tool registry.
+//!
+//! Every capability a chat turn has, expressed as an [`AgentTool`]. The four
+//! core tools are always present; the page-context and canvas tools are
+//! registered only when the frontend sent the matching context, which is how
+//! "conditional tools" works now that there is no dispatch match to branch
+//! inside.
+//!
+//! Tools that surface knowledge register it with the run's citation ledger
+//! and put the number they get back into their own output — that number is
+//! the `[N]` the model must write for the source to reach the user.
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use regex::Regex;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::agent::{CanvasContext, ChatEvent, ChatEventCallback, PageContext};
+use crate::agent_runtime::{AgentTool, CitationSource, ToolContext, ToolRegistry, ToolResult};
+use crate::atom_edit::{apply_atom_edits, AtomEditOperation};
+use crate::embedding::EmbeddingEvent;
+use crate::models::{AtomKind, AtomWithTags, SemanticSearchResult, TagWithCount};
+use crate::providers::types::ToolDefinition;
+use crate::providers::ProviderConfig;
+use crate::search::{ScopeFilter, SearchMode, SearchOptions};
+use crate::storage::StorageBackend;
+use crate::CanvasCache;
+
+/// How much of a source is stored with a citation. Long enough for the UI's
+/// popover to be useful, short enough not to duplicate the atom.
+const EXCERPT_LEN: usize = 200;
+
+/// Default line limit for a single content-reading call. Chosen to keep
+/// context usage bounded on long content (imports, pasted articles, wiki
+/// articles) while being large enough that most of them fit in one call.
+const READ_DEFAULT_LIMIT: usize = 500;
+const READ_MAX_LIMIT: usize = 2000;
+
+/// Tags rendered per level by `list_tags` before the rest are summarized as
+/// a count. Deep trees are common; a turn's worth of context is not.
+const MAX_TAGS_PER_LEVEL: usize = 15;
+
+/// Levels of tag tree one `list_tags` call renders. Two is enough to see
+/// what a branch is about; `parent_id` walks further.
+const TAG_TREE_DEPTH: usize = 2;
+
+/// Reports rendered by `list_reports`. A knowledge base with more than this
+/// many scheduled reports is unusual, and the tail is the least recently
+/// useful part of the list.
+const MAX_REPORTS: usize = 25;
+
+/// Everything a chat turn's tools need. Assembled by the chat entrypoints;
+/// `page_context` and `canvas` decide which optional tools get registered.
+pub(crate) struct ChatToolset {
+    pub storage: StorageBackend,
+    pub conversation_id: String,
+    pub scope: ScopeFilter,
+    pub settings: Option<HashMap<String, String>>,
+    pub inline_pipeline: bool,
+    pub canvas_cache: Option<CanvasCache>,
+    pub page_context: Option<PageContext>,
+    pub canvas_context: Option<CanvasContext>,
+    pub on_event: ChatEventCallback,
+}
+
+impl ChatToolset {
+    pub fn into_registry(self) -> ToolRegistry {
+        let mutations = MutationDeps {
+            storage: self.storage.clone(),
+            settings: self.settings.clone(),
+            inline_pipeline: self.inline_pipeline,
+            canvas_cache: self.canvas_cache,
+            conversation_id: self.conversation_id.clone(),
+            on_embedding_event: embedding_event_bridge(
+                Arc::clone(&self.on_event),
+                self.conversation_id.clone(),
+            ),
+            on_event: Arc::clone(&self.on_event),
+        };
+
+        let mut registry = ToolRegistry::new()
+            .with(SearchAtoms {
+                storage: self.storage.clone(),
+                settings: self.settings,
+                scope: self.scope,
+            })
+            .with(GetAtom {
+                storage: self.storage.clone(),
+            })
+            .with(ListTags {
+                storage: self.storage.clone(),
+            })
+            .with(GetWiki {
+                storage: self.storage.clone(),
+            })
+            .with(ListReports {
+                storage: self.storage.clone(),
+            })
+            .with(GetFinding {
+                storage: self.storage.clone(),
+            })
+            .with(CreateAtom {
+                deps: mutations.clone(),
+            })
+            .with(EditAtom { deps: mutations });
+
+        if let Some(page_context) = self.page_context {
+            registry.register(CurrentPageContext {
+                storage: self.storage,
+                page_context,
+            });
+        }
+        if self.canvas_context.is_some() {
+            registry
+                .register(CanvasNavigation {
+                    action: CanvasAction::ZoomToCluster,
+                    conversation_id: self.conversation_id.clone(),
+                    on_event: Arc::clone(&self.on_event),
+                })
+                .register(CanvasNavigation {
+                    action: CanvasAction::FocusAtom,
+                    conversation_id: self.conversation_id,
+                    on_event: self.on_event,
+                });
+        }
+
+        registry
+    }
+}
+
+/// Bridge the agent's atom mutations onto the conversation's event stream so
+/// the UI sees embedding/tagging progress for atoms the agent touched.
+fn embedding_event_bridge(
+    on_event: ChatEventCallback,
+    conversation_id: String,
+) -> Arc<dyn Fn(EmbeddingEvent) + Send + Sync + 'static> {
+    Arc::new(move |event| {
+        on_event(ChatEvent::AtomPipelineEvent {
+            conversation_id: conversation_id.clone(),
+            event,
+        });
+    })
+}
+
+fn excerpt(text: &str) -> String {
+    text.chars().take(EXCERPT_LEN).collect()
+}
+
+/// Lead a tool result with the number the model must cite, or with nothing
+/// when the run refuses to make this evidence citable.
+fn citation_marker(number: Option<i32>) -> String {
+    number.map(|n| format!("[{}] ", n)).unwrap_or_default()
+}
+
+/// Wiki articles and report findings carry `[N]` markers of their own,
+/// numbered against *their* source lists. Left in place, the model copies
+/// one into its answer and this turn's ledger resolves it to whatever
+/// happens to hold that number — a citation pointing at the wrong source.
+/// The prose reads fine without them.
+fn strip_citation_markers(text: &str) -> String {
+    static MARKER: OnceLock<Option<Regex>> = OnceLock::new();
+    match MARKER
+        .get_or_init(|| Regex::new(r" ?\[\d+\]").ok())
+        .as_ref()
+    {
+        Some(marker) => marker.replace_all(text, "").into_owned(),
+        None => text.to_string(),
+    }
+}
+
+/// The shared `offset`/`limit` pair for tools that return a window of lines,
+/// merged into the caller's own properties.
+fn paged_schema(properties: serde_json::Value, required: serde_json::Value) -> serde_json::Value {
+    let mut properties = properties;
+    if let Some(map) = properties.as_object_mut() {
+        map.insert(
+            "offset".to_string(),
+            json!({
+                "type": "integer",
+                "description": "Line number to start reading from (0-indexed). Use the value from a prior response's header to continue reading truncated content.",
+                "minimum": 0,
+                "default": 0
+            }),
+        );
+        map.insert(
+            "limit".to_string(),
+            json!({
+                "type": "integer",
+                "description": format!("Maximum number of lines to return. Defaults to {}; prefer the default unless you know you need more.", READ_DEFAULT_LIMIT),
+                "minimum": 1,
+                "maximum": READ_MAX_LIMIT,
+                "default": READ_DEFAULT_LIMIT
+            }),
+        );
+    }
+    json!({
+        "type": "object",
+        "properties": properties,
+        "required": required
+    })
+}
+
+fn paging_args(args: &serde_json::Value) -> (usize, usize) {
+    let offset = args
+        .get("offset")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as usize)
+        .unwrap_or(0);
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|v| (v as usize).clamp(1, READ_MAX_LIMIT))
+        .unwrap_or(READ_DEFAULT_LIMIT);
+    (offset, limit)
+}
+
+/// A window of `limit` lines starting at `offset`, headed by how to read the
+/// rest through `tool`. Short content (the common case) comes back clean,
+/// with no metadata noise.
+fn line_window(content: &str, offset: usize, limit: usize, tool: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    let total = lines.len();
+
+    // Empty content — return empty before the range math, otherwise a
+    // nonzero offset would produce lines[offset..0] and panic.
+    if total == 0 {
+        return String::new();
+    }
+
+    if offset >= total {
+        return format!(
+            "[offset={} is past end of content ({} total lines)]",
+            offset, total
+        );
+    }
+
+    let end = (offset + limit).min(total);
+    let slice = lines[offset..end].join("\n");
+
+    if offset == 0 && end == total {
+        return slice;
+    }
+
+    let header = if end < total {
+        format!(
+            "[lines {}-{} of {}. {} more lines. Call {} again with offset={} to continue.]\n",
+            offset + 1,
+            end,
+            total,
+            total - end,
+            tool,
+            end,
+        )
+    } else {
+        format!(
+            "[lines {}-{} of {} (end of content).]\n",
+            offset + 1,
+            end,
+            total
+        )
+    };
+
+    format!("{}{}", header, slice)
+}
+
+/// Find a tag by id, then by exact name, then case-insensitively — the same
+/// resolution order the MCP surface uses, and no fuzzier than that.
+fn resolve_tag<'a>(nodes: &'a [TagWithCount], needle: &str) -> Option<&'a TagWithCount> {
+    fn walk<'a>(
+        nodes: &'a [TagWithCount],
+        matches: &impl Fn(&TagWithCount) -> bool,
+    ) -> Option<&'a TagWithCount> {
+        for node in nodes {
+            if matches(node) {
+                return Some(node);
+            }
+            if let Some(found) = walk(&node.children, matches) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    let lowered = needle.to_lowercase();
+    walk(nodes, &|node: &TagWithCount| {
+        node.tag.id == needle || node.tag.name == needle
+    })
+    .or_else(|| {
+        walk(nodes, &|node: &TagWithCount| {
+            node.tag.name.to_lowercase() == lowered
+        })
+    })
+}
+
+// ==================== search_atoms ====================
+
+struct SearchAtoms {
+    storage: StorageBackend,
+    settings: Option<HashMap<String, String>>,
+    scope: ScopeFilter,
+}
+
+#[async_trait]
+impl AgentTool for SearchAtoms {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "search_atoms",
+            "Search for relevant atoms using hybrid keyword and semantic search. Use this to find information related to a specific topic or question. Set since_days when the user is asking about recent notes (e.g., 7 for last week, 30 for last month).",
+            json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query to find relevant atoms"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of results to return (default: 5)",
+                        "default": 5
+                    },
+                    "since_days": {
+                        "type": "integer",
+                        "description": "Optional recency filter: only return atoms created within the last N days. Use when the user's question is time-sensitive (e.g., 7 for last week, 30 for last month).",
+                        "minimum": 1
+                    }
+                },
+                "required": ["query"]
+            }),
+        )
+    }
+
+    async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult {
+        let query = args["query"].as_str().unwrap_or("");
+        let limit = args["limit"].as_i64().unwrap_or(5) as i32;
+        let since_days = args
+            .get("since_days")
+            .and_then(|v| v.as_f64())
+            .map(|v| v as i32)
+            .filter(|days| *days > 0);
+
+        let results = match search_atoms(
+            &self.storage,
+            query,
+            limit,
+            since_days,
+            &self.scope,
+            self.settings.clone(),
+        )
+        .await
+        {
+            Ok(results) => results,
+            Err(e) => return ToolResult::failed(e),
+        };
+
+        let count = results.len() as i32;
+        let rendered: Vec<String> = results
+            .iter()
+            .map(|result| {
+                let number = ctx.citations.register(
+                    CitationSource::Atom,
+                    &result.atom.atom.id,
+                    Some(result.matching_chunk_index),
+                    excerpt(&result.matching_chunk_content),
+                );
+                format!(
+                    "{}(atom_id: {}, similarity: {:.2})\n{}",
+                    citation_marker(number),
+                    result.atom.atom.id,
+                    result.similarity_score,
+                    result.matching_chunk_content
+                )
+            })
+            .collect();
+
+        ToolResult::ok(rendered.join("\n\n"), count)
+    }
+}
+
+async fn search_atoms(
+    storage: &StorageBackend,
+    query: &str,
+    limit: i32,
+    since_days: Option<i32>,
+    scope: &ScopeFilter,
+    external_settings: Option<HashMap<String, String>>,
+) -> Result<Vec<SemanticSearchResult>, String> {
+    // Try SQLite path first (uses full search module with settings resolution)
+    if let Some(sqlite) = storage.as_sqlite() {
+        let options = SearchOptions::new(query, SearchMode::Hybrid, limit)
+            .with_threshold(0.3)
+            .with_scope_filter(scope.clone())
+            .with_since_days(since_days);
+        return crate::search::search_atoms_with_settings(&sqlite.db, options, external_settings)
+            .await;
+    }
+
+    // Postgres path: use storage dispatch methods. Provider config is
+    // deployment-wide, so the fallback reads the global settings tier.
+    let settings = match external_settings {
+        Some(s) => s,
+        None => storage
+            .get_global_settings_sync()
+            .await
+            .map_err(|e| e.to_string())?,
+    };
+    let config = ProviderConfig::from_settings(&settings);
+
+    // Generate query embedding
+    let provider = crate::providers::get_embedding_provider(&config).map_err(|e| e.to_string())?;
+    let embed_config = config.embedding_config();
+    let embeddings = provider
+        .embed_batch(&[query.to_string()], &embed_config)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let cutoff = since_days.map(crate::search::since_days_cutoff);
+    let cutoff_ref = cutoff.as_deref();
+
+    // Chat is an in-app conversational surface over the user's own KB;
+    // finding atoms participate as first-class context just like captured
+    // ones (mirrors the SQLite path that goes through SearchOptions with
+    // its default KindFilter::All).
+    let kinds = crate::models::KindFilter::All;
+    let keyword = storage
+        .keyword_search_sync(query, limit * 2, scope, cutoff_ref, &kinds)
+        .await
+        .map_err(|e| e.to_string())?;
+    let semantic = if !embeddings.is_empty() && !embeddings[0].is_empty() {
+        storage
+            .vector_search_sync(&embeddings[0], limit * 2, 0.3, scope, cutoff_ref, &kinds)
+            .await
+            .map_err(|e| e.to_string())?
+    } else {
+        vec![]
+    };
+
+    Ok(crate::search::merge_search_results_rrf(
+        semantic, keyword, limit,
+    ))
+}
+
+// ==================== get_atom ====================
+
+struct GetAtom {
+    storage: StorageBackend,
+}
+
+#[async_trait]
+impl AgentTool for GetAtom {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "get_atom",
+            "Get the content of a specific atom by its ID. Returns up to `limit` lines starting at `offset` (defaults: offset=0, limit=500). If the atom has more content, the response includes a line-count header indicating how to continue reading via a follow-up call with a higher offset.",
+            paged_schema(
+                json!({
+                    "atom_id": {
+                        "type": "string",
+                        "description": "The ID of the atom to retrieve"
+                    }
+                }),
+                json!(["atom_id"]),
+            ),
+        )
+    }
+
+    async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult {
+        let atom_id = args["atom_id"].as_str().unwrap_or("");
+        let (offset, limit) = paging_args(args);
+
+        match read_atom_lines(&self.storage, atom_id, offset, limit).await {
+            Ok(Some(content)) => {
+                let number =
+                    ctx.citations
+                        .register(CitationSource::Atom, atom_id, None, excerpt(&content));
+                ToolResult::ok(
+                    format!(
+                        "{}(atom_id: {})\n{}",
+                        citation_marker(number),
+                        atom_id,
+                        content
+                    ),
+                    1,
+                )
+            }
+            Ok(None) => ToolResult::ok("Atom not found", 0),
+            Err(e) => ToolResult::failed(e),
+        }
+    }
+}
+
+async fn read_atom_lines(
+    storage: &StorageBackend,
+    atom_id: &str,
+    offset: usize,
+    limit: usize,
+) -> Result<Option<String>, String> {
+    let Some(content) = storage
+        .get_atom_content_impl(atom_id)
+        .await
+        .map_err(|e| e.to_string())?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(line_window(&content, offset, limit, "get_atom")))
+}
+
+// ==================== list_tags ====================
+
+/// The shape of the knowledge base itself: which topics exist and how much
+/// sits under each. Purely navigational — a tag is not a source, so nothing
+/// here is citable.
+struct ListTags {
+    storage: StorageBackend,
+}
+
+#[async_trait]
+impl AgentTool for ListTags {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "list_tags",
+            "List the tags that organize this knowledge base, with the number of atoms under each (counts include sub-tags). Use it to see how the user's knowledge is structured, to choose a tag for get_wiki, or to find a tag id to scope your reading. Returns the top of the tree and one level below it; pass parent_id to expand a branch further.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "parent_id": {
+                        "type": "string",
+                        "description": "Tag id (or exact name) to expand. Omit for the top of the tree."
+                    }
+                }
+            }),
+        )
+    }
+
+    async fn execute(&self, args: &serde_json::Value, _ctx: &ToolContext<'_>) -> ToolResult {
+        let tree = match self.storage.get_all_tags_impl().await {
+            Ok(tree) => tree,
+            Err(e) => return ToolResult::failed(e),
+        };
+
+        let parent = args
+            .get("parent_id")
+            .and_then(|v| v.as_str())
+            .filter(|value| !value.is_empty());
+        let (heading, roots) = match parent {
+            Some(needle) => match resolve_tag(&tree, needle) {
+                Some(tag) => (
+                    format!("Sub-tags of {} (counts include sub-tags):", tag.tag.name),
+                    std::slice::from_ref(tag),
+                ),
+                None => {
+                    return ToolResult::ok(
+                        format!("No tag matches '{}'. Call list_tags with no arguments to see the top of the tree.", needle),
+                        0,
+                    )
+                }
+            },
+            None => (
+                "Tags (counts include sub-tags):".to_string(),
+                tree.as_slice(),
+            ),
+        };
+
+        if roots.is_empty() {
+            return ToolResult::ok("This knowledge base has no tags yet.", 0);
+        }
+
+        let mut out = heading;
+        let mut rendered = 0;
+        render_tags(roots, 0, &mut out, &mut rendered);
+        ToolResult::ok(out, rendered)
+    }
+}
+
+/// Render two levels of the tag tree: each node on its own line, its
+/// children indented beneath it, and a pointer to `list_tags` for whatever
+/// the caps left out.
+fn render_tags(nodes: &[TagWithCount], depth: usize, out: &mut String, rendered: &mut i32) {
+    let indent = "  ".repeat(depth + 1);
+    for node in nodes.iter().take(MAX_TAGS_PER_LEVEL) {
+        *rendered += 1;
+        out.push_str(&format!(
+            "\n{}{} ({} atom{}, tag_id: {})",
+            indent,
+            node.tag.name,
+            node.atom_count,
+            if node.atom_count == 1 { "" } else { "s" },
+            node.tag.id
+        ));
+        if depth + 1 < TAG_TREE_DEPTH {
+            render_tags(&node.children, depth + 1, out, rendered);
+        } else if node.children_total > 0 {
+            out.push_str(&format!(
+                "\n{}  ({} sub-tags — call list_tags with parent_id \"{}\")",
+                indent, node.children_total, node.tag.id
+            ));
+        }
+    }
+    if nodes.len() > MAX_TAGS_PER_LEVEL {
+        out.push_str(&format!(
+            "\n{}… {} more at this level",
+            indent,
+            nodes.len() - MAX_TAGS_PER_LEVEL
+        ));
+    }
+}
+
+// ==================== get_wiki ====================
+
+/// The synthesized article for a tag — the one place the knowledge base
+/// already answers "what do I know about X?" in prose.
+struct GetWiki {
+    storage: StorageBackend,
+}
+
+#[async_trait]
+impl AgentTool for GetWiki {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "get_wiki",
+            "Read the wiki article for a tag: a synthesized overview of everything stored under that topic. Prefer this over stitching many search results together when the user asks about a topic as a whole. Accepts a tag id or tag name. Returns up to `limit` lines starting at `offset`, with a header telling you how to read the rest.",
+            paged_schema(
+                json!({
+                    "tag": {
+                        "type": "string",
+                        "description": "Tag name or tag id whose article to read (see list_tags)"
+                    }
+                }),
+                json!(["tag"]),
+            ),
+        )
+    }
+
+    async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult {
+        let needle = args["tag"].as_str().unwrap_or("").trim();
+        if needle.is_empty() {
+            return ToolResult::failed("tag is required");
+        }
+
+        let tree = match self.storage.get_all_tags_impl().await {
+            Ok(tree) => tree,
+            Err(e) => return ToolResult::failed(e),
+        };
+        let Some(tag) = resolve_tag(&tree, needle) else {
+            return ToolResult::ok(
+                format!(
+                    "No tag matches '{}'. Call list_tags to see what exists.",
+                    needle
+                ),
+                0,
+            );
+        };
+
+        let wiki = match self.storage.get_wiki_sync(&tag.tag.id).await {
+            Ok(Some(wiki)) => wiki,
+            Ok(None) => {
+                return ToolResult::ok(
+                    format!(
+                        "No wiki article exists for '{}' yet. Use search_atoms to read the atoms under the tag instead.",
+                        tag.tag.name
+                    ),
+                    0,
+                )
+            }
+            Err(e) => return ToolResult::failed(e),
+        };
+
+        let (offset, limit) = paging_args(args);
+        let content = line_window(
+            &strip_citation_markers(&wiki.article.content),
+            offset,
+            limit,
+            "get_wiki",
+        );
+        let number =
+            ctx.citations
+                .register(CitationSource::Wiki, &tag.tag.id, None, excerpt(&content));
+        ToolResult::ok(
+            format!(
+                "{}(wiki article for tag: {}, tag_id: {}, {} atoms, updated {})\n{}",
+                citation_marker(number),
+                tag.tag.name,
+                tag.tag.id,
+                wiki.article.atom_count,
+                wiki.article.updated_at,
+                content
+            ),
+            1,
+        )
+    }
+}
+
+// ==================== list_reports / get_finding ====================
+
+/// What the user's scheduled research has been looking into, and when it
+/// last reported back.
+struct ListReports {
+    storage: StorageBackend,
+}
+
+#[async_trait]
+impl AgentTool for ListReports {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "list_reports",
+            "List the scheduled research reports configured in this knowledge base, each with its most recent finding. Reports run on a schedule and write their conclusions back as findings. Use get_finding to read one in full.",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, _args: &serde_json::Value, _ctx: &ToolContext<'_>) -> ToolResult {
+        let reports = match self.storage.list_reports_sync().await {
+            Ok(reports) => reports,
+            Err(e) => return ToolResult::failed(e),
+        };
+        if reports.is_empty() {
+            return ToolResult::ok("No research reports are configured.", 0);
+        }
+
+        let total = reports.len();
+        let mut out = String::new();
+        let mut count = 0;
+        for report in reports.into_iter().take(MAX_REPORTS) {
+            count += 1;
+            out.push_str(&format!(
+                "{} (report_id: {}, schedule: {}{})",
+                report.name,
+                report.id,
+                report.schedule,
+                if report.enabled { "" } else { ", disabled" }
+            ));
+            if let Some(description) = report.description.as_deref().filter(|d| !d.is_empty()) {
+                out.push_str(&format!("\n  {}", description));
+            }
+            // One finding each: the list is a menu, and get_finding is how
+            // the model reads the thing it picks.
+            match self
+                .storage
+                .list_findings_for_report_sync(&report.id, 1)
+                .await
+            {
+                Ok(findings) => match findings.first() {
+                    Some((finding, atom)) => out.push_str(&format!(
+                        "\n  latest finding: {} ({}, atom_id: {})",
+                        if atom.atom.title.is_empty() {
+                            "(untitled)"
+                        } else {
+                            atom.atom.title.as_str()
+                        },
+                        finding.created_at,
+                        atom.atom.id
+                    )),
+                    None => out.push_str("\n  no findings yet"),
+                },
+                Err(e) => out.push_str(&format!("\n  (could not load findings: {})", e)),
+            }
+            out.push_str("\n\n");
+        }
+        if total > MAX_REPORTS {
+            out.push_str(&format!("… {} more reports\n", total - MAX_REPORTS));
+        }
+
+        ToolResult::ok(out.trim_end(), count)
+    }
+}
+
+/// One finding in full. Findings are atoms of kind `report`, so this is the
+/// atom read path with the provenance the finding reader shows.
+struct GetFinding {
+    storage: StorageBackend,
+}
+
+#[async_trait]
+impl AgentTool for GetFinding {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "get_finding",
+            "Read a report finding in full — the write-up a scheduled report produced. Get finding ids from list_reports. Returns up to `limit` lines starting at `offset`, with a header telling you how to read the rest.",
+            paged_schema(
+                json!({
+                    "atom_id": {
+                        "type": "string",
+                        "description": "The finding's atom id (from list_reports)"
+                    }
+                }),
+                json!(["atom_id"]),
+            ),
+        )
+    }
+
+    async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult {
+        let atom_id = args["atom_id"].as_str().unwrap_or("");
+        let finding = match self.storage.get_atom_impl(atom_id).await {
+            Ok(Some(finding)) => finding,
+            Ok(None) => return ToolResult::ok("Finding not found", 0),
+            Err(e) => return ToolResult::failed(e),
+        };
+        if finding.atom.kind != AtomKind::Report {
+            return ToolResult::ok(
+                format!(
+                    "Atom {} is not a report finding. Use get_atom to read it.",
+                    atom_id
+                ),
+                0,
+            );
+        }
+
+        let provenance = self
+            .storage
+            .get_finding_provenance_sync(atom_id)
+            .await
+            .unwrap_or_default();
+        let report_name = provenance
+            .as_ref()
+            .map(|p| p.report_name_snapshot.as_str())
+            .unwrap_or("(unknown report)");
+
+        let (offset, limit) = paging_args(args);
+        let content = line_window(
+            &strip_citation_markers(&finding.atom.content),
+            offset,
+            limit,
+            "get_finding",
+        );
+        let number =
+            ctx.citations
+                .register(CitationSource::Finding, atom_id, None, excerpt(&content));
+        ToolResult::ok(
+            format!(
+                "{}(finding from report: {}, atom_id: {}, created {})\n{}",
+                citation_marker(number),
+                report_name,
+                atom_id,
+                finding.atom.created_at,
+                content
+            ),
+            1,
+        )
+    }
+}
+
+// ==================== create_atom / edit_atom ====================
+
+/// Shared state for the tools that write to the knowledge base.
+#[derive(Clone)]
+struct MutationDeps {
+    storage: StorageBackend,
+    settings: Option<HashMap<String, String>>,
+    inline_pipeline: bool,
+    canvas_cache: Option<CanvasCache>,
+    conversation_id: String,
+    on_event: ChatEventCallback,
+    on_embedding_event: Arc<dyn Fn(EmbeddingEvent) + Send + Sync + 'static>,
+}
+
+impl MutationDeps {
+    /// Announce the mutation, make the atom citable, and describe it back to
+    /// the model — identical for creates and edits.
+    fn report(
+        &self,
+        atom: AtomWithTags,
+        event: fn(String, AtomWithTags) -> ChatEvent,
+        ctx: &ToolContext<'_>,
+    ) -> ToolResult {
+        (self.on_event)(event(self.conversation_id.clone(), atom.clone()));
+        let number = ctx.citations.register(
+            CitationSource::Atom,
+            &atom.atom.id,
+            None,
+            excerpt(&atom.atom.snippet),
+        );
+        let mut payload = json!({
+            "atom_id": atom.atom.id,
+            "title": atom.atom.title,
+            "snippet": atom.atom.snippet,
+            "reference": format!("[[{}]]", atom.atom.id),
+        });
+        if let (Some(number), Some(payload)) = (number, payload.as_object_mut()) {
+            payload.insert("citation_index".to_string(), json!(number));
+        }
+        ToolResult::ok(
+            serde_json::to_string_pretty(&payload).unwrap_or(atom.atom.id),
+            1,
+        )
+    }
+}
+
+struct CreateAtom {
+    deps: MutationDeps,
+}
+
+#[async_trait]
+impl AgentTool for CreateAtom {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "create_atom",
+            "Create a new atom with markdown content. Only use this when the user explicitly asks you to create, save, draft, or add a new atom/note. Do not call this for ordinary answers. After creating an atom, mention it in your final response using [[atom_id]] so the UI can link to it.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "description": "Full markdown content for the new atom"
+                    },
+                    "source_url": {
+                        "type": "string",
+                        "description": "Optional source URL for the atom"
+                    },
+                    "published_at": {
+                        "type": "string",
+                        "description": "Optional ISO 8601 publication date"
+                    },
+                    "tag_ids": {
+                        "type": "array",
+                        "description": "Optional existing tag IDs to assign",
+                        "items": { "type": "string" },
+                        "default": []
+                    }
+                },
+                "required": ["content"]
+            }),
+        )
+    }
+
+    async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult {
+        let content = args["content"].as_str().unwrap_or("").to_string();
+        if content.trim().is_empty() {
+            return ToolResult::failed("Cannot create an empty atom");
+        }
+
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now().to_rfc3339();
+        let request = crate::CreateAtomRequest {
+            content,
+            source_url: optional_string_arg(args, "source_url"),
+            published_at: optional_string_arg(args, "published_at"),
+            tag_ids: tag_ids_arg(args),
+            skip_if_source_exists: false,
+        };
+
+        let atom = match self
+            .deps
+            .storage
+            .insert_atom_impl(&id, &request, &now)
+            .await
+        {
+            Ok(atom) => atom,
+            Err(e) => return ToolResult::failed(e),
+        };
+        if let Some(cache) = &self.deps.canvas_cache {
+            cache.invalidate();
+        }
+        enqueue_pipeline_in_background(&self.deps, id, "agent_create_atom");
+
+        self.deps.report(
+            atom,
+            |conversation_id, atom| ChatEvent::AtomCreated {
+                conversation_id,
+                atom,
+            },
+            ctx,
+        )
+    }
+}
+
+struct EditAtom {
+    deps: MutationDeps,
+}
+
+#[async_trait]
+impl AgentTool for EditAtom {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "edit_atom",
+            "Apply edits to an existing atom. Only use this when the user explicitly asks you to modify an atom. Supports replace, insert_after, append, and replace_all operations. Prefer targeted edits. Use replace_all only when the user explicitly asks for a full rewrite or provides complete replacement content. replace and insert_after require exact text that appears exactly once in the current atom; call get_atom first if you need context.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "atom_id": {
+                        "type": "string",
+                        "description": "The ID of the atom to edit"
+                    },
+                    "edits": {
+                        "type": "array",
+                        "description": "One or more edits applied in order to the atom content. The whole operation fails without saving if any edit is invalid.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "operation": {
+                                    "type": "string",
+                                    "enum": ["replace", "insert_after", "append", "replace_all"],
+                                    "description": "replace swaps exact old_text for new_text; insert_after inserts text after exact anchor_text; append adds text to the end of the atom; replace_all replaces the full atom content."
+                                },
+                                "old_text": {
+                                    "type": "string",
+                                    "description": "Exact text to replace. Required for replace and must occur exactly once."
+                                },
+                                "new_text": {
+                                    "type": "string",
+                                    "description": "Replacement text for replace."
+                                },
+                                "anchor_text": {
+                                    "type": "string",
+                                    "description": "Exact text to insert after. Required for insert_after and must occur exactly once."
+                                },
+                                "text": {
+                                    "type": "string",
+                                    "description": "Text to insert for insert_after or append. Include leading newlines/spaces exactly as desired."
+                                },
+                                "content": {
+                                    "type": "string",
+                                    "description": "Full replacement markdown content. Required for replace_all."
+                                }
+                            },
+                            "required": ["operation"]
+                        },
+                        "minItems": 1
+                    }
+                },
+                "required": ["atom_id", "edits"]
+            }),
+        )
+    }
+
+    async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult {
+        let atom_id = args["atom_id"].as_str().unwrap_or("");
+        let existing = match self.deps.storage.get_atom_impl(atom_id).await {
+            Ok(Some(existing)) => existing,
+            Ok(None) => return ToolResult::ok("Atom not found", 0),
+            Err(e) => return ToolResult::failed(e),
+        };
+
+        let edits: Vec<AtomEditOperation> = match args
+            .get("edits")
+            .cloned()
+            .ok_or_else(|| "edits must be an array".to_string())
+            .and_then(|value| {
+                serde_json::from_value(value)
+                    .map_err(|e| format!("edits must be valid edit operations: {}", e))
+            }) {
+            Ok(edits) => edits,
+            Err(e) => return ToolResult::failed(e),
+        };
+        let content = match apply_atom_edits(&existing.atom.content, &edits) {
+            Ok(content) => content,
+            Err(e) => return ToolResult::failed(e),
+        };
+        if content == existing.atom.content {
+            return ToolResult::failed("Edits did not change the atom content");
+        }
+        if content.trim().is_empty() {
+            return ToolResult::failed("Cannot update an atom to empty content");
+        }
+
+        let request = crate::UpdateAtomRequest {
+            content,
+            source_url: existing.atom.source_url,
+            published_at: existing.atom.published_at,
+            tag_ids: None,
+        };
+        let now = Utc::now().to_rfc3339();
+        let atom = match self
+            .deps
+            .storage
+            .update_atom_if_unchanged_impl(atom_id, &request, &now, &existing.atom.updated_at)
+            .await
+        {
+            Ok(atom) => atom,
+            Err(e) => return ToolResult::failed(e),
+        };
+        if let Some(cache) = &self.deps.canvas_cache {
+            cache.invalidate();
+        }
+        enqueue_pipeline_in_background(&self.deps, atom_id.to_string(), "agent_edit_atom");
+
+        self.deps.report(
+            atom,
+            |conversation_id, atom| ChatEvent::AtomUpdated {
+                conversation_id,
+                atom,
+            },
+            ctx,
+        )
+    }
+}
+
+fn optional_string_arg(args: &serde_json::Value, key: &str) -> Option<String> {
+    args.get(key)
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn tag_ids_arg(args: &serde_json::Value) -> Vec<String> {
+    args.get("tag_ids")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str())
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn enqueue_pipeline_in_background(deps: &MutationDeps, atom_id: String, reason: &'static str) {
+    let deps = deps.clone();
+    let failure_callback = Arc::clone(&deps.on_embedding_event);
+    tokio::spawn(async move {
+        let result = enqueue_and_process_pipeline(&deps, &atom_id, reason).await;
+        if let Err(error) = result {
+            tracing::warn!(
+                atom_id = %atom_id,
+                reason = %reason,
+                error = %error,
+                "Agent mutation pipeline failed"
+            );
+            failure_callback(EmbeddingEvent::EmbeddingFailed { atom_id, error });
+        }
+    });
+}
+
+async fn enqueue_and_process_pipeline(
+    deps: &MutationDeps,
+    atom_id: &str,
+    reason: &str,
+) -> Result<(), String> {
+    let job = crate::models::AtomPipelineJobRequest {
+        atom_id: atom_id.to_string(),
+        embed_requested: true,
+        tag_requested: true,
+        not_before: None,
+        reason: reason.to_string(),
+        replace_existing: false,
+    };
+    deps.storage
+        .enqueue_pipeline_jobs_sync(&[job])
+        .await
+        .map_err(|e| e.to_string())?;
+    if !deps.inline_pipeline {
+        // The job persists in the durable ledger; the host's dedicated
+        // pipeline worker executes it (see AtomicCore::set_inline_pipeline).
+        return Ok(());
+    }
+    let callback = {
+        let on_embedding_event = Arc::clone(&deps.on_embedding_event);
+        move |event| on_embedding_event(event)
+    };
+    match deps.settings.clone() {
+        Some(settings) => {
+            crate::embedding::process_queued_pipeline_jobs_with_settings(
+                deps.storage.clone(),
+                callback,
+                settings,
+                deps.canvas_cache.clone(),
+            )
+            .await?;
+        }
+        None => {
+            crate::embedding::process_queued_pipeline_jobs(
+                deps.storage.clone(),
+                callback,
+                deps.canvas_cache.clone(),
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+// ==================== get_current_page_context ====================
+
+struct CurrentPageContext {
+    storage: StorageBackend,
+    page_context: PageContext,
+}
+
+#[async_trait]
+impl AgentTool for CurrentPageContext {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "get_current_page_context",
+            "Get compact context about what the user is currently viewing in Atomic, such as the visible atom, wiki page, selected tag, and a short atom snippet. Use this first when the user says things like \"this atom\", \"the note I'm reading\", \"this page\", \"what I'm looking at\", or otherwise refers to visible UI context.",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, _args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult {
+        let page = &self.page_context;
+        let mut visible_atom = serde_json::Value::Null;
+        if let Some(atom_id) = page.atom_id.as_deref().filter(|id| !id.is_empty()) {
+            let stored = match self.storage.get_atom_impl(atom_id).await {
+                Ok(stored) => stored,
+                Err(e) => return ToolResult::failed(e),
+            };
+            visible_atom = match stored {
+                Some(atom_with_tags) => json!({
+                    "id": atom_with_tags.atom.id,
+                    "title": atom_with_tags.atom.title,
+                    "snippet": atom_with_tags.atom.snippet,
+                    "source_url": atom_with_tags.atom.source_url,
+                    "tags": atom_with_tags
+                        .tags
+                        .into_iter()
+                        .map(|tag| json!({ "id": tag.id, "name": tag.name }))
+                        .collect::<Vec<_>>(),
+                }),
+                None => json!({
+                    "id": atom_id,
+                    "title": page.atom_title.as_deref(),
+                    "snippet": page.atom_snippet.as_deref(),
+                    "not_found": true,
+                }),
+            };
+
+            let snippet = visible_atom
+                .get("snippet")
+                .and_then(|snippet| snippet.as_str())
+                .unwrap_or("");
+            if !snippet.is_empty() {
+                let number =
+                    ctx.citations
+                        .register(CitationSource::Atom, atom_id, None, excerpt(snippet));
+                if let (Some(number), Some(atom)) = (number, visible_atom.as_object_mut()) {
+                    atom.insert("citation_index".to_string(), json!(number));
+                }
+            }
+        }
+
+        let context = json!({
+            "view": page.view.as_deref(),
+            "visible_atom": visible_atom,
+            "wiki": {
+                "tag_id": page.wiki_tag_id.as_deref(),
+                "tag_name": page.wiki_tag_name.as_deref(),
+            },
+            "selected_tag_id": page.selected_tag_id.as_deref(),
+        });
+        ToolResult::ok(
+            serde_json::to_string_pretty(&context).unwrap_or_else(|_| context.to_string()),
+            1,
+        )
+    }
+}
+
+// ==================== canvas navigation ====================
+
+#[derive(Clone, Copy)]
+enum CanvasAction {
+    ZoomToCluster,
+    FocusAtom,
+}
+
+/// The canvas tools do no work in core: they ask the frontend to move its
+/// camera and report back what they asked for.
+struct CanvasNavigation {
+    action: CanvasAction,
+    conversation_id: String,
+    on_event: ChatEventCallback,
+}
+
+#[async_trait]
+impl AgentTool for CanvasNavigation {
+    fn definition(&self) -> ToolDefinition {
+        match self.action {
+            CanvasAction::ZoomToCluster => ToolDefinition::new(
+                "zoom_to_cluster",
+                "Zoom the canvas camera to center on a single cluster of related atoms. The canvas can only show one view at a time — each call replaces the previous view. Use this when the user asks about a topic area visible on their knowledge graph.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "cluster_label": {
+                            "type": "string",
+                            "description": "The label of the cluster to zoom to"
+                        }
+                    },
+                    "required": ["cluster_label"]
+                }),
+            ),
+            CanvasAction::FocusAtom => ToolDefinition::new(
+                "focus_atom",
+                "Zoom to a specific atom on the canvas and show its preview. The canvas can only focus on one atom at a time. Use this after searching to highlight a specific result on the graph.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "atom_id": {
+                            "type": "string",
+                            "description": "The ID of the atom to focus on"
+                        }
+                    },
+                    "required": ["atom_id"]
+                }),
+            ),
+        }
+    }
+
+    async fn execute(&self, args: &serde_json::Value, _ctx: &ToolContext<'_>) -> ToolResult {
+        let (action, params, acknowledgement) = match self.action {
+            CanvasAction::ZoomToCluster => {
+                let label = args["cluster_label"].as_str().unwrap_or("");
+                (
+                    "zoom_to_cluster",
+                    json!({ "cluster_label": label }),
+                    format!("Zoomed canvas to cluster '{}'", label),
+                )
+            }
+            CanvasAction::FocusAtom => {
+                let atom_id = args["atom_id"].as_str().unwrap_or("");
+                (
+                    "focus_atom",
+                    json!({ "atom_id": atom_id }),
+                    format!("Focused canvas on atom '{}'", atom_id),
+                )
+            }
+        };
+        (self.on_event)(ChatEvent::CanvasAction {
+            conversation_id: self.conversation_id.clone(),
+            action: action.to_string(),
+            params,
+        });
+        ToolResult::ok(acknowledgement, 1)
+    }
+}

--- a/crates/atomic-core/src/db.rs
+++ b/crates/atomic-core/src/db.rs
@@ -281,7 +281,7 @@ impl Database {
     ///   1. Add a new `if version < N` block at the end (before the virtual-table section)
     ///   2. End the block with `PRAGMA user_version = N;`
     ///   3. Bump LATEST_VERSION
-    const LATEST_VERSION: i32 = 22;
+    const LATEST_VERSION: i32 = 24;
 
     pub fn run_migrations(conn: &Connection) -> Result<(), AtomicCoreError> {
         Self::run_migrations_internal(conn, false)
@@ -1089,6 +1089,79 @@ impl Database {
         // at server startup with a per-DB idempotency flag. A pure SQL drop
         // here would discard history before the Rust path could rehome it.
         if version < 22 {
+            conn.execute_batch("PRAGMA user_version = 22;")?;
+        }
+
+        // V23: chat citations can point at things that aren't atoms.
+        //
+        // `source_type` says how to read `atom_id`: 'atom' (the atom id,
+        // and the default every pre-existing row keeps), 'wiki' (the tag
+        // id whose article was cited), 'finding' (the finding atom's id).
+        // One id column, one discriminator — exactly one id is ever
+        // meaningful per row.
+        //
+        // The table is rebuilt rather than altered because `atom_id`'s
+        // `REFERENCES atoms(id)` is now wrong: a wiki citation's id is a
+        // tag's, and this connection *does* enforce foreign keys. Losing
+        // the constraint also loses its ON DELETE CASCADE, so deleting an
+        // atom now leaves its citations behind as dead links — which is
+        // already how the Postgres backend behaves (its column never had
+        // the constraint) and how the readers already render a source that
+        // has gone missing.
+        if version < 23 {
+            let has_col: bool = conn
+                .query_row(
+                    "SELECT 1 FROM pragma_table_info('chat_citations') WHERE name='source_type'",
+                    [],
+                    |_| Ok(true),
+                )
+                .unwrap_or(false);
+
+            if !has_col {
+                conn.execute_batch(
+                    "CREATE TABLE chat_citations_v23 (
+                         id TEXT PRIMARY KEY,
+                         message_id TEXT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
+                         citation_index INTEGER NOT NULL,
+                         atom_id TEXT NOT NULL,
+                         chunk_index INTEGER,
+                         excerpt TEXT NOT NULL,
+                         relevance_score REAL,
+                         source_type TEXT NOT NULL DEFAULT 'atom'
+                     );
+                     INSERT INTO chat_citations_v23
+                         (id, message_id, citation_index, atom_id, chunk_index, excerpt, relevance_score, source_type)
+                     SELECT id, message_id, citation_index, atom_id, chunk_index, excerpt, relevance_score, 'atom'
+                     FROM chat_citations;
+                     DROP TABLE chat_citations;
+                     ALTER TABLE chat_citations_v23 RENAME TO chat_citations;
+                     CREATE INDEX IF NOT EXISTS idx_chat_citations_message ON chat_citations(message_id);
+                     CREATE INDEX IF NOT EXISTS idx_chat_citations_atom ON chat_citations(atom_id);",
+                )?;
+            }
+
+            conn.execute_batch("PRAGMA user_version = 23;")?;
+        }
+
+        // V24: a conversation's scope tags carry the role they play —
+        // 'include' (any of them admits an atom), 'require' (all of them
+        // must be present), 'exclude' (none may be). Existing rows default
+        // to 'include', which is exactly the OR scope they already meant.
+        if version < 24 {
+            let has_col: bool = conn
+                .query_row(
+                    "SELECT 1 FROM pragma_table_info('conversation_tags') WHERE name='mode'",
+                    [],
+                    |_| Ok(true),
+                )
+                .unwrap_or(false);
+
+            if !has_col {
+                conn.execute_batch(
+                    "ALTER TABLE conversation_tags ADD COLUMN mode TEXT NOT NULL DEFAULT 'include';",
+                )?;
+            }
+
             conn.execute_batch(&format!("PRAGMA user_version = {};", Self::LATEST_VERSION))?;
         }
 

--- a/crates/atomic-core/src/db.rs
+++ b/crates/atomic-core/src/db.rs
@@ -1101,13 +1101,24 @@ impl Database {
         // meaningful per row.
         //
         // The table is rebuilt rather than altered because `atom_id`'s
-        // `REFERENCES atoms(id)` is now wrong: a wiki citation's id is a
-        // tag's, and this connection *does* enforce foreign keys. Losing
-        // the constraint also loses its ON DELETE CASCADE, so deleting an
-        // atom now leaves its citations behind as dead links — which is
-        // already how the Postgres backend behaves (its column never had
-        // the constraint) and how the readers already render a source that
-        // has gone missing.
+        // `REFERENCES atoms(id)` is now wrong and *is enforced*: a wiki
+        // citation's id belongs to a tag, so inserting one raises "FOREIGN
+        // KEY constraint failed". Note this holds despite no `PRAGMA
+        // foreign_keys = ON` appearing anywhere in the codebase — rusqlite's
+        // `bundled` feature compiles SQLite with
+        // `-DSQLITE_DEFAULT_FOREIGN_KEYS=1`, which flips the default for
+        // every connection we open. Losing the constraint also loses its ON
+        // DELETE CASCADE, so deleting an atom now leaves its citations behind
+        // as dead links — which is already how the Postgres backend behaves
+        // (its column never had the constraint) and how the readers already
+        // render a source that has gone missing.
+        //
+        // The rebuild runs in one transaction, version bump included: a crash
+        // partway through rolls back to v22 in full, and the next open retries
+        // from a consistent schema. Committing the DDL and the `user_version`
+        // separately is what would brick the database — a process killed
+        // between them leaves a v22 marker over a v23 schema, or a dropped
+        // table and no replacement.
         if version < 23 {
             let has_col: bool = conn
                 .query_row(
@@ -1117,8 +1128,9 @@ impl Database {
                 )
                 .unwrap_or(false);
 
+            let tx = conn.unchecked_transaction()?;
             if !has_col {
-                conn.execute_batch(
+                tx.execute_batch(
                     "CREATE TABLE chat_citations_v23 (
                          id TEXT PRIMARY KEY,
                          message_id TEXT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
@@ -1139,8 +1151,8 @@ impl Database {
                      CREATE INDEX IF NOT EXISTS idx_chat_citations_atom ON chat_citations(atom_id);",
                 )?;
             }
-
-            conn.execute_batch("PRAGMA user_version = 23;")?;
+            tx.execute_batch("PRAGMA user_version = 23;")?;
+            tx.commit()?;
         }
 
         // V24: a conversation's scope tags carry the role they play —
@@ -1565,6 +1577,61 @@ mod tests {
                 .unwrap_or(false);
             assert!(exists, "Table '{}' should exist", table);
         }
+    }
+
+    /// Foreign keys are on — our bundled SQLite is compiled with
+    /// `SQLITE_DEFAULT_FOREIGN_KEYS=1` — which is the whole reason V23
+    /// rebuilds `chat_citations` instead of adding a column to it. If this
+    /// ever reads OFF, the rebuild's justification is gone; if `atom_id`
+    /// regains its `REFERENCES atoms(id)`, wiki citations (whose id is a
+    /// *tag's*) stop being insertable.
+    #[test]
+    fn chat_citations_can_hold_ids_that_are_not_atoms() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db = Database::open_or_create(temp_file.path()).unwrap();
+        let conn = db.conn.lock().unwrap();
+
+        let foreign_keys: i32 = conn
+            .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            foreign_keys, 1,
+            "foreign keys are enforced on our connections; V23's rebuild depends on it"
+        );
+
+        let references_atoms: bool = conn
+            .prepare("SELECT 1 FROM pragma_foreign_key_list('chat_citations') WHERE \"table\" = 'atoms'")
+            .unwrap()
+            .exists([])
+            .unwrap();
+        assert!(
+            !references_atoms,
+            "chat_citations.atom_id must not reference atoms — a wiki citation stores a tag id"
+        );
+    }
+
+    /// The V23 rebuild is one transaction, so a database interrupted anywhere
+    /// inside it comes back as a coherent v22 and re-migrates. This pins the
+    /// invariant the transaction exists to protect: version and schema never
+    /// disagree.
+    #[test]
+    fn migrating_twice_is_a_no_op() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db = Database::open_or_create(temp_file.path()).unwrap();
+        let conn = db.conn.lock().unwrap();
+
+        Database::run_migrations(&conn).unwrap();
+
+        let version: i32 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, Database::LATEST_VERSION);
+        let has_source_type: bool = conn
+            .prepare("SELECT 1 FROM pragma_table_info('chat_citations') WHERE name = 'source_type'")
+            .unwrap()
+            .exists([])
+            .unwrap();
+        assert!(has_source_type, "source_type survives a re-run");
     }
 
     #[test]

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -28,11 +28,13 @@
 //! ```
 
 pub mod agent;
+pub mod agent_runtime;
 pub mod atom_edit;
 pub(crate) mod atom_links;
 pub mod canvas_level;
 pub mod chat;
 mod chat_title;
+mod chat_tools;
 pub mod chunking;
 pub mod clustering;
 pub mod compaction;
@@ -75,7 +77,7 @@ pub use manager::DatabaseManager;
 pub use models::*;
 pub use providers::{ProviderConfig, ProviderType};
 pub use registry::{DatabaseInfo, OAuthCodeInfo, Registry};
-pub use search::{SearchMode, SearchOptions};
+pub use search::{ScopeFilter, SearchMode, SearchOptions};
 #[cfg(feature = "postgres")]
 pub use storage::PgPoolConfig;
 pub use tokens::ApiTokenInfo;
@@ -1781,7 +1783,7 @@ impl AtomicCore {
         // Postgres path: use storage dispatch methods directly
         let settings = self.settings_for_ai().await?;
         let config = providers::ProviderConfig::from_settings(&settings);
-        let scope_tag_ids = options.scope_tag_ids.as_slice();
+        let scope = &options.scope;
         let cutoff = options.since_days.map(search::since_days_cutoff);
         let cutoff_ref = cutoff.as_deref();
 
@@ -1791,7 +1793,7 @@ impl AtomicCore {
                     .keyword_search_sync(
                         &options.query,
                         options.limit,
-                        scope_tag_ids,
+                        scope,
                         cutoff_ref,
                         &options.kinds,
                     )
@@ -1814,7 +1816,7 @@ impl AtomicCore {
                         &embeddings[0],
                         options.limit,
                         options.threshold,
-                        scope_tag_ids,
+                        scope,
                         cutoff_ref,
                         &options.kinds,
                     )
@@ -1835,7 +1837,7 @@ impl AtomicCore {
                     .keyword_search_sync(
                         &options.query,
                         options.limit * 2,
-                        scope_tag_ids,
+                        scope,
                         cutoff_ref,
                         &options.kinds,
                     )
@@ -1847,7 +1849,7 @@ impl AtomicCore {
                             &embeddings[0],
                             options.limit * 2,
                             options.threshold,
-                            scope_tag_ids,
+                            scope,
                             cutoff_ref,
                             &options.kinds,
                         )
@@ -3159,21 +3161,23 @@ impl AtomicCore {
     pub async fn set_conversation_scope(
         &self,
         conversation_id: &str,
-        tag_ids: &[String],
+        entries: &[ScopeEntry],
     ) -> Result<ConversationWithTags, AtomicCoreError> {
         self.storage
-            .set_conversation_scope_sync(conversation_id, tag_ids)
+            .set_conversation_scope_sync(conversation_id, entries)
             .await
     }
 
-    /// Add a single tag to conversation scope
+    /// Put a single tag in the conversation scope under `mode`; a tag already
+    /// in scope changes mode.
     pub async fn add_tag_to_scope(
         &self,
         conversation_id: &str,
         tag_id: &str,
+        mode: ScopeMode,
     ) -> Result<ConversationWithTags, AtomicCoreError> {
         self.storage
-            .add_tag_to_scope_sync(conversation_id, tag_id)
+            .add_tag_to_scope_sync(conversation_id, tag_id, mode)
             .await
     }
 
@@ -9882,7 +9886,7 @@ mod tests {
             .keyword_search_sync(
                 "elephants",
                 10,
-                &[],
+                &ScopeFilter::default(),
                 None,
                 &models::KindFilter::only(models::AtomKind::Captured),
             )
@@ -9897,7 +9901,13 @@ mod tests {
 
         let all = db
             .storage
-            .keyword_search_sync("elephants", 10, &[], None, &models::KindFilter::All)
+            .keyword_search_sync(
+                "elephants",
+                10,
+                &ScopeFilter::default(),
+                None,
+                &models::KindFilter::All,
+            )
             .await
             .unwrap();
         let all_ids: std::collections::HashSet<_> =
@@ -9936,7 +9946,7 @@ mod tests {
             .keyword_search_sync(
                 "pelicans",
                 10,
-                &[rust.id.clone(), sailing.id.clone()],
+                &ScopeFilter::including(vec![rust.id.clone(), sailing.id.clone()]),
                 None,
                 &models::KindFilter::All,
             )
@@ -9955,10 +9965,305 @@ mod tests {
 
         let unscoped = db
             .storage
-            .keyword_search_sync("pelicans", 10, &[], None, &models::KindFilter::All)
+            .keyword_search_sync(
+                "pelicans",
+                10,
+                &ScopeFilter::default(),
+                None,
+                &models::KindFilter::All,
+            )
             .await
             .unwrap();
         assert_eq!(unscoped.len(), 3, "an empty scope filters nothing");
+    }
+
+    /// Tag two atoms so the boolean-scope tests have something to intersect.
+    async fn create_multi_tagged_atom(
+        db: &AtomicCore,
+        content: &str,
+        tag_ids: &[&str],
+    ) -> AtomWithTags {
+        db.create_atom(
+            CreateAtomRequest {
+                content: content.to_string(),
+                tag_ids: tag_ids.iter().map(|id| id.to_string()).collect(),
+                ..Default::default()
+            },
+            |_| {},
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    }
+
+    async fn scoped_search_ids(
+        db: &AtomicCore,
+        query: &str,
+        scope: ScopeFilter,
+    ) -> std::collections::HashSet<String> {
+        db.storage
+            .keyword_search_sync(query, 20, &scope, None, &models::KindFilter::All)
+            .await
+            .unwrap()
+            .iter()
+            .map(|r| r.atom.atom.id.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn scope_require_and_exclude_shape_results() {
+        // The three-list predicate: include admits, require narrows to atoms
+        // carrying *every* required tag, exclude removes. Each list is
+        // exercised on its own and in combination, because the failure mode
+        // that matters is one list being applied with another's semantics.
+        let (db, _temp) = create_test_db().await;
+        let topics = get_seeded_tag(&db, "Topics");
+        let rust = db.create_tag("Rust", Some(&topics.id)).await.unwrap();
+        let sailing = db.create_tag("Sailing", Some(&topics.id)).await.unwrap();
+        let draft = db.create_tag("Draft", Some(&topics.id)).await.unwrap();
+
+        let rust_only = create_tagged_atom(&db, "walruses one", &rust.id).await;
+        let rust_and_sailing =
+            create_multi_tagged_atom(&db, "walruses two", &[&rust.id, &sailing.id]).await;
+        let rust_and_draft =
+            create_multi_tagged_atom(&db, "walruses three", &[&rust.id, &draft.id]).await;
+        let untagged = create_test_atom(&db, "walruses four").await;
+
+        // Require narrows an include list to the intersection.
+        let ids = scoped_search_ids(
+            &db,
+            "walruses",
+            ScopeFilter {
+                include: vec![rust.id.clone()],
+                require: vec![sailing.id.clone()],
+                exclude: vec![],
+            },
+        )
+        .await;
+        assert_eq!(
+            ids,
+            std::collections::HashSet::from([rust_and_sailing.atom.id.clone()]),
+            "require keeps only atoms carrying every required tag"
+        );
+
+        // Exclude removes from an include list.
+        let ids = scoped_search_ids(
+            &db,
+            "walruses",
+            ScopeFilter {
+                include: vec![rust.id.clone()],
+                require: vec![],
+                exclude: vec![draft.id.clone()],
+            },
+        )
+        .await;
+        assert_eq!(
+            ids,
+            std::collections::HashSet::from([
+                rust_only.atom.id.clone(),
+                rust_and_sailing.atom.id.clone()
+            ]),
+            "exclude removes atoms carrying an excluded tag"
+        );
+        assert!(
+            !ids.contains(&rust_and_draft.atom.id),
+            "exclude beats include for an atom carrying both"
+        );
+
+        // Empty include: the base set is everything, and exclude still applies
+        // — including to atoms with no tags at all, which stay in.
+        let ids = scoped_search_ids(
+            &db,
+            "walruses",
+            ScopeFilter {
+                include: vec![],
+                require: vec![],
+                exclude: vec![draft.id.clone()],
+            },
+        )
+        .await;
+        assert_eq!(
+            ids,
+            std::collections::HashSet::from([
+                rust_only.atom.id.clone(),
+                rust_and_sailing.atom.id.clone(),
+                untagged.atom.id.clone(),
+            ]),
+            "an empty include list means all atoms, minus the exclusions"
+        );
+
+        // Empty include with a require: still all atoms, narrowed.
+        let ids = scoped_search_ids(
+            &db,
+            "walruses",
+            ScopeFilter {
+                include: vec![],
+                require: vec![rust.id.clone(), sailing.id.clone()],
+                exclude: vec![],
+            },
+        )
+        .await;
+        assert_eq!(
+            ids,
+            std::collections::HashSet::from([rust_and_sailing.atom.id.clone()]),
+            "require applies to the whole knowledge base when nothing is included"
+        );
+
+        // A tag both required and excluded can never be satisfied.
+        let ids = scoped_search_ids(
+            &db,
+            "walruses",
+            ScopeFilter {
+                include: vec![],
+                require: vec![rust.id.clone()],
+                exclude: vec![rust.id.clone()],
+            },
+        )
+        .await;
+        assert!(ids.is_empty(), "contradictory lists admit nothing");
+
+        assert!(
+            !scoped_search_ids(
+                &db,
+                "walruses",
+                ScopeFilter::including(vec![rust.id.clone()])
+            )
+            .await
+            .contains(&untagged.atom.id),
+            "include-only still behaves like today's OR scope"
+        );
+    }
+
+    #[tokio::test]
+    async fn scope_lists_expand_to_descendant_tags() {
+        // Descendant expansion is what makes scoping to a parent tag mean
+        // "this branch". It has always applied to includes; require and
+        // exclude must read the tree the same way or the same tag would mean
+        // different things depending on which list it landed in.
+        let (db, _temp) = create_test_db().await;
+        let topics = get_seeded_tag(&db, "Topics");
+        let languages = db.create_tag("Languages", Some(&topics.id)).await.unwrap();
+        let rust = db.create_tag("Rust", Some(&languages.id)).await.unwrap();
+        let status = db.create_tag("Status", Some(&topics.id)).await.unwrap();
+        let draft = db.create_tag("Draft", Some(&status.id)).await.unwrap();
+
+        let child_tagged = create_tagged_atom(&db, "narwhals one", &rust.id).await;
+        let child_and_draft =
+            create_multi_tagged_atom(&db, "narwhals two", &[&rust.id, &draft.id]).await;
+
+        // Requiring the parent matches an atom tagged with its child.
+        let ids = scoped_search_ids(
+            &db,
+            "narwhals",
+            ScopeFilter {
+                include: vec![],
+                require: vec![languages.id.clone()],
+                exclude: vec![],
+            },
+        )
+        .await;
+        assert_eq!(
+            ids,
+            std::collections::HashSet::from([
+                child_tagged.atom.id.clone(),
+                child_and_draft.atom.id.clone()
+            ]),
+            "require matches descendants of the required tag"
+        );
+
+        // Excluding the parent removes an atom tagged with its child.
+        let ids = scoped_search_ids(
+            &db,
+            "narwhals",
+            ScopeFilter {
+                include: vec![languages.id.clone()],
+                require: vec![],
+                exclude: vec![status.id.clone()],
+            },
+        )
+        .await;
+        assert_eq!(
+            ids,
+            std::collections::HashSet::from([child_tagged.atom.id.clone()]),
+            "exclude matches descendants of the excluded tag"
+        );
+    }
+
+    #[tokio::test]
+    async fn conversation_scope_round_trips_modes_into_the_filter() {
+        // The scope the agent retrieves with is the scope the UI wrote:
+        // per-tag modes survive storage and land in the right list.
+        let (db, _temp) = create_test_db().await;
+        let topics = get_seeded_tag(&db, "Topics");
+        let rust = db.create_tag("Rust", Some(&topics.id)).await.unwrap();
+        let sailing = db.create_tag("Sailing", Some(&topics.id)).await.unwrap();
+        let draft = db.create_tag("Draft", Some(&topics.id)).await.unwrap();
+
+        let conv = db
+            .create_conversation(&[rust.id.clone()], Some("scoped"))
+            .await
+            .unwrap();
+        let conversation_id = conv.conversation.id.clone();
+        assert_eq!(
+            conv.tags[0].mode,
+            models::ScopeMode::Include,
+            "a conversation created with tags scopes by including them"
+        );
+
+        db.add_tag_to_scope(&conversation_id, &sailing.id, models::ScopeMode::Require)
+            .await
+            .unwrap();
+        db.add_tag_to_scope(&conversation_id, &draft.id, models::ScopeMode::Exclude)
+            .await
+            .unwrap();
+
+        let scope = db
+            .storage
+            .get_conversation_scope_sync(&conversation_id)
+            .await
+            .unwrap();
+        assert_eq!(scope.include, vec![rust.id.clone()]);
+        assert_eq!(scope.require, vec![sailing.id.clone()]);
+        assert_eq!(scope.exclude, vec![draft.id.clone()]);
+
+        let description = db.storage.get_scope_description_sync(&scope).await.unwrap();
+        assert!(description.contains("Rust"), "{description}");
+        assert!(
+            description.contains("every one of: Sailing"),
+            "the model is told what require means: {description}"
+        );
+        assert!(
+            description.contains("Draft") && description.contains("excluded"),
+            "the model is told what exclude means: {description}"
+        );
+
+        // Cycling a chip back to include rewrites the mode in place.
+        let updated = db
+            .add_tag_to_scope(&conversation_id, &draft.id, models::ScopeMode::Include)
+            .await
+            .unwrap();
+        assert_eq!(updated.tags.len(), 3, "cycling a mode never duplicates");
+        let scope = db
+            .storage
+            .get_conversation_scope_sync(&conversation_id)
+            .await
+            .unwrap();
+        assert!(scope.exclude.is_empty());
+        assert_eq!(scope.include.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn empty_scope_description_still_names_the_whole_base() {
+        let (db, _temp) = create_test_db().await;
+        let description = db
+            .storage
+            .get_scope_description_sync(&ScopeFilter::default())
+            .await
+            .unwrap();
+        assert!(
+            description.contains("ALL atoms"),
+            "an unscoped conversation reads as unscoped: {description}"
+        );
     }
 
     #[tokio::test]

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod atom_edit;
 pub(crate) mod atom_links;
 pub mod canvas_level;
 pub mod chat;
+mod chat_title;
 pub mod chunking;
 pub mod clustering;
 pub mod compaction;
@@ -61,7 +62,7 @@ pub mod tokens;
 pub mod wiki;
 
 // Re-exports for convenience
-pub use agent::{CanvasClusterSummary, CanvasContext, ChatEvent, PageContext};
+pub use agent::{CanvasClusterSummary, CanvasContext, ChatCancel, ChatEvent, PageContext};
 pub use atom_edit::{apply_atom_edits, AtomEditOperation};
 pub use db::Database;
 pub use embedding::{EmbeddingEvent, EmbeddingStrategy, TaggingStrategy};
@@ -1780,7 +1781,7 @@ impl AtomicCore {
         // Postgres path: use storage dispatch methods directly
         let settings = self.settings_for_ai().await?;
         let config = providers::ProviderConfig::from_settings(&settings);
-        let tag_id = options.scope_tag_ids.first().map(|s| s.as_str());
+        let scope_tag_ids = options.scope_tag_ids.as_slice();
         let cutoff = options.since_days.map(search::since_days_cutoff);
         let cutoff_ref = cutoff.as_deref();
 
@@ -1790,7 +1791,7 @@ impl AtomicCore {
                     .keyword_search_sync(
                         &options.query,
                         options.limit,
-                        tag_id,
+                        scope_tag_ids,
                         cutoff_ref,
                         &options.kinds,
                     )
@@ -1813,7 +1814,7 @@ impl AtomicCore {
                         &embeddings[0],
                         options.limit,
                         options.threshold,
-                        tag_id,
+                        scope_tag_ids,
                         cutoff_ref,
                         &options.kinds,
                     )
@@ -1834,7 +1835,7 @@ impl AtomicCore {
                     .keyword_search_sync(
                         &options.query,
                         options.limit * 2,
-                        tag_id,
+                        scope_tag_ids,
                         cutoff_ref,
                         &options.kinds,
                     )
@@ -1846,7 +1847,7 @@ impl AtomicCore {
                             &embeddings[0],
                             options.limit * 2,
                             options.threshold,
-                            tag_id,
+                            scope_tag_ids,
                             cutoff_ref,
                             &options.kinds,
                         )
@@ -3115,15 +3116,17 @@ impl AtomicCore {
         self.storage.create_conversation_sync(tag_ids, title).await
     }
 
-    /// Get all conversations, optionally filtered by tag
+    /// Get all conversations, optionally filtered by tag. Archived
+    /// conversations are excluded unless `include_archived`.
     pub async fn get_conversations(
         &self,
         filter_tag_id: Option<&str>,
         limit: i32,
         offset: i32,
+        include_archived: bool,
     ) -> Result<Vec<ConversationWithTags>, AtomicCoreError> {
         self.storage
-            .get_conversations_sync(filter_tag_id, limit, offset)
+            .get_conversations_sync(filter_tag_id, limit, offset, include_archived)
             .await
     }
 
@@ -3188,12 +3191,15 @@ impl AtomicCore {
     /// Send a chat message and run the agent loop.
     ///
     /// The `on_event` callback receives streaming deltas, tool call events,
-    /// and completion/error events during the agent loop.
+    /// and completion/error events during the agent loop. `cancel` is an
+    /// optional flag the host can raise to stop the turn early (see
+    /// [`ChatCancel`]); the partial answer is still persisted and returned.
     pub async fn send_chat_message<F>(
         &self,
         conversation_id: &str,
         content: &str,
         on_event: F,
+        cancel: Option<ChatCancel>,
     ) -> Result<ChatMessageWithContext, AtomicCoreError>
     where
         F: Fn(ChatEvent) + Send + Sync + 'static,
@@ -3205,12 +3211,14 @@ impl AtomicCore {
             on_event,
             self.settings_for_background().await,
             self.inline_pipeline(),
+            cancel,
         )
         .await
         .map_err(|e| AtomicCoreError::DatabaseOperation(e))
     }
 
     /// Send a chat message with optional UI context for page-aware and canvas-aware tools.
+    #[allow(clippy::too_many_arguments)] // Public chat entry; each argument is a distinct context channel.
     pub async fn send_chat_message_with_canvas<F>(
         &self,
         conversation_id: &str,
@@ -3218,6 +3226,7 @@ impl AtomicCore {
         on_event: F,
         canvas_context: Option<CanvasContext>,
         page_context: Option<PageContext>,
+        cancel: Option<ChatCancel>,
     ) -> Result<ChatMessageWithContext, AtomicCoreError>
     where
         F: Fn(ChatEvent) + Send + Sync + 'static,
@@ -3232,6 +3241,7 @@ impl AtomicCore {
             canvas_context,
             page_context,
             Some(self.canvas_cache.clone()),
+            cancel,
         )
         .await
         .map_err(|e| AtomicCoreError::DatabaseOperation(e))
@@ -5379,6 +5389,21 @@ mod tests {
                 ..Default::default()
             },
             |_| {}, // no-op callback
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    }
+
+    /// Test utility: create an atom already assigned to `tag_id`.
+    async fn create_tagged_atom(db: &AtomicCore, content: &str, tag_id: &str) -> AtomWithTags {
+        db.create_atom(
+            CreateAtomRequest {
+                content: content.to_string(),
+                tag_ids: vec![tag_id.to_string()],
+                ..Default::default()
+            },
+            |_| {},
         )
         .await
         .unwrap()
@@ -9857,7 +9882,7 @@ mod tests {
             .keyword_search_sync(
                 "elephants",
                 10,
-                None,
+                &[],
                 None,
                 &models::KindFilter::only(models::AtomKind::Captured),
             )
@@ -9872,7 +9897,7 @@ mod tests {
 
         let all = db
             .storage
-            .keyword_search_sync("elephants", 10, None, None, &models::KindFilter::All)
+            .keyword_search_sync("elephants", 10, &[], None, &models::KindFilter::All)
             .await
             .unwrap();
         let all_ids: std::collections::HashSet<_> =
@@ -9881,6 +9906,59 @@ mod tests {
             all_ids.contains(&captured.atom.id) && all_ids.contains(&finding.atom.id),
             "KindFilter::All returns both kinds"
         );
+    }
+
+    #[tokio::test]
+    async fn keyword_search_honors_every_scope_tag() {
+        // Chat scopes a conversation to N tags and expects OR semantics across
+        // all of them. The search stores take the full list precisely so no
+        // backend can quietly honor only the first one (the Postgres path used
+        // to pass `scope_tag_ids.first()`); this pins the contract on the
+        // SQLite path, which shares the scope helper's OR-with-descendants SQL
+        // with Postgres.
+        let (db, _temp) = create_test_db().await;
+        let topics = get_seeded_tag(&db, "Topics");
+        let rust = db
+            .create_tag("Rust", Some(&topics.id))
+            .await
+            .expect("create Rust tag");
+        let sailing = db
+            .create_tag("Sailing", Some(&topics.id))
+            .await
+            .expect("create Sailing tag");
+
+        let rust_atom = create_tagged_atom(&db, "pelicans compile fast", &rust.id).await;
+        let sailing_atom = create_tagged_atom(&db, "pelicans sail south", &sailing.id).await;
+        let untagged_atom = create_test_atom(&db, "pelicans wander off").await;
+
+        let scoped = db
+            .storage
+            .keyword_search_sync(
+                "pelicans",
+                10,
+                &[rust.id.clone(), sailing.id.clone()],
+                None,
+                &models::KindFilter::All,
+            )
+            .await
+            .unwrap();
+        let ids: std::collections::HashSet<_> =
+            scoped.iter().map(|r| r.atom.atom.id.clone()).collect();
+        assert!(
+            ids.contains(&rust_atom.atom.id) && ids.contains(&sailing_atom.atom.id),
+            "every scope tag contributes results, not just the first"
+        );
+        assert!(
+            !ids.contains(&untagged_atom.atom.id),
+            "atoms outside the scope stay out"
+        );
+
+        let unscoped = db
+            .storage
+            .keyword_search_sync("pelicans", 10, &[], None, &models::KindFilter::All)
+            .await
+            .unwrap();
+        assert_eq!(unscoped.len(), 3, "an empty scope filters nothing");
     }
 
     #[tokio::test]

--- a/crates/atomic-core/src/migrate/tables.rs
+++ b/crates/atomic-core/src/migrate/tables.rs
@@ -380,13 +380,13 @@ pub(super) const TABLE_SPECS: &[TableSpec] = &[
     TableSpec {
         table: "conversation_tags",
         source_table: "conversation_tags",
-        select_exprs: "conversation_id, tag_id",
+        select_exprs: "conversation_id, tag_id, COALESCE(mode, 'include')",
         guard: Some(
             "conversation_id IN (SELECT id FROM conversations) \
              AND tag_id IN (SELECT id FROM tags)",
         ),
-        pg_cols: &["conversation_id", "tag_id"],
-        types: &[Col::Text, Col::Text],
+        pg_cols: &["conversation_id", "tag_id", "mode"],
+        types: &[Col::Text, Col::Text, Col::Text],
         binds_skip_json: false,
     },
     TableSpec {
@@ -439,30 +439,32 @@ pub(super) const TABLE_SPECS: &[TableSpec] = &[
         ],
         binds_skip_json: false,
     },
-    // Postgres has no citation_index column; its read path numbers citations
-    // in row order, so rows are inserted in (message_id, citation_index)
-    // order — rowid order in SQLite already matches insertion order.
     TableSpec {
         table: "chat_citations",
         source_table: "chat_citations",
-        select_exprs: "id, message_id, atom_id, chunk_index, COALESCE(excerpt, ''), \
-                       relevance_score",
+        select_exprs: "id, message_id, citation_index, atom_id, chunk_index, \
+                       COALESCE(excerpt, ''), relevance_score, \
+                       COALESCE(source_type, 'atom')",
         guard: Some("message_id IN (SELECT id FROM chat_messages)"),
         pg_cols: &[
             "id",
             "message_id",
+            "citation_index",
             "atom_id",
             "chunk_index",
             "excerpt",
             "relevance_score",
+            "source_type",
         ],
         types: &[
             Col::Text,
             Col::Text,
+            Col::Int,
             Col::Text,
             Col::Int,
             Col::Text,
             Col::Real,
+            Col::Text,
         ],
         binds_skip_json: false,
     },

--- a/crates/atomic-core/src/models.rs
+++ b/crates/atomic-core/src/models.rs
@@ -915,12 +915,13 @@ pub struct ChatToolCall {
 /// `source_type` names: `atom` (the default, and what every row written
 /// before source types existed is), `wiki`, or `finding`. `atom_id` is the
 /// id of that source — an atom id, the *tag* id of a wiki article, or the
-/// finding atom's id — so exactly one id column is ever meaningful. (Neither
-/// backend constrains that column any more: a wiki citation's id belongs to
-/// a tag, so SQLite's `REFERENCES atoms(id)` was dropped in the v23 table
-/// rebuild. Deleting a source consequently leaves its citations behind as
-/// dead links, which is how the readers already render a source that has
-/// gone missing.)
+/// finding atom's id — so exactly one id column is ever meaningful. Neither
+/// backend constrains that column any more: Postgres never declared a foreign
+/// key on it, and SQLite's `REFERENCES atoms(id)` — which *was* enforced, our
+/// bundled SQLite defaulting `foreign_keys` on — was dropped in the v23 table
+/// rebuild, because a wiki citation's id belongs to a tag. Deleting a source
+/// consequently leaves its citations behind as dead links, which is how the
+/// readers already render a source that has gone missing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChatCitation {

--- a/crates/atomic-core/src/models.rs
+++ b/crates/atomic-core/src/models.rs
@@ -760,6 +760,87 @@ pub struct CanvasLevel {
 // These are included here for use by the Tauri app's chat functionality,
 // even though chat is not part of atomic-core's scope.
 
+/// The role a tag plays in a conversation's scope.
+///
+/// `Include` is the historical behavior and the default every pre-boolean
+/// row and client gets: an atom carrying any include tag is in scope.
+/// `Require` narrows (every require tag must be present), `Exclude` removes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum ScopeMode {
+    #[default]
+    Include,
+    Require,
+    Exclude,
+}
+
+impl ScopeMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ScopeMode::Include => "include",
+            ScopeMode::Require => "require",
+            ScopeMode::Exclude => "exclude",
+        }
+    }
+
+    /// Read a stored mode. Anything unrecognized reads as `Include` so a
+    /// value written by a newer version can never widen an existing scope.
+    pub fn from_db(value: &str) -> Self {
+        match value {
+            "require" => ScopeMode::Require,
+            "exclude" => ScopeMode::Exclude,
+            _ => ScopeMode::Include,
+        }
+    }
+}
+
+/// One tag's membership in a conversation's scope, as clients send it.
+///
+/// Deserializes from either `{"tag_id": "...", "mode": "exclude"}` or a bare
+/// tag id string — the shape every client sent before modes existed, which
+/// means include.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ScopeEntry {
+    pub tag_id: String,
+    #[serde(default)]
+    pub mode: ScopeMode,
+}
+
+impl<'de> Deserialize<'de> for ScopeEntry {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Id(String),
+            Entry {
+                tag_id: String,
+                #[serde(default)]
+                mode: ScopeMode,
+            },
+        }
+        Ok(match Repr::deserialize(deserializer)? {
+            Repr::Id(tag_id) => ScopeEntry {
+                tag_id,
+                mode: ScopeMode::Include,
+            },
+            Repr::Entry { tag_id, mode } => ScopeEntry { tag_id, mode },
+        })
+    }
+}
+
+/// A scope tag as clients read it: the whole tag plus its mode. Flattened so
+/// the JSON stays the tag object it has always been, with `mode` added.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ScopeTag {
+    #[serde(flatten)]
+    pub tag: Tag,
+    #[serde(default)]
+    pub mode: ScopeMode,
+}
+
 /// Chat conversation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -777,7 +858,7 @@ pub struct Conversation {
 pub struct ConversationWithTags {
     #[serde(flatten)]
     pub conversation: Conversation,
-    pub tags: Vec<Tag>,
+    pub tags: Vec<ScopeTag>,
     pub message_count: i32,
     pub last_message_preview: Option<String>,
 }
@@ -788,7 +869,7 @@ pub struct ConversationWithTags {
 pub struct ConversationWithMessages {
     #[serde(flatten)]
     pub conversation: Conversation,
-    pub tags: Vec<Tag>,
+    pub tags: Vec<ScopeTag>,
     pub messages: Vec<ChatMessageWithContext>,
 }
 
@@ -828,17 +909,43 @@ pub struct ChatToolCall {
     pub completed_at: Option<String>,
 }
 
-/// Citation in a chat message
+/// Citation in a chat message.
+///
+/// A citation points at whatever kind of source the answer cited, which
+/// `source_type` names: `atom` (the default, and what every row written
+/// before source types existed is), `wiki`, or `finding`. `atom_id` is the
+/// id of that source — an atom id, the *tag* id of a wiki article, or the
+/// finding atom's id — so exactly one id column is ever meaningful. (Neither
+/// backend constrains that column any more: a wiki citation's id belongs to
+/// a tag, so SQLite's `REFERENCES atoms(id)` was dropped in the v23 table
+/// rebuild. Deleting a source consequently leaves its citations behind as
+/// dead links, which is how the readers already render a source that has
+/// gone missing.)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChatCitation {
     pub id: String,
     pub message_id: String,
     pub citation_index: i32,
+    /// The cited source's id, read according to `source_type`.
     pub atom_id: String,
     pub chunk_index: Option<i32>,
     pub excerpt: String,
     pub relevance_score: Option<f32>,
+    /// `atom` | `wiki` | `finding`. Defaults to `atom` so clients and rows
+    /// that predate source types keep working.
+    #[serde(default = "default_citation_source_type")]
+    pub source_type: String,
+    /// Display name for sources the UI can't name from an id alone — the
+    /// tag name behind a wiki citation. Resolved at read time (not stored),
+    /// so a renamed tag reads back correctly; `None` for atoms and
+    /// findings, whose titles the reader already loads with the atom.
+    #[serde(default)]
+    pub source_title: Option<String>,
+}
+
+fn default_citation_source_type() -> String {
+    "atom".to_string()
 }
 
 // ==================== Feed Types ====================
@@ -1507,4 +1614,48 @@ pub struct ReportFindingCitation {
     pub cited_atom_id: String,
     pub position: i32,
     pub excerpt: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_entry_accepts_a_bare_tag_id() {
+        // Every client that predates boolean scope sends `["tag-a"]`; that
+        // has to keep meaning "include tag-a" rather than failing the request.
+        let entries: Vec<ScopeEntry> =
+            serde_json::from_str(r#"["tag-a", {"tag_id": "tag-b", "mode": "exclude"}]"#)
+                .expect("mixed scope payload");
+        assert_eq!(entries[0].tag_id, "tag-a");
+        assert_eq!(entries[0].mode, ScopeMode::Include);
+        assert_eq!(entries[1].tag_id, "tag-b");
+        assert_eq!(entries[1].mode, ScopeMode::Exclude);
+
+        // An object without a mode is an include too.
+        let bare: ScopeEntry =
+            serde_json::from_str(r#"{"tag_id": "tag-c"}"#).expect("modeless entry");
+        assert_eq!(bare.mode, ScopeMode::Include);
+    }
+
+    #[test]
+    fn scope_tag_serializes_flat_with_its_mode() {
+        // The UI reads a scope tag as the tag object it has always been,
+        // plus `mode` — nothing nested, nothing renamed.
+        let json = serde_json::to_value(ScopeTag {
+            tag: Tag {
+                id: "tag-a".into(),
+                name: "Rust".into(),
+                parent_id: None,
+                created_at: "2026-01-01T00:00:00Z".into(),
+                is_autotag_target: false,
+                autotag_description: String::new(),
+            },
+            mode: ScopeMode::Require,
+        })
+        .expect("serialize scope tag");
+        assert_eq!(json["id"], "tag-a");
+        assert_eq!(json["name"], "Rust");
+        assert_eq!(json["mode"], "require");
+    }
 }

--- a/crates/atomic-core/src/providers/ollama/llm.rs
+++ b/crates/atomic-core/src/providers/ollama/llm.rs
@@ -423,14 +423,18 @@ pub async fn complete_streaming_with_tools(
                     on_delta(StreamDelta::Content(response.message.content.clone()));
                 }
 
-                // Handle tool calls - they typically come all at once in Ollama
+                // Handle tool calls - they typically come all at once in Ollama.
+                // The base is captured before the loop: the push below grows
+                // tool_calls while `i` advances, so `tool_calls.len() + i`
+                // would double-count within a multi-call frame.
                 if let Some(tcs) = response.message.tool_calls {
+                    let base = tool_calls.len();
                     for (i, tc) in tcs.iter().enumerate() {
-                        let tool_call = convert_tool_call(tc, tool_calls.len() + i);
+                        let tool_call = convert_tool_call(tc, base + i);
 
                         // Emit tool call start
                         on_delta(StreamDelta::ToolCallStart {
-                            index: tool_calls.len() + i,
+                            index: base + i,
                             id: tool_call.id.clone(),
                             name: tc.function.name.clone(),
                         });
@@ -439,7 +443,7 @@ pub async fn complete_streaming_with_tools(
                         let args =
                             serde_json::to_string(&tc.function.arguments).unwrap_or_default();
                         on_delta(StreamDelta::ToolCallArguments {
-                            index: tool_calls.len() + i,
+                            index: base + i,
                             arguments: args,
                         });
 
@@ -471,4 +475,198 @@ pub async fn complete_streaming_with_tools(
         upstream_provider: None,
         generation_id: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    //! Ollama's streaming parser, against the framing Ollama actually
+    //! produces.
+    //!
+    //! Nothing here is shared with the two OpenAI-shaped providers. The
+    //! stream is newline-delimited JSON rather than SSE frames; there is no
+    //! `[DONE]` sentinel, just a final object with `done: true`; a tool call
+    //! arrives complete in one frame with its arguments as a **JSON object**
+    //! rather than dribbled out as a string; and the wire carries neither an
+    //! id nor an index, so both are synthesized here. Every one of those is a
+    //! place the agent loop's assumptions could quietly not hold.
+
+    use std::sync::{Arc, Mutex};
+
+    use atomic_test_support::MockAiServer;
+
+    use super::*;
+    use crate::providers::traits::StreamingLlmProvider;
+    use crate::providers::types::GenerationParams;
+
+    /// Drive one streaming completion against a scripted NDJSON body,
+    /// returning the assembled response and every delta emitted, in order.
+    async fn stream(script: &str) -> (CompletionResponse, Vec<StreamDelta>) {
+        let mock = MockAiServer::start().await;
+        mock.set_stream_script(Some(script));
+        let provider = OllamaProvider::new(Some(mock.base_url()), Some(30));
+        let deltas = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&deltas);
+        let response = provider
+            .complete_streaming_with_tools(
+                &[Message::user("go")],
+                &[ToolDefinition::new(
+                    "search_atoms",
+                    "search",
+                    serde_json::json!({ "type": "object" }),
+                )],
+                &LlmConfig::new("mock-model").with_params(GenerationParams::new()),
+                Box::new(move |delta| sink.lock().expect("delta sink").push(delta)),
+            )
+            .await
+            .expect("streaming completion");
+        let deltas = deltas.lock().expect("delta sink").clone();
+        (response, deltas)
+    }
+
+    fn content_deltas(deltas: &[StreamDelta]) -> Vec<String> {
+        deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                StreamDelta::Content(text) => Some(text.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn tool_starts(deltas: &[StreamDelta]) -> Vec<(usize, String)> {
+        deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                StreamDelta::ToolCallStart { index, name, .. } => Some((*index, name.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Each NDJSON frame's content is forwarded on its own, and the closing
+    /// `done` frame ends the stream. Empty content frames carry no delta —
+    /// Ollama sends one as the terminator and an empty chunk on the wire is
+    /// not something a UI should render.
+    #[tokio::test]
+    async fn ndjson_content_frames_are_forwarded_one_at_a_time() {
+        let script = concat!(
+            r#"{"model":"llama3.2","message":{"role":"assistant","content":"Mock "},"done":false}"#,
+            "\n",
+            r#"{"model":"llama3.2","message":{"role":"assistant","content":"answer"},"done":false}"#,
+            "\n",
+            r#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}"#,
+            "\n",
+        );
+        let (response, deltas) = stream(script).await;
+
+        assert_eq!(response.content, "Mock answer");
+        assert_eq!(content_deltas(&deltas), vec!["Mock ", "answer"]);
+        assert!(
+            matches!(deltas.last(), Some(StreamDelta::Done { .. })),
+            "the `done` frame closes the stream: {deltas:?}"
+        );
+        assert!(response.tool_calls.is_none());
+    }
+
+    /// A tool call arrives whole, with **object**-valued arguments, and no
+    /// id. The parser has to stringify the arguments (every consumer, from
+    /// the agent loop to the stored transcript, reads them as a JSON string)
+    /// and mint an id, since the loop keys tool results by one.
+    #[tokio::test]
+    async fn object_valued_arguments_are_stringified_and_an_id_is_minted() {
+        let script = concat!(
+            r#"{"model":"llama3.2","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"search_atoms","arguments":{"query":"pelicans","limit":5}}}]},"done":false}"#,
+            "\n",
+            r#"{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}"#,
+            "\n",
+        );
+        let (response, deltas) = stream(script).await;
+
+        let calls = response.tool_calls.expect("a tool call");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].get_name(), Some("search_atoms"));
+        let arguments: serde_json::Value =
+            serde_json::from_str(calls[0].get_arguments().expect("arguments"))
+                .expect("arguments must be a JSON string the loop can parse");
+        assert_eq!(
+            arguments,
+            serde_json::json!({ "query": "pelicans", "limit": 5 })
+        );
+        assert!(
+            !calls[0].id.is_empty(),
+            "an id has to be minted; the wire sends none"
+        );
+        assert_eq!(calls[0].call_type.as_deref(), Some("function"));
+
+        assert_eq!(tool_starts(&deltas), vec![(0, "search_atoms".to_string())]);
+    }
+
+    /// Several tool calls in one turn arrive in order, complete, with
+    /// distinct minted ids — ids that collided would make the loop's
+    /// tool-result transcript ambiguous — and contiguous delta indices
+    /// even when one frame carries more than one call.
+    #[tokio::test]
+    async fn several_tool_calls_arrive_in_order_with_distinct_ids() {
+        let script = concat!(
+            r#"{"message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"first","arguments":{"a":1}}},{"function":{"name":"second","arguments":{"b":2}}}]},"done":false}"#,
+            "\n",
+            r#"{"message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"third","arguments":{"c":3}}}]},"done":false}"#,
+            "\n",
+            r#"{"message":{"role":"assistant","content":""},"done":true}"#,
+            "\n",
+        );
+        let (response, deltas) = stream(script).await;
+
+        let calls = response.tool_calls.expect("three tool calls");
+        assert_eq!(calls.len(), 3);
+        let names: Vec<_> = calls.iter().filter_map(|c| c.get_name()).collect();
+        assert_eq!(names, vec!["first", "second", "third"]);
+
+        let ids: std::collections::HashSet<_> = calls.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids.len(), 3, "minted ids must not collide: {calls:?}");
+
+        // Every call is announced, in wire order, at contiguous indices —
+        // including within the two-call first frame.
+        assert_eq!(
+            tool_starts(&deltas),
+            vec![
+                (0, "first".to_string()),
+                (1, "second".to_string()),
+                (2, "third".to_string()),
+            ]
+        );
+    }
+
+    /// A frame may carry prose and a tool call together; both are surfaced.
+    #[tokio::test]
+    async fn a_frame_carrying_both_prose_and_a_tool_call_surfaces_both() {
+        let script = concat!(
+            r#"{"message":{"role":"assistant","content":"Looking it up. ","tool_calls":[{"function":{"name":"search_atoms","arguments":{"query":"x"}}}]},"done":false}"#,
+            "\n",
+            r#"{"message":{"role":"assistant","content":""},"done":true}"#,
+            "\n",
+        );
+        let (response, deltas) = stream(script).await;
+
+        assert_eq!(response.content, "Looking it up. ");
+        assert_eq!(content_deltas(&deltas), vec!["Looking it up. "]);
+        assert_eq!(response.tool_calls.expect("a tool call").len(), 1);
+    }
+
+    /// Blank lines and frames the parser cannot read are skipped rather
+    /// than failing the stream — the same tolerance the SSE parsers have.
+    #[tokio::test]
+    async fn blank_and_unreadable_lines_are_skipped() {
+        let script = concat!(
+            "\n",
+            r#"{"message":{"role":"assistant","content":"kept"},"done":false}"#,
+            "\n",
+            "{not json at all}\n",
+            "\n",
+            r#"{"message":{"role":"assistant","content":""},"done":true}"#,
+            "\n",
+        );
+        let (response, _deltas) = stream(script).await;
+        assert_eq!(response.content, "kept");
+    }
 }

--- a/crates/atomic-core/src/providers/openai_compat/llm.rs
+++ b/crates/atomic-core/src/providers/openai_compat/llm.rs
@@ -536,3 +536,172 @@ pub async fn complete_streaming_with_tools(
         generation_id: None,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    //! What this parser does that the OpenRouter one does not.
+    //!
+    //! "OpenAI-compatible" is a family, not a spec, and the two divergences
+    //! this provider carries exist because real servers in that family
+    //! diverge: some (reasoning models behind vLLM/SGLang) put the answer in
+    //! `reasoning_content` rather than `content`, and some close the
+    //! connection without ever sending `data: [DONE]`. Both are silent
+    //! failures if the parser stops handling them — an empty answer, or a
+    //! stream that never signals completion. The shared machinery (argument
+    //! accumulation across deltas) is pinned here too because it is a second
+    //! copy of the code, free to drift from OpenRouter's.
+
+    use std::sync::{Arc, Mutex};
+
+    use atomic_test_support::MockAiServer;
+
+    use super::*;
+    use crate::providers::openai_compat::OpenAICompatProvider;
+    use crate::providers::traits::StreamingLlmProvider;
+    use crate::providers::types::GenerationParams;
+
+    /// Drive one streaming completion against a scripted body, returning the
+    /// assembled response and every delta the provider emitted, in order.
+    async fn stream(script: &str) -> (CompletionResponse, Vec<StreamDelta>) {
+        let mock = MockAiServer::start().await;
+        mock.set_stream_script(Some(script));
+        let provider = OpenAICompatProvider::new(mock.base_url(), Some("k".to_string()), Some(30));
+        let deltas = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&deltas);
+        let response = provider
+            .complete_streaming_with_tools(
+                &[Message::user("go")],
+                &[ToolDefinition::new(
+                    "search_atoms",
+                    "search",
+                    serde_json::json!({ "type": "object" }),
+                )],
+                &LlmConfig::new("mock-model").with_params(GenerationParams::new()),
+                Box::new(move |delta| sink.lock().expect("delta sink").push(delta)),
+            )
+            .await
+            .expect("streaming completion");
+        let deltas = deltas.lock().expect("delta sink").clone();
+        (response, deltas)
+    }
+
+    fn content_deltas(deltas: &[StreamDelta]) -> Vec<String> {
+        deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                StreamDelta::Content(text) => Some(text.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Servers that stream the answer as `reasoning_content` are answered
+    /// the same way as servers that use `content` — otherwise the turn
+    /// arrives empty with no error to explain it.
+    #[tokio::test]
+    async fn reasoning_content_stands_in_for_an_empty_content_field() {
+        let script = concat!(
+            r#"data: {"choices":[{"delta":{"content":"","reasoning_content":"thought "},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"reasoning_content":"then answer"},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (response, deltas) = stream(script).await;
+        assert_eq!(response.content, "thought then answer");
+        assert_eq!(content_deltas(&deltas), vec!["thought ", "then answer"]);
+    }
+
+    /// When both fields are populated, `content` wins — `reasoning_content`
+    /// is a fallback, not an addition, and concatenating both would
+    /// duplicate the answer.
+    #[tokio::test]
+    async fn content_wins_over_reasoning_content_when_both_arrive() {
+        let script = concat!(
+            r#"data: {"choices":[{"delta":{"content":"real","reasoning_content":"scratch"},"finish_reason":null}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (response, deltas) = stream(script).await;
+        assert_eq!(response.content, "real");
+        assert_eq!(content_deltas(&deltas), vec!["real"]);
+    }
+
+    /// A stream that just ends still reports completion. Without the
+    /// fallback the caller would wait for a `Done` that never comes.
+    #[tokio::test]
+    async fn a_stream_without_the_done_sentinel_still_completes() {
+        let script = concat!(
+            r#"data: {"choices":[{"delta":{"content":"all there is"},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}]}"#,
+            "\n\n",
+        );
+        let (response, deltas) = stream(script).await;
+        assert_eq!(response.content, "all there is");
+        assert_eq!(response.finish_reason.as_deref(), Some("stop"));
+        assert!(
+            matches!(
+                deltas.last(),
+                Some(StreamDelta::Done { finish_reason }) if finish_reason.as_deref() == Some("stop")
+            ),
+            "the close has to be synthesized: {deltas:?}"
+        );
+        assert_eq!(
+            deltas
+                .iter()
+                .filter(|d| matches!(d, StreamDelta::Done { .. }))
+                .count(),
+            1,
+            "exactly one close, never a duplicate"
+        );
+    }
+
+    /// The sentinel is not double-counted when it *is* sent.
+    #[tokio::test]
+    async fn the_done_sentinel_closes_the_stream_exactly_once() {
+        let script = concat!(
+            r#"data: {"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (_response, deltas) = stream(script).await;
+        assert_eq!(
+            deltas
+                .iter()
+                .filter(|d| matches!(d, StreamDelta::Done { .. }))
+                .count(),
+            1
+        );
+    }
+
+    /// Argument accumulation, pinned independently of OpenRouter's copy.
+    #[tokio::test]
+    async fn tool_call_arguments_accumulate_across_deltas() {
+        let script = concat!(
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search_atoms","arguments":"{\"query\""}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\"pelicans\"}"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (response, deltas) = stream(script).await;
+
+        let calls = response.tool_calls.expect("a tool call");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(calls[0].get_name(), Some("search_atoms"));
+        assert_eq!(calls[0].get_arguments(), Some(r#"{"query":"pelicans"}"#));
+        assert_eq!(response.finish_reason.as_deref(), Some("tool_calls"));
+
+        let starts = deltas
+            .iter()
+            .filter(|d| matches!(d, StreamDelta::ToolCallStart { .. }))
+            .count();
+        assert_eq!(starts, 1, "announced once, not once per fragment");
+    }
+}

--- a/crates/atomic-core/src/providers/openrouter/llm.rs
+++ b/crates/atomic-core/src/providers/openrouter/llm.rs
@@ -535,6 +535,7 @@ async fn complete_streaming_internal(
     let mut native_finish_reason = None;
     let mut upstream_provider = None;
     let mut generation_id = None;
+    let mut done_emitted = false;
 
     let mut stream = response.bytes_stream();
 
@@ -555,6 +556,7 @@ async fn complete_streaming_internal(
 
             // Check for stream end
             if line == "data: [DONE]" {
+                done_emitted = true;
                 on_delta(StreamDelta::Done {
                     finish_reason: finish_reason.clone(),
                 });
@@ -641,6 +643,14 @@ async fn complete_streaming_internal(
         }
     }
 
+    // Some upstreams close the stream without sending [DONE] — mirror the
+    // openai_compat parser and still close out the delta stream exactly once.
+    if !done_emitted {
+        on_delta(StreamDelta::Done {
+            finish_reason: finish_reason.clone(),
+        });
+    }
+
     // Convert accumulators to ToolCall
     let tool_calls = if tool_call_accumulators.is_empty() {
         None
@@ -673,4 +683,302 @@ async fn complete_streaming_internal(
         upstream_provider,
         generation_id,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    //! The streaming parser against wire shapes OpenRouter actually
+    //! produces and the generated mock responses never do.
+    //!
+    //! Two things are only reachable here. First, **argument accumulation**:
+    //! a real provider dribbles a tool call's JSON out over many deltas, and
+    //! [`ToolCallAccumulator`] exists solely to stitch them back together —
+    //! a mock that sends each call whole in one delta exercises none of it.
+    //! Second, the **OpenRouter-only metadata** (`provider`, generation `id`,
+    //! `native_finish_reason`), which is diagnostic gold when a generation
+    //! ends early and is silently dropped if the parser stops reading it.
+
+    use std::sync::{Arc, Mutex};
+
+    use atomic_test_support::MockAiServer;
+
+    use super::*;
+    use crate::providers::openrouter::OpenRouterProvider;
+    use crate::providers::traits::StreamingLlmProvider;
+    use crate::providers::types::GenerationParams;
+
+    /// Drive one streaming completion against a scripted body, returning the
+    /// assembled response and every delta the provider emitted, in order.
+    async fn stream(script: &str) -> (CompletionResponse, Vec<StreamDelta>) {
+        let mock = MockAiServer::start().await;
+        mock.set_stream_script(Some(script));
+        // A bare base URL: the provider appends `/v1` itself, which is how
+        // the request finds the mock's OpenAI-shaped route.
+        let provider = OpenRouterProvider::with_base_url("test-key".to_string(), mock.base_url());
+        let deltas = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&deltas);
+        let response = provider
+            .complete_streaming_with_tools(
+                &[Message::user("go")],
+                &[ToolDefinition::new(
+                    "search_atoms",
+                    "search",
+                    serde_json::json!({ "type": "object" }),
+                )],
+                &LlmConfig::new("mock-model").with_params(GenerationParams::new()),
+                Box::new(move |delta| sink.lock().expect("delta sink").push(delta)),
+            )
+            .await
+            .expect("streaming completion");
+        let deltas = deltas.lock().expect("delta sink").clone();
+        (response, deltas)
+    }
+
+    fn tool_arg_deltas(deltas: &[StreamDelta]) -> Vec<(usize, String)> {
+        deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                StreamDelta::ToolCallArguments { index, arguments } => {
+                    Some((*index, arguments.clone()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn tool_starts(deltas: &[StreamDelta]) -> Vec<(usize, String, String)> {
+        deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                StreamDelta::ToolCallStart { index, id, name } => {
+                    Some((*index, id.clone(), name.clone()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// A tool call arriving one fragment at a time — the normal case on a
+    /// real stream — reassembles into one call with the whole argument
+    /// string, and announces itself exactly once.
+    #[tokio::test]
+    async fn tool_call_arguments_accumulate_across_deltas() {
+        let script = concat!(
+            // The opening frame names the call; arguments start empty.
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search_atoms","arguments":""}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"query\":"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"pelic"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ans\"}"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (response, deltas) = stream(script).await;
+
+        let calls = response.tool_calls.expect("a tool call");
+        assert_eq!(calls.len(), 1, "fragments are one call, not four");
+        assert_eq!(calls[0].id, "call_1");
+        assert_eq!(calls[0].get_name(), Some("search_atoms"));
+        assert_eq!(
+            calls[0].get_arguments(),
+            Some(r#"{"query":"pelicans"}"#),
+            "the argument string must reassemble in order"
+        );
+        assert_eq!(response.finish_reason.as_deref(), Some("tool_calls"));
+
+        // Announced once, on the frame that named it — repeated starts would
+        // make a UI render a new tool card per fragment.
+        assert_eq!(
+            tool_starts(&deltas),
+            vec![(0, "call_1".to_string(), "search_atoms".to_string())]
+        );
+        // Every fragment is forwarded as it arrives, all under index 0, and
+        // together they spell the same string the accumulator built — a
+        // consumer rendering the deltas live sees exactly what the finished
+        // call says.
+        let forwarded = tool_arg_deltas(&deltas);
+        assert!(
+            forwarded.iter().all(|(index, _)| *index == 0),
+            "one call means one index: {forwarded:?}"
+        );
+        let joined: String = forwarded.into_iter().map(|(_, args)| args).collect();
+        assert_eq!(joined, r#"{"query":"pelicans"}"#);
+    }
+
+    /// Two tool calls in one turn are kept apart by their `index`, even when
+    /// their fragments interleave — which is what an accumulator keyed by
+    /// index buys over one keyed by arrival order.
+    #[tokio::test]
+    async fn parallel_tool_calls_are_kept_apart_by_index() {
+        let script = concat!(
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"first","arguments":"{\"a\":"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"call_b","type":"function","function":{"name":"second","arguments":"{\"b\":"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"1}"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"2}"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (response, deltas) = stream(script).await;
+
+        let calls = response.tool_calls.expect("two tool calls");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].id, "call_a");
+        assert_eq!(calls[0].get_name(), Some("first"));
+        assert_eq!(calls[0].get_arguments(), Some(r#"{"a":1}"#));
+        assert_eq!(calls[1].id, "call_b");
+        assert_eq!(calls[1].get_name(), Some("second"));
+        assert_eq!(calls[1].get_arguments(), Some(r#"{"b":2}"#));
+
+        assert_eq!(
+            tool_starts(&deltas),
+            vec![
+                (0, "call_a".to_string(), "first".to_string()),
+                (1, "call_b".to_string(), "second".to_string()),
+            ]
+        );
+    }
+
+    /// A tool call whose first frame carries only an index and arguments —
+    /// no id, no name — still lands under its index. The upstream shape
+    /// exists (some endpoints send the header frame late), and dropping such
+    /// fragments would silently truncate the arguments.
+    #[tokio::test]
+    async fn argument_fragments_before_the_naming_frame_are_not_lost() {
+        let script = concat!(
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q\":"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_late","type":"function","function":{"name":"search_atoms","arguments":"1}"}}]},"finish_reason":null}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (response, deltas) = stream(script).await;
+
+        let calls = response.tool_calls.expect("a tool call");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_late");
+        assert_eq!(calls[0].get_arguments(), Some(r#"{"q":1}"#));
+        assert_eq!(
+            tool_starts(&deltas),
+            vec![(0, "call_late".to_string(), "search_atoms".to_string())],
+            "the start fires once the call is nameable, not before"
+        );
+    }
+
+    /// OpenRouter's routing metadata survives the stream: which upstream
+    /// served the request, its generation id, and the upstream's raw finish
+    /// reason behind OpenRouter's normalized one. All three are what make an
+    /// early-ending generation diagnosable after the fact.
+    #[tokio::test]
+    async fn routing_metadata_and_native_finish_reason_survive() {
+        let script = concat!(
+            r#"data: {"id":"gen-abc123","provider":"Anthropic","choices":[{"delta":{"content":"partial "},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{"content":"answer"},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{},"finish_reason":"stop","native_finish_reason":"max_tokens"}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (response, deltas) = stream(script).await;
+
+        assert_eq!(response.content, "partial answer");
+        assert_eq!(response.upstream_provider.as_deref(), Some("Anthropic"));
+        assert_eq!(response.generation_id.as_deref(), Some("gen-abc123"));
+        assert_eq!(response.finish_reason.as_deref(), Some("stop"));
+        assert_eq!(
+            response.native_finish_reason.as_deref(),
+            Some("max_tokens"),
+            "a truncation hidden behind a normalized `stop` must still be visible"
+        );
+
+        // Content is forwarded chunk by chunk, and the sentinel closes with
+        // the finish reason the last frame carried.
+        let content: Vec<String> = deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                StreamDelta::Content(text) => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(content, vec!["partial ", "answer"]);
+        assert!(matches!(
+            deltas.last(),
+            Some(StreamDelta::Done { finish_reason }) if finish_reason.as_deref() == Some("stop")
+        ));
+    }
+
+    /// Keep-alive comments and unparseable frames are noise, not failures:
+    /// a stream carrying them still yields the content around them.
+    #[tokio::test]
+    async fn unparseable_frames_are_skipped_rather_than_failing_the_stream() {
+        let script = concat!(
+            ": OPENROUTER PROCESSING\n\n",
+            r#"data: {"choices":[{"delta":{"content":"kept"},"finish_reason":null}]}"#,
+            "\n\n",
+            "data: {not json at all}\n\n",
+            r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (response, _deltas) = stream(script).await;
+        assert_eq!(response.content, "kept");
+        assert_eq!(response.finish_reason.as_deref(), Some("stop"));
+    }
+
+    /// A stream that just ends still reports completion — mirrored from the
+    /// openai_compat parser so the two SSE loops keep one contract.
+    #[tokio::test]
+    async fn a_stream_without_the_done_sentinel_still_completes() {
+        let script = concat!(
+            r#"data: {"choices":[{"delta":{"content":"all there is"},"finish_reason":null}]}"#,
+            "\n\n",
+            r#"data: {"choices":[{"delta":{},"finish_reason":"stop"}]}"#,
+            "\n\n",
+        );
+        let (response, deltas) = stream(script).await;
+        assert_eq!(response.content, "all there is");
+        assert_eq!(response.finish_reason.as_deref(), Some("stop"));
+        assert!(
+            matches!(
+                deltas.last(),
+                Some(StreamDelta::Done { finish_reason }) if finish_reason.as_deref() == Some("stop")
+            ),
+            "the close has to be synthesized: {deltas:?}"
+        );
+        assert_eq!(
+            deltas
+                .iter()
+                .filter(|d| matches!(d, StreamDelta::Done { .. }))
+                .count(),
+            1,
+            "exactly one close, never a duplicate"
+        );
+    }
+
+    /// The sentinel is not double-counted when it *is* sent.
+    #[tokio::test]
+    async fn the_done_sentinel_closes_the_stream_exactly_once() {
+        let script = concat!(
+            r#"data: {"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}"#,
+            "\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (_response, deltas) = stream(script).await;
+        assert_eq!(
+            deltas
+                .iter()
+                .filter(|d| matches!(d, StreamDelta::Done { .. }))
+                .count(),
+            1
+        );
+    }
 }

--- a/crates/atomic-core/src/reports/agentic.rs
+++ b/crates/atomic-core/src/reports/agentic.rs
@@ -1,38 +1,44 @@
-//! Generalized agentic research loop for report runs.
+//! Report runs: what makes a scheduled research run a *report*.
 //!
-//! Reads from a source batch + parameterized context corpus, produces a
-//! prose finding with `[N]` citation markers, and returns a typed
-//! `RunOutput` the runner persists transactionally.
+//! The loop itself, the tool registry, and the citation ledger live in
+//! [`crate::agent_runtime`]. This module owns the report-shaped parts: the
+//! three tools a run gets (`read_atom`, `semantic_search`, `done`), the
+//! prompt the source batch is rendered into, the citation policy, and the
+//! final pass that turns the gathered transcript into prose. It never
+//! touches storage directly, so it can be exercised against a mock LLM.
 //!
-//! The agent is intentionally given the same three tools the existing
-//! daily briefing uses (`read_atom`, `semantic_search`, `done`). The
-//! differences live in the citable-evidence map and the search filter:
+//! Citations are numbered evidence, and the two policies differ only in what
+//! the run admits:
 //!
-//! - Source atoms are pre-numbered `[1]..[N]` so `source_only` reports
-//!   have a fixed citation surface.
-//! - Under `source_and_context`, every `semantic_search` result is
-//!   assigned the next available number on first appearance and surfaced
-//!   to the agent alongside title/snippet. Repeat hits reuse the number.
-//! - `semantic_search` results are post-filtered by the report's
-//!   context scope (tag subtree, time window, kinds, self-exclusion).
-//!   The agent never sees atoms outside scope.
+//! - Source atoms are seeded `[1]..[N]` in list order, so `source_only`
+//!   reports have a fixed citation surface.
+//! - Under `source_and_context`, every `semantic_search` result is assigned
+//!   the next available number on first appearance and surfaced to the agent
+//!   alongside title/snippet. Repeat hits reuse the number.
+//! - `semantic_search` results are post-filtered by the report's context
+//!   scope (tag subtree, time window, kinds, self-exclusion). The agent never
+//!   sees atoms outside scope.
 //!
 //! The final pass uses the long-form markdown contract
 //! (`call_long_form_markdown`): the report body is plain markdown with a
 //! `CITATIONS_USED:` trailer, never JSON — see that helper's docs for the
 //! two truncation incidents that ruled JSON envelopes out.
 
+use crate::agent_runtime::{
+    AgentRun, AgentTool, CitationAdmission, CitationLedger, CitationSource, RunConfig, RunError,
+    Termination, ToolContext, ToolRegistry, ToolResult,
+};
 use crate::error::AtomicCoreError;
 use crate::models::{AtomWithTags, CitationPolicy, Report};
-use crate::providers::types::{CompletionResponse, Message, MessageRole, ToolDefinition};
-use crate::providers::{get_llm_provider, LlmConfig, ProviderConfig, ProviderType};
+use crate::providers::types::{GenerationParams, Message, ToolDefinition};
+use crate::providers::{ProviderConfig, ProviderType};
 use crate::reports::scope::{ContextFilter, TimeWindow};
 use crate::search::{SearchMode, SearchOptions};
 use crate::AtomicCore;
 
-use regex::Regex;
+use async_trait::async_trait;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 /// Default cap on tool-calling iterations. Reports can override via the
 /// `max_tool_iterations` column; the cap exists so a runaway agent
@@ -55,15 +61,9 @@ const DEFAULT_SEARCH_LIMIT: i64 = 5;
 const MAX_SEARCH_LIMIT: i64 = 10;
 const DEFAULT_READ_LIMIT: i64 = 500;
 const MAX_READ_LIMIT: i64 = 500;
-
-/// One entry in the run's citable-evidence map. Source atoms are loaded
-/// up front; context atoms (when citable) accrue during the agent loop.
-#[derive(Debug, Clone)]
-struct Citable {
-    number: i32,
-    atom_id: String,
-    excerpt: String,
-}
+/// The tool the agent calls to end research. Named once because it is both a
+/// registry entry and the run's termination condition.
+const DONE_TOOL: &str = "done";
 
 /// What the agent ultimately produced. The runner persists this — this
 /// module never touches storage so it can be exercised against a mock
@@ -76,6 +76,15 @@ pub struct RunOutput {
     pub citations: Vec<ResolvedCitation>,
 }
 
+/// One `[N]` marker the finished report actually wrote, resolved back to the
+/// atom it points at.
+///
+/// `position` carries the **marker number N**, not the order of appearance:
+/// the dashboard renders `[N]` in the prose and looks the citation up by that
+/// same N (`citationMap.get(citation_index)`), so the storage column is the
+/// lookup key. Repeated markers collapse to one row — the composite PK
+/// `(finding_atom_id, cited_atom_id, position)` would reject the second
+/// insert, and one row per `(finding, marker)` renders every occurrence.
 #[derive(Debug, Clone)]
 pub struct ResolvedCitation {
     pub position: i32,
@@ -136,45 +145,16 @@ fn excerpt_for(atom: &AtomWithTags) -> String {
     truncate_on_char_boundary(src.trim(), EXCERPT_LEN)
 }
 
-fn report_tools() -> Vec<ToolDefinition> {
-    vec![
-        ToolDefinition::new(
-            "read_atom",
-            "Read a window of lines from an atom's markdown content. Page through with offset for long atoms.",
-            serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "atom_id": { "type": "string" },
-                    "limit": { "type": "integer", "default": 500 },
-                    "offset": { "type": "integer", "default": 0 }
-                },
-                "required": ["atom_id"],
-                "additionalProperties": false
-            }),
-        ),
-        ToolDefinition::new(
-            "semantic_search",
-            "Search the context corpus configured for this report. Each result has a citation number; whether you may cite it is shown in the response.",
-            serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "query": { "type": "string" },
-                    "limit": { "type": "integer", "default": 5 }
-                },
-                "required": ["query"],
-                "additionalProperties": false
-            }),
-        ),
-        ToolDefinition::new(
-            "done",
-            "Signal that research is complete. Call this before writing the final report.",
-            serde_json::json!({
-                "type": "object",
-                "properties": {},
-                "additionalProperties": false
-            }),
-        ),
-    ]
+/// A tool failure whose wording predates the runtime's `Error: ` prefix.
+/// Reports surface no tool status anywhere — the flag exists for the
+/// transcript — but the text is part of the prompt the model reads next, so
+/// it stays verbatim.
+fn failed_verbatim(output: String) -> ToolResult {
+    ToolResult {
+        output,
+        results_count: 0,
+        failed: true,
+    }
 }
 
 fn build_user_prompt(report: &Report, source: &[AtomWithTags], total_in_scope: i32) -> String {
@@ -247,54 +227,82 @@ fn build_user_prompt(report: &Report, source: &[AtomWithTags], total_in_scope: i
     out
 }
 
-async fn handle_read_atom(core: &AtomicCore, args: &serde_json::Value) -> String {
-    let Some(atom_id) = args.get("atom_id").and_then(|v| v.as_str()) else {
-        return "Error: atom_id is required".to_string();
-    };
-    let limit = args
-        .get("limit")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(DEFAULT_READ_LIMIT)
-        .clamp(1, MAX_READ_LIMIT) as usize;
-    let offset = args
-        .get("offset")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0)
-        .max(0) as usize;
+// ==================== read_atom ====================
 
-    let atom = match core.get_atom(atom_id).await {
-        Ok(Some(a)) => a,
-        Ok(None) => return format!("Error: no atom found with id {}", atom_id),
-        Err(e) => return format!("Error fetching atom {}: {}", atom_id, e),
-    };
-
-    let title = if atom.atom.title.is_empty() {
-        "(untitled)"
-    } else {
-        atom.atom.title.as_str()
-    };
-    let lines: Vec<&str> = atom.atom.content.lines().collect();
-    let total_lines = lines.len();
-    let start = offset.min(total_lines);
-    let end = (start + limit).min(total_lines);
-    let has_more = end < total_lines;
-
-    let mut out = format!(
-        "# {}\n(lines {}-{} of {})\n\n",
-        title,
-        start + 1,
-        end,
-        total_lines
-    );
-    out.push_str(&lines[start..end].join("\n"));
-    if has_more {
-        out.push_str(&format!(
-            "\n\n(More content available. Call read_atom again with offset={} to continue.)",
-            end
-        ));
-    }
-    out
+struct ReadAtom {
+    core: AtomicCore,
 }
+
+#[async_trait]
+impl AgentTool for ReadAtom {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "read_atom",
+            "Read a window of lines from an atom's markdown content. Page through with offset for long atoms.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "atom_id": { "type": "string" },
+                    "limit": { "type": "integer", "default": 500 },
+                    "offset": { "type": "integer", "default": 0 }
+                },
+                "required": ["atom_id"],
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, args: &serde_json::Value, _ctx: &ToolContext<'_>) -> ToolResult {
+        let Some(atom_id) = args.get("atom_id").and_then(|v| v.as_str()) else {
+            return ToolResult::failed("atom_id is required");
+        };
+        let limit = args
+            .get("limit")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(DEFAULT_READ_LIMIT)
+            .clamp(1, MAX_READ_LIMIT) as usize;
+        let offset = args
+            .get("offset")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0)
+            .max(0) as usize;
+
+        let atom = match self.core.get_atom(atom_id).await {
+            Ok(Some(a)) => a,
+            Ok(None) => return ToolResult::failed(format!("no atom found with id {}", atom_id)),
+            Err(e) => return failed_verbatim(format!("Error fetching atom {}: {}", atom_id, e)),
+        };
+
+        let title = if atom.atom.title.is_empty() {
+            "(untitled)"
+        } else {
+            atom.atom.title.as_str()
+        };
+        let lines: Vec<&str> = atom.atom.content.lines().collect();
+        let total_lines = lines.len();
+        let start = offset.min(total_lines);
+        let end = (start + limit).min(total_lines);
+        let has_more = end < total_lines;
+
+        let mut out = format!(
+            "# {}\n(lines {}-{} of {})\n\n",
+            title,
+            start + 1,
+            end,
+            total_lines
+        );
+        out.push_str(&lines[start..end].join("\n"));
+        if has_more {
+            out.push_str(&format!(
+                "\n\n(More content available. Call read_atom again with offset={} to continue.)",
+                end
+            ));
+        }
+        ToolResult::ok(out, 1)
+    }
+}
+
+// ==================== semantic_search ====================
 
 fn passes_context_filter(atom: &AtomWithTags, ctx: &ContextFilter) -> bool {
     if ctx.excluded_atom_ids.contains(&atom.atom.id) {
@@ -344,141 +352,172 @@ async fn build_context_tag_scope_set(
     Ok(Some(atoms.into_iter().map(|a| a.atom.id).collect()))
 }
 
-struct AgentState {
-    messages: Vec<Message>,
-    done_called: bool,
-    /// Map atom_id → Citable. Owned, ordered by `number`.
-    citables: HashMap<String, Citable>,
-    next_citation_number: i32,
-    citation_policy: CitationPolicy,
+/// Search over the report's context corpus. Scope is frozen at run start —
+/// the agent picks the query, never what it is allowed to see.
+struct SemanticSearch {
+    core: AtomicCore,
+    ctx: ContextFilter,
+    tag_scope_set: Option<HashSet<String>>,
 }
 
-impl AgentState {
-    fn from_source(report: &Report, source: &[AtomWithTags]) -> Self {
-        let mut citables = HashMap::new();
-        for (i, atom) in source.iter().enumerate() {
-            let number = (i + 1) as i32;
-            citables.insert(
-                atom.atom.id.clone(),
-                Citable {
-                    number,
-                    atom_id: atom.atom.id.clone(),
-                    excerpt: excerpt_for(atom),
+#[async_trait]
+impl AgentTool for SemanticSearch {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "semantic_search",
+            "Search the context corpus configured for this report. Each result has a citation number; whether you may cite it is shown in the response.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string" },
+                    "limit": { "type": "integer", "default": 5 }
                 },
-            );
-        }
-        let next_citation_number = source.len() as i32 + 1;
-        AgentState {
-            messages: Vec::new(),
-            done_called: false,
-            citables,
-            next_citation_number,
-            citation_policy: report.citation_policy,
-        }
+                "required": ["query"],
+                "additionalProperties": false
+            }),
+        )
     }
 
-    /// Return the citation number for `atom`, assigning a new one if this
-    /// is a fresh context atom under `source_and_context`.
-    fn citation_for_search_result(&mut self, atom: &AtomWithTags) -> Option<i32> {
-        if let Some(c) = self.citables.get(&atom.atom.id) {
-            return Some(c.number);
+    async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext<'_>) -> ToolResult {
+        let query = args
+            .get("query")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if query.is_empty() {
+            return ToolResult::failed("query is required");
         }
-        if self.citation_policy == CitationPolicy::SourceAndContext {
-            let number = self.next_citation_number;
-            self.next_citation_number += 1;
-            self.citables.insert(
-                atom.atom.id.clone(),
-                Citable {
-                    number,
-                    atom_id: atom.atom.id.clone(),
-                    excerpt: excerpt_for(atom),
-                },
-            );
-            Some(number)
-        } else {
-            None
-        }
-    }
-}
+        // Over-fetch slightly so post-filter losses don't leave the agent
+        // with an empty result set on tag-scoped reports.
+        let requested = args
+            .get("limit")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(DEFAULT_SEARCH_LIMIT)
+            .clamp(1, MAX_SEARCH_LIMIT) as i32;
+        let fetch = (requested.saturating_mul(3)).min(MAX_SEARCH_LIMIT as i32);
 
-async fn handle_semantic_search(
-    core: &AtomicCore,
-    state: &mut AgentState,
-    ctx: &ContextFilter,
-    tag_scope_set: &Option<HashSet<String>>,
-    args: &serde_json::Value,
-) -> String {
-    let query = args
-        .get("query")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    if query.is_empty() {
-        return "Error: query is required".to_string();
-    }
-    // Over-fetch slightly so post-filter losses don't leave the agent
-    // with an empty result set on tag-scoped reports.
-    let requested = args
-        .get("limit")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(DEFAULT_SEARCH_LIMIT)
-        .clamp(1, MAX_SEARCH_LIMIT) as i32;
-    let fetch = (requested.saturating_mul(3)).min(MAX_SEARCH_LIMIT as i32);
+        let options = SearchOptions::new(query.clone(), SearchMode::Semantic, fetch);
+        let results = match self.core.search(options).await {
+            Ok(r) => r,
+            Err(e) => return failed_verbatim(format!("Search error: {}", e)),
+        };
 
-    let options = SearchOptions::new(query.clone(), SearchMode::Semantic, fetch);
-    let results = match core.search(options).await {
-        Ok(r) => r,
-        Err(e) => return format!("Search error: {}", e),
-    };
-
-    let mut shown: Vec<(i32, AtomWithTags, f32, String)> = Vec::new();
-    for r in results {
-        if !passes_context_filter(&r.atom, ctx) {
-            continue;
-        }
-        if let Some(set) = tag_scope_set {
-            if !set.contains(&r.atom.atom.id) {
+        let mut shown: Vec<(i32, AtomWithTags, f32, String)> = Vec::new();
+        for r in results {
+            if !passes_context_filter(&r.atom, &self.ctx) {
                 continue;
             }
+            if let Some(set) = &self.tag_scope_set {
+                if !set.contains(&r.atom.atom.id) {
+                    continue;
+                }
+            }
+            let snippet = truncate_on_char_boundary(
+                &r.matching_chunk_content
+                    .chars()
+                    .map(|c| if c == '\n' { ' ' } else { c })
+                    .collect::<String>(),
+                SNIPPET_LEN,
+            );
+            // A `source_only` run admits no new evidence, so a non-source
+            // atom gets no number back and is surfaced as uncitable
+            // background (encoded as 0 in the marker).
+            let number = ctx
+                .citations
+                .register(
+                    CitationSource::Atom,
+                    &r.atom.atom.id,
+                    None,
+                    excerpt_for(&r.atom),
+                )
+                .unwrap_or(0);
+            shown.push((number, r.atom.clone(), r.similarity_score, snippet));
+            if shown.len() >= requested as usize {
+                break;
+            }
         }
-        let snippet = truncate_on_char_boundary(
-            &r.matching_chunk_content
-                .chars()
-                .map(|c| if c == '\n' { ' ' } else { c })
-                .collect::<String>(),
-            SNIPPET_LEN,
-        );
-        // source_only + non-source atom returns None → surface as
-        // uncitable background context (encoded as 0 in the marker).
-        let number = state.citation_for_search_result(&r.atom).unwrap_or(0);
-        shown.push((number, r.atom.clone(), r.similarity_score, snippet));
-        if shown.len() >= requested as usize {
-            break;
+
+        if shown.is_empty() {
+            return ToolResult::ok("No results in context scope.", 0);
         }
+
+        let count = shown.len() as i32;
+        let mut out = String::new();
+        for (number, atom, score, snippet) in &shown {
+            let title = if atom.atom.title.is_empty() {
+                "(untitled)"
+            } else {
+                atom.atom.title.as_str()
+            };
+            let citation_marker = if *number > 0 {
+                format!("[{number}] citable")
+            } else {
+                "(context only, not citable)".to_string()
+            };
+            out.push_str(&format!(
+                "{}. {}\n   {}\n   (atom id: {}, score: {:.2})\n   {}\n\n",
+                citation_marker, title, snippet, atom.atom.id, score, snippet
+            ));
+        }
+        ToolResult::ok(out, count)
+    }
+}
+
+// ==================== done ====================
+
+/// The run's sentinel: calling it ends research and hands the transcript to
+/// [`final_pass`].
+struct Done;
+
+#[async_trait]
+impl AgentTool for Done {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            DONE_TOOL,
+            "Signal that research is complete. Call this before writing the final report.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        )
     }
 
-    if shown.is_empty() {
-        return "No results in context scope.".to_string();
+    async fn execute(&self, _args: &serde_json::Value, _ctx: &ToolContext<'_>) -> ToolResult {
+        ToolResult::ok("Acknowledged. Write the report in your next message.", 0)
     }
+}
 
-    let mut out = String::new();
-    for (number, atom, score, snippet) in &shown {
-        let title = if atom.atom.title.is_empty() {
-            "(untitled)"
-        } else {
-            atom.atom.title.as_str()
-        };
-        let citation_marker = if *number > 0 {
-            format!("[{number}] citable")
-        } else {
-            "(context only, not citable)".to_string()
-        };
-        out.push_str(&format!(
-            "{}. {}\n   {}\n   (atom id: {}, score: {:.2})\n   {}\n\n",
-            citation_marker, title, snippet, atom.atom.id, score, snippet
-        ));
+// ==================== Run assembly ====================
+
+fn report_tools(
+    core: &AtomicCore,
+    ctx: &ContextFilter,
+    tag_scope_set: Option<HashSet<String>>,
+) -> ToolRegistry {
+    ToolRegistry::new()
+        .with(ReadAtom { core: core.clone() })
+        .with(SemanticSearch {
+            core: core.clone(),
+            ctx: ctx.clone(),
+            tag_scope_set,
+        })
+        .with(Done)
+}
+
+/// Number the source batch `[1]..[N]` in list order, matching the numbering
+/// [`build_user_prompt`] shows the model. `source_only` admits nothing
+/// further, so those numbers are the run's entire citation surface;
+/// `source_and_context` lets `semantic_search` mint more.
+fn seeded_ledger(report: &Report, source: &[AtomWithTags]) -> CitationLedger {
+    let ledger = CitationLedger::new(match report.citation_policy {
+        CitationPolicy::SourceOnly => CitationAdmission::SeededOnly,
+        CitationPolicy::SourceAndContext => CitationAdmission::Open,
+    });
+    for atom in source {
+        ledger.seed(CitationSource::Atom, &atom.atom.id, None, excerpt_for(atom));
     }
-    out
+    ledger
 }
 
 async fn resolve_model(core: &AtomicCore) -> Result<(ProviderConfig, String), AtomicCoreError> {
@@ -493,88 +532,6 @@ async fn resolve_model(core: &AtomicCore) -> Result<(ProviderConfig, String), At
             .unwrap_or_else(|| crate::providers::DEFAULT_AGENTIC_MODEL.to_string()),
     };
     Ok((config, model))
-}
-
-async fn run_research(
-    core: &AtomicCore,
-    state: &mut AgentState,
-    ctx: &ContextFilter,
-    tag_scope_set: &Option<HashSet<String>>,
-    provider_config: &ProviderConfig,
-    model: &str,
-    max_iters: usize,
-) -> Result<(), AtomicCoreError> {
-    let tools = report_tools();
-    // Explicit output budget (see providers::structured::DEFAULT_MAX_OUTPUT_TOKENS
-    // for why it must never be left unset on long-output calls).
-    let llm_config = LlmConfig::new(model).with_params(
-        crate::providers::types::GenerationParams::new()
-            .with_max_tokens(crate::providers::structured::DEFAULT_MAX_OUTPUT_TOKENS),
-    );
-    let provider = get_llm_provider(provider_config)
-        .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
-
-    for iteration in 0..max_iters {
-        tracing::debug!(
-            iteration = iteration + 1,
-            max = max_iters,
-            "[reports/agentic] Research iteration"
-        );
-
-        let response: CompletionResponse = provider
-            .complete_with_tools(&state.messages, &tools, &llm_config)
-            .await
-            .map_err(|e| {
-                AtomicCoreError::DatabaseOperation(format!("report research LLM call failed: {e}"))
-            })?;
-
-        let tool_calls = match response.tool_calls {
-            Some(ref tcs) if !tcs.is_empty() => tcs.clone(),
-            _ => break,
-        };
-
-        state.messages.push(Message {
-            role: MessageRole::Assistant,
-            content: if response.content.is_empty() {
-                None
-            } else {
-                Some(response.content.clone())
-            },
-            tool_calls: Some(tool_calls.clone()),
-            tool_call_id: None,
-            name: None,
-        });
-
-        let mut done_this_round = false;
-        for tc in &tool_calls {
-            let name = tc.get_name().unwrap_or("");
-            let args: serde_json::Value = tc
-                .get_arguments()
-                .and_then(|a| serde_json::from_str(a).ok())
-                .unwrap_or(serde_json::json!({}));
-
-            let result = match name {
-                "read_atom" => handle_read_atom(core, &args).await,
-                "semantic_search" => {
-                    handle_semantic_search(core, state, ctx, tag_scope_set, &args).await
-                }
-                "done" => {
-                    done_this_round = true;
-                    state.done_called = true;
-                    "Acknowledged. Write the report in your next message.".to_string()
-                }
-                _ => format!("Unknown tool: {}", name),
-            };
-            state
-                .messages
-                .push(Message::tool_result(tc.id.clone(), result));
-        }
-
-        if done_this_round {
-            break;
-        }
-    }
-    Ok(())
 }
 
 async fn final_pass(
@@ -603,56 +560,6 @@ async fn final_pass(
     }
 }
 
-/// Resolve each `[N]` marker in `content` to a `(position, atom_id,
-/// excerpt)` row. Markers that don't map to a known citable are dropped
-/// with a warning — same behavior as the briefing's extractor.
-///
-/// `position` carries the **marker number N**, not the order of appearance.
-/// The dashboard renders `[N]` in the prose and looks up the citation by
-/// that same N (`citationMap.get(citation_index)`); the storage column is
-/// the lookup key. Storing appearance order would break the lookup the
-/// moment the agent emits `[3]` before `[1]` or uses one marker twice.
-///
-/// Repeated markers dedupe — `Detail [1]. More [1].` produces a single row
-/// for atom 1. The composite PK `(finding_atom_id, cited_atom_id,
-/// position)` would otherwise reject the second insert, and the dashboard
-/// only needs one row per `(finding, marker)` to render every occurrence
-/// of that marker as a clickable popover.
-fn extract_citations(content: &str, citables: &HashMap<String, Citable>) -> Vec<ResolvedCitation> {
-    let re = match Regex::new(r"\[(\d+)\]") {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::error!(error = %e, "[reports/agentic] citation regex compile");
-            return vec![];
-        }
-    };
-    let by_number: HashMap<i32, &Citable> = citables.values().map(|c| (c.number, c)).collect();
-    let mut seen: std::collections::HashSet<i32> = std::collections::HashSet::new();
-    let mut out: Vec<ResolvedCitation> = Vec::new();
-    for cap in re.captures_iter(content) {
-        let Some(m) = cap.get(1) else { continue };
-        let Ok(n) = m.as_str().parse::<i32>() else {
-            continue;
-        };
-        if !seen.insert(n) {
-            continue;
-        }
-        let Some(c) = by_number.get(&n) else {
-            tracing::warn!(
-                citation_number = n,
-                "[reports/agentic] Agent produced unknown citation; dropping"
-            );
-            continue;
-        };
-        out.push(ResolvedCitation {
-            position: n,
-            cited_atom_id: c.atom_id.clone(),
-            excerpt: c.excerpt.clone(),
-        });
-    }
-    out
-}
-
 /// Run the agent against `source` + `ctx` and return the produced
 /// content + resolved citations. Caller is responsible for persistence.
 pub async fn run(
@@ -663,42 +570,71 @@ pub async fn run(
     ctx: &ContextFilter,
 ) -> Result<RunOutput, AtomicCoreError> {
     let (provider_config, model) = resolve_model(core).await?;
-    let max_iters = report
+    let max_iterations = report
         .max_tool_iterations
         .map(|n| n.max(1) as usize)
         .unwrap_or(DEFAULT_MAX_ITERATIONS);
 
     let tag_scope_set = build_context_tag_scope_set(core, ctx).await?;
+    let tools = report_tools(core, ctx, tag_scope_set);
+    let ledger = seeded_ledger(report, source);
 
-    let mut state = AgentState::from_source(report, source);
-    state.messages.push(Message::system(format!(
-        "{SYSTEM_PROMPT_SCAFFOLD}\n\n---\nReport-specific instructions follow."
-    )));
-    state.messages.push(Message::user(build_user_prompt(
-        report,
-        source,
-        total_in_scope,
-    )));
+    let outcome = AgentRun {
+        config: RunConfig {
+            model: model.clone(),
+            // Explicit output budget (see
+            // providers::structured::DEFAULT_MAX_OUTPUT_TOKENS for why it
+            // must never be left unset on long-output calls).
+            params: GenerationParams::new()
+                .with_max_tokens(crate::providers::structured::DEFAULT_MAX_OUTPUT_TOKENS),
+            max_iterations,
+            termination: Termination::Sentinel(DONE_TOOL.to_string()),
+            streaming: false,
+            // The report is written by `final_pass` over the whole
+            // transcript, so an exhausted budget needs no salvage answer.
+            salvage_on_cap: false,
+            // Reports send their history as-is; the iteration cap is the
+            // only bound on prompt growth.
+            context_length: None,
+        },
+        provider_config: &provider_config,
+        tools: &tools,
+        citations: &ledger,
+        messages: vec![
+            Message::system(format!(
+                "{SYSTEM_PROMPT_SCAFFOLD}\n\n---\nReport-specific instructions follow."
+            )),
+            Message::user(build_user_prompt(report, source, total_in_scope)),
+        ],
+        cancel: None,
+        events: None,
+    }
+    .execute()
+    .await
+    .map_err(|error| match error {
+        RunError::Setup(error) => AtomicCoreError::DatabaseOperation(error),
+        RunError::Provider(error) => {
+            AtomicCoreError::DatabaseOperation(format!("report research LLM call failed: {error}"))
+        }
+    })?;
 
-    run_research(
-        core,
-        &mut state,
-        ctx,
-        &tag_scope_set,
-        &provider_config,
-        &model,
-        max_iters,
-    )
-    .await?;
-
-    state.messages.push(Message::user(
+    let mut messages = outcome.messages;
+    messages.push(Message::user(
         "Now write the final report as markdown prose with [N] citation \
          markers. Do not call tools."
             .to_string(),
     ));
 
-    let content = final_pass(&provider_config, &model, &state.messages).await?;
-    let citations = extract_citations(&content, &state.citables);
+    let content = final_pass(&provider_config, &model, &messages).await?;
+    let citations = ledger
+        .cited_in(&content)
+        .into_iter()
+        .map(|citable| ResolvedCitation {
+            position: citable.number,
+            cited_atom_id: citable.source_id,
+            excerpt: citable.excerpt,
+        })
+        .collect();
 
     Ok(RunOutput { content, citations })
 }
@@ -760,93 +696,40 @@ mod tests {
     }
 
     #[test]
-    fn source_atoms_numbered_one_indexed() {
-        let report = mock_report(CitationPolicy::SourceOnly);
+    fn source_only_seeds_the_batch_and_refuses_everything_else() {
         let source = vec![
             mock_atom("a1", "one", "first"),
             mock_atom("a2", "two", "second"),
         ];
-        let state = AgentState::from_source(&report, &source);
-        assert_eq!(state.citables.get("a1").unwrap().number, 1);
-        assert_eq!(state.citables.get("a2").unwrap().number, 2);
-        assert_eq!(state.next_citation_number, 3);
+        let ledger = seeded_ledger(&mock_report(CitationPolicy::SourceOnly), &source);
+        let seeded = ledger.snapshot();
+        assert_eq!(seeded.len(), 2);
+        assert_eq!((seeded[0].number, seeded[0].source_id.as_str()), (1, "a1"));
+        assert_eq!((seeded[1].number, seeded[1].source_id.as_str()), (2, "a2"));
+        assert_eq!(
+            ledger.register(CitationSource::Atom, "a-new", None, "context"),
+            None,
+            "search results are background only under source_only"
+        );
     }
 
     #[test]
-    fn source_only_refuses_to_cite_context_results() {
-        let report = mock_report(CitationPolicy::SourceOnly);
+    fn source_and_context_numbers_new_evidence_after_the_batch() {
         let source = vec![mock_atom("a1", "one", "first")];
-        let mut state = AgentState::from_source(&report, &source);
-        let new = mock_atom("a-new", "context", "body");
-        assert!(state.citation_for_search_result(&new).is_none());
-        assert!(!state.citables.contains_key("a-new"));
-    }
-
-    #[test]
-    fn source_and_context_assigns_next_number_on_first_appearance() {
-        let report = mock_report(CitationPolicy::SourceAndContext);
-        let source = vec![mock_atom("a1", "one", "first")];
-        let mut state = AgentState::from_source(&report, &source);
-        let new = mock_atom("a-new", "context", "body");
-        assert_eq!(state.citation_for_search_result(&new), Some(2));
-        // Reuses the same number on second appearance.
-        assert_eq!(state.citation_for_search_result(&new), Some(2));
-        // Third atom gets 3.
-        let other = mock_atom("a-other", "other", "body");
-        assert_eq!(state.citation_for_search_result(&other), Some(3));
-    }
-
-    #[test]
-    fn extract_citations_maps_marker_to_known_atom() {
-        let report = mock_report(CitationPolicy::SourceOnly);
-        let source = vec![
-            mock_atom("a1", "one", "first"),
-            mock_atom("a2", "two", "second"),
-        ];
-        let state = AgentState::from_source(&report, &source);
-        // `[1]` cited twice; only one row should land. `position` reflects
-        // the actual marker number, not appearance order — the dashboard
-        // looks the citation up by N.
-        let content = "Intro [1]. Detail [2]. More [1].";
-        let cites = extract_citations(content, &state.citables);
-        assert_eq!(cites.len(), 2);
-        assert_eq!(cites[0].position, 1);
-        assert_eq!(cites[0].cited_atom_id, "a1");
-        assert_eq!(cites[1].position, 2);
-        assert_eq!(cites[1].cited_atom_id, "a2");
-    }
-
-    #[test]
-    fn extract_citations_out_of_sequence_preserves_marker_number() {
-        // Regression for the appearance-counter bug: the agent emits
-        // `[3]` before `[1]` and skips `[2]`. The stored `position` must
-        // be the marker number itself so the dashboard's lookup by
-        // citation_index finds the right source.
-        let report = mock_report(CitationPolicy::SourceOnly);
-        let source = vec![
-            mock_atom("a1", "one", "first"),
-            mock_atom("a2", "two", "second"),
-            mock_atom("a3", "three", "third"),
-        ];
-        let state = AgentState::from_source(&report, &source);
-        let content = "First [3]. Then [1].";
-        let cites = extract_citations(content, &state.citables);
-        assert_eq!(cites.len(), 2);
-        assert_eq!(cites[0].position, 3);
-        assert_eq!(cites[0].cited_atom_id, "a3");
-        assert_eq!(cites[1].position, 1);
-        assert_eq!(cites[1].cited_atom_id, "a1");
-    }
-
-    #[test]
-    fn extract_citations_drops_unknown_markers() {
-        let report = mock_report(CitationPolicy::SourceOnly);
-        let source = vec![mock_atom("a1", "one", "first")];
-        let state = AgentState::from_source(&report, &source);
-        let content = "Valid [1]. Hallucinated [9].";
-        let cites = extract_citations(content, &state.citables);
-        assert_eq!(cites.len(), 1);
-        assert_eq!(cites[0].cited_atom_id, "a1");
+        let ledger = seeded_ledger(&mock_report(CitationPolicy::SourceAndContext), &source);
+        assert_eq!(
+            ledger.register(CitationSource::Atom, "a-new", None, "context"),
+            Some(2)
+        );
+        assert_eq!(
+            ledger.register(CitationSource::Atom, "a-new", None, "context"),
+            Some(2),
+            "a repeat hit reuses its number"
+        );
+        assert_eq!(
+            ledger.register(CitationSource::Atom, "a-other", None, "context"),
+            Some(3)
+        );
     }
 
     #[test]

--- a/crates/atomic-core/src/search.rs
+++ b/crates/atomic-core/src/search.rs
@@ -24,6 +24,74 @@ pub enum SearchMode {
     Hybrid,
 }
 
+/// Which atoms a search is allowed to return, as three tag lists.
+///
+/// An atom passes iff it carries **at least one** `include` tag (skipped when
+/// `include` is empty), **every** `require` tag, and **no** `exclude` tag.
+/// Every list matches its tags' descendants too, so scoping to a parent tag
+/// scopes to its whole branch. An empty filter admits everything, which makes
+/// the pre-boolean behavior — OR over a flat include list — the degenerate
+/// case rather than a separate code path.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ScopeFilter {
+    pub include: Vec<String>,
+    pub require: Vec<String>,
+    pub exclude: Vec<String>,
+}
+
+impl ScopeFilter {
+    /// The flat-list shape: every tag included, OR semantics.
+    pub fn including(tag_ids: Vec<String>) -> Self {
+        Self {
+            include: tag_ids,
+            ..Self::default()
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.include.is_empty() && self.require.is_empty() && self.exclude.is_empty()
+    }
+
+    pub fn push(&mut self, tag_id: String, mode: crate::models::ScopeMode) {
+        match mode {
+            crate::models::ScopeMode::Include => self.include.push(tag_id),
+            crate::models::ScopeMode::Require => self.require.push(tag_id),
+            crate::models::ScopeMode::Exclude => self.exclude.push(tag_id),
+        }
+    }
+
+    /// Every tag named by the filter — the roots a backend expands to
+    /// descendants before evaluating the predicate.
+    pub fn roots(&self) -> Vec<String> {
+        let mut roots = self.include.clone();
+        roots.extend(self.require.iter().cloned());
+        roots.extend(self.exclude.iter().cloned());
+        roots
+    }
+
+    /// Decide which of `atom_ids` the filter admits, given — per atom — the
+    /// scope roots it matched directly or through a descendant tag. Backends
+    /// differ only in how they build `matched_roots`; the predicate itself
+    /// lives here so both answer identically.
+    pub fn admitted<'a>(
+        &self,
+        atom_ids: impl IntoIterator<Item = &'a str>,
+        matched_roots: &HashMap<String, std::collections::HashSet<String>>,
+    ) -> std::collections::HashSet<String> {
+        let none = std::collections::HashSet::new();
+        atom_ids
+            .into_iter()
+            .filter(|atom_id| {
+                let roots = matched_roots.get(*atom_id).unwrap_or(&none);
+                (self.include.is_empty() || self.include.iter().any(|t| roots.contains(t)))
+                    && self.require.iter().all(|t| roots.contains(t))
+                    && !self.exclude.iter().any(|t| roots.contains(t))
+            })
+            .map(str::to_string)
+            .collect()
+    }
+}
+
 /// Options for search queries
 #[derive(Debug, Clone)]
 pub struct SearchOptions {
@@ -35,8 +103,8 @@ pub struct SearchOptions {
     pub limit: i32,
     /// Minimum similarity threshold (0.0-1.0) for semantic/hybrid modes
     pub threshold: f32,
-    /// Optional tag IDs to filter results (only return atoms with these tags)
-    pub scope_tag_ids: Vec<String>,
+    /// Which atoms are eligible at all; see [`ScopeFilter`]
+    pub scope: ScopeFilter,
     /// Optional recency filter: only return atoms created within the last N days
     pub since_days: Option<i32>,
     /// Atom-kind filter. Defaults to `KindFilter::All` so existing callers
@@ -54,7 +122,7 @@ impl SearchOptions {
             mode,
             limit,
             threshold: 0.3,
-            scope_tag_ids: vec![],
+            scope: ScopeFilter::default(),
             since_days: None,
             kinds: KindFilter::All,
         }
@@ -65,8 +133,15 @@ impl SearchOptions {
         self
     }
 
+    /// Scope to a flat tag list (include semantics). Callers with modes use
+    /// [`SearchOptions::with_scope_filter`].
     pub fn with_scope(mut self, tag_ids: Vec<String>) -> Self {
-        self.scope_tag_ids = tag_ids;
+        self.scope = ScopeFilter::including(tag_ids);
+        self
+    }
+
+    pub fn with_scope_filter(mut self, scope: ScopeFilter) -> Self {
+        self.scope = scope;
         self
     }
 
@@ -88,7 +163,7 @@ impl Default for SearchOptions {
             mode: SearchMode::Hybrid,
             limit: 10,
             threshold: 0.3,
-            scope_tag_ids: vec![],
+            scope: ScopeFilter::default(),
             since_days: None,
             kinds: KindFilter::All,
         }
@@ -443,7 +518,7 @@ async fn search_keyword_chunks(
     };
 
     // Apply tag scope filter if specified
-    let filtered = filter_by_scope(&conn, raw_results, &options.scope_tag_ids)?;
+    let filtered = filter_by_scope(&conn, raw_results, &options.scope)?;
     // Apply atom-kind filter (e.g. exclude report findings on external paths).
     let filtered = filter_by_kind(&conn, filtered, &options.kinds)?;
 
@@ -560,10 +635,10 @@ async fn search_semantic_chunks(
     let chunk_map = batch_fetch_chunk_info(&conn, &chunk_ids)?;
 
     // Pre-compute scope filter for all candidate atom_ids in one batch query
-    let scope_atom_ids: std::collections::HashSet<String> = if !options.scope_tag_ids.is_empty() {
+    let scope_atom_ids: std::collections::HashSet<String> = if !options.scope.is_empty() {
         let candidate_atom_ids: Vec<&str> =
             chunk_map.values().map(|(aid, _, _)| aid.as_str()).collect();
-        batch_atoms_with_scope_tags(&conn, &candidate_atom_ids, &options.scope_tag_ids)?
+        atoms_passing_scope(&conn, &candidate_atom_ids, &options.scope)?
     } else {
         std::collections::HashSet::new()
     };
@@ -579,7 +654,7 @@ async fn search_semantic_chunks(
     for (chunk_id, distance) in filtered {
         let similarity = distance_to_similarity(distance);
         if let Some((atom_id, content, chunk_index)) = chunk_map.get(&chunk_id) {
-            if !options.scope_tag_ids.is_empty() && !scope_atom_ids.contains(atom_id) {
+            if !options.scope.is_empty() && !scope_atom_ids.contains(atom_id) {
                 continue;
             }
             if let Some(ref allowed) = kind_allowed_atom_ids {
@@ -674,19 +749,18 @@ async fn search_hybrid_chunks(
 fn filter_by_scope<T>(
     conn: &rusqlite::Connection,
     results: Vec<(String, String, String, i32, T)>,
-    scope_tag_ids: &[String],
+    scope: &ScopeFilter,
 ) -> Result<Vec<(String, String, String, i32, T)>, String> {
-    if scope_tag_ids.is_empty() {
+    if scope.is_empty() {
         return Ok(results);
     }
 
-    // Batch check: get all atom_ids that have at least one scope tag
     let atom_ids: Vec<&str> = results.iter().map(|r| r.1.as_str()).collect();
-    let matching_atom_ids = batch_atoms_with_scope_tags(conn, &atom_ids, scope_tag_ids)?;
+    let passing = atoms_passing_scope(conn, &atom_ids, scope)?;
 
     let filtered = results
         .into_iter()
-        .filter(|r| matching_atom_ids.contains(r.1.as_str()))
+        .filter(|r| passing.contains(r.1.as_str()))
         .collect();
     Ok(filtered)
 }
@@ -768,31 +842,48 @@ fn batch_atom_ids_matching_kind<'a>(
     Ok(Some(allowed))
 }
 
-/// Batch check which atom_ids have at least one of the specified scope tags.
-/// Returns the set of matching atom_ids.
-fn batch_atoms_with_scope_tags(
+/// Resolve which of `atom_ids` the scope filter admits.
+///
+/// One query maps each candidate atom to the scope *roots* it carries —
+/// walking each root's descendants, so a scope on a parent tag covers its
+/// branch — and [`ScopeFilter::admitted`] turns that into the answer. Shared
+/// by every SQLite retrieval path so include/require/exclude means one thing.
+pub(crate) fn atoms_passing_scope(
     conn: &rusqlite::Connection,
     atom_ids: &[&str],
-    scope_tag_ids: &[String],
+    scope: &ScopeFilter,
 ) -> Result<std::collections::HashSet<String>, String> {
-    if atom_ids.is_empty() || scope_tag_ids.is_empty() {
+    if scope.is_empty() {
+        return Ok(atom_ids.iter().map(|id| id.to_string()).collect());
+    }
+    if atom_ids.is_empty() {
         return Ok(std::collections::HashSet::new());
     }
 
+    let roots = scope.roots();
     let atom_placeholders: Vec<&str> = atom_ids.iter().map(|_| "?").collect();
-    let tag_placeholders: Vec<&str> = scope_tag_ids.iter().map(|_| "?").collect();
+    let tag_placeholders: Vec<&str> = roots.iter().map(|_| "?").collect();
     let query = format!(
-        "SELECT DISTINCT atom_id FROM atom_tags WHERE atom_id IN ({}) AND tag_id IN ({})",
-        atom_placeholders.join(","),
-        tag_placeholders.join(","),
+        "WITH RECURSIVE scope_tags(root_id, id) AS (
+            SELECT id, id FROM tags WHERE id IN ({tag_ph})
+            UNION ALL
+            SELECT st.root_id, t.id FROM tags t
+            INNER JOIN scope_tags st ON t.parent_id = st.id
+         )
+         SELECT DISTINCT st.root_id, att.atom_id
+         FROM atom_tags att
+         INNER JOIN scope_tags st ON st.id = att.tag_id
+         WHERE att.atom_id IN ({atom_ph})",
+        tag_ph = tag_placeholders.join(","),
+        atom_ph = atom_placeholders.join(","),
     );
 
-    let mut params: Vec<&dyn rusqlite::ToSql> =
-        Vec::with_capacity(atom_ids.len() + scope_tag_ids.len());
-    for id in atom_ids {
+    // Bind order matches SQL: roots first (CTE), then atom_ids (WHERE)
+    let mut params: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(atom_ids.len() + roots.len());
+    for id in &roots {
         params.push(id);
     }
-    for id in scope_tag_ids {
+    for id in atom_ids {
         params.push(id);
     }
 
@@ -801,15 +892,17 @@ fn batch_atoms_with_scope_tags(
         .map_err(|e| format!("Failed to prepare scope query: {}", e))?;
     let rows = stmt
         .query_map(rusqlite::params_from_iter(params), |row| {
-            row.get::<_, String>(0)
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })
         .map_err(|e| format!("Failed to execute scope query: {}", e))?;
 
-    let mut matching = std::collections::HashSet::new();
+    let mut matched: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
     for row in rows {
-        matching.insert(row.map_err(|e| format!("Failed to read scope result: {}", e))?);
+        let (root_id, atom_id) = row.map_err(|e| format!("Failed to read scope result: {}", e))?;
+        matched.entry(atom_id).or_default().insert(root_id);
     }
-    Ok(matching)
+
+    Ok(scope.admitted(atom_ids.iter().copied(), &matched))
 }
 
 /// Find atoms similar to a given atom based on embedding similarity
@@ -993,7 +1086,7 @@ mod tests {
         assert_eq!(options.mode, SearchMode::Hybrid);
         assert_eq!(options.limit, 10);
         assert_eq!(options.threshold, 0.3);
-        assert!(options.scope_tag_ids.is_empty());
+        assert!(options.scope.is_empty());
     }
 
     #[test]
@@ -1006,7 +1099,7 @@ mod tests {
         assert_eq!(options.mode, SearchMode::Semantic);
         assert_eq!(options.limit, 20);
         assert_eq!(options.threshold, 0.5);
-        assert_eq!(options.scope_tag_ids, vec!["tag1".to_string()]);
+        assert_eq!(options.scope.include, vec!["tag1".to_string()]);
     }
 
     // ==================== find_similar_atoms Tests ====================

--- a/crates/atomic-core/src/storage/mod.rs
+++ b/crates/atomic-core/src/storage/mod.rs
@@ -221,7 +221,7 @@ macro_rules! impl_spawn_arg_copy {
         )*
     };
 }
-impl_spawn_arg_copy!(i32, usize, f32, bool, Option<i32>, Option<bool>);
+impl_spawn_arg_copy!(i32, usize, f32, bool, Option<i32>, Option<bool>, ScopeMode);
 
 // ---- ReborrowArg impls ----
 
@@ -270,7 +270,7 @@ macro_rules! impl_reborrow_copy {
         )*
     };
 }
-impl_reborrow_copy!(i32, usize, f32, bool, Option<i32>, Option<bool>);
+impl_reborrow_copy!(i32, usize, f32, bool, Option<i32>, Option<bool>, ScopeMode);
 
 // Struct types: sync method takes `&Struct`, owned is `Struct`, reborrow is `&Struct`.
 macro_rules! impl_reborrow_struct {
@@ -294,6 +294,7 @@ impl_reborrow_struct!(
     crate::models::CreateReportRequest,
     crate::models::UpdateReportRequest,
     crate::models::ReportFinding,
+    crate::search::ScopeFilter,
 );
 
 /// Macro to generate async dispatch methods. For each method:
@@ -519,15 +520,15 @@ dispatch! {
         => sqlite: rearm_pipeline_jobs_sync, pg_trait: ChunkStore, pg_method: rearm_pipeline_jobs;
 
     // ---- SearchStore ----
-    fn vector_search_sync(&self, query_embedding: &[f32], limit: i32, threshold: f32, scope_tag_ids: &[String], created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<SemanticSearchResult>, AtomicCoreError>
+    fn vector_search_sync(&self, query_embedding: &[f32], limit: i32, threshold: f32, scope: &crate::search::ScopeFilter, created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<SemanticSearchResult>, AtomicCoreError>
         => sqlite: vector_search_sync, pg_trait: SearchStore, pg_method: vector_search;
-    fn keyword_search_sync(&self, query: &str, limit: i32, scope_tag_ids: &[String], created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<SemanticSearchResult>, AtomicCoreError>
+    fn keyword_search_sync(&self, query: &str, limit: i32, scope: &crate::search::ScopeFilter, created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<SemanticSearchResult>, AtomicCoreError>
         => sqlite: keyword_search_sync, pg_trait: SearchStore, pg_method: keyword_search;
     fn find_similar_sync(&self, atom_id: &str, limit: i32, threshold: f32) -> Result<Vec<SimilarAtomResult>, AtomicCoreError>
         => sqlite: find_similar_sync, pg_trait: SearchStore, pg_method: find_similar;
-    fn keyword_search_chunks_sync(&self, query: &str, limit: i32, scope_tag_ids: &[String], created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<ChunkSearchResult>, AtomicCoreError>
+    fn keyword_search_chunks_sync(&self, query: &str, limit: i32, scope: &crate::search::ScopeFilter, created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<ChunkSearchResult>, AtomicCoreError>
         => sqlite: keyword_search_chunks_sync, pg_trait: SearchStore, pg_method: keyword_search_chunks;
-    fn vector_search_chunks_sync(&self, query_embedding: &[f32], limit: i32, threshold: f32, scope_tag_ids: &[String], created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<ChunkSearchResult>, AtomicCoreError>
+    fn vector_search_chunks_sync(&self, query_embedding: &[f32], limit: i32, threshold: f32, scope: &crate::search::ScopeFilter, created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<ChunkSearchResult>, AtomicCoreError>
         => sqlite: vector_search_chunks_sync, pg_trait: SearchStore, pg_method: vector_search_chunks;
 
     // ---- ChatStore ----
@@ -541,9 +542,9 @@ dispatch! {
         => sqlite: update_conversation_sync, pg_trait: ChatStore, pg_method: update_conversation;
     fn delete_conversation_sync(&self, id: &str) -> Result<(), AtomicCoreError>
         => sqlite: delete_conversation_sync, pg_trait: ChatStore, pg_method: delete_conversation;
-    fn set_conversation_scope_sync(&self, conversation_id: &str, tag_ids: &[String]) -> Result<ConversationWithTags, AtomicCoreError>
+    fn set_conversation_scope_sync(&self, conversation_id: &str, entries: &[ScopeEntry]) -> Result<ConversationWithTags, AtomicCoreError>
         => sqlite: set_conversation_scope_sync, pg_trait: ChatStore, pg_method: set_conversation_scope;
-    fn add_tag_to_scope_sync(&self, conversation_id: &str, tag_id: &str) -> Result<ConversationWithTags, AtomicCoreError>
+    fn add_tag_to_scope_sync(&self, conversation_id: &str, tag_id: &str, mode: ScopeMode) -> Result<ConversationWithTags, AtomicCoreError>
         => sqlite: add_tag_to_scope_sync, pg_trait: ChatStore, pg_method: add_tag_to_scope;
     fn remove_tag_from_scope_sync(&self, conversation_id: &str, tag_id: &str) -> Result<ConversationWithTags, AtomicCoreError>
         => sqlite: remove_tag_from_scope_sync, pg_trait: ChatStore, pg_method: remove_tag_from_scope;
@@ -553,9 +554,9 @@ dispatch! {
         => sqlite: save_tool_calls_sync, pg_trait: ChatStore, pg_method: save_tool_calls;
     fn save_citations_sync(&self, message_id: &str, citations: &[ChatCitation]) -> Result<(), AtomicCoreError>
         => sqlite: save_citations_sync, pg_trait: ChatStore, pg_method: save_citations;
-    fn get_scope_tag_ids_sync(&self, conversation_id: &str) -> Result<Vec<String>, AtomicCoreError>
-        => sqlite: get_scope_tag_ids_sync, pg_trait: ChatStore, pg_method: get_scope_tag_ids;
-    fn get_scope_description_sync(&self, tag_ids: &[String]) -> Result<String, AtomicCoreError>
+    fn get_conversation_scope_sync(&self, conversation_id: &str) -> Result<crate::search::ScopeFilter, AtomicCoreError>
+        => sqlite: get_conversation_scope_sync, pg_trait: ChatStore, pg_method: get_conversation_scope;
+    fn get_scope_description_sync(&self, scope: &crate::search::ScopeFilter) -> Result<String, AtomicCoreError>
         => sqlite: get_scope_description_sync, pg_trait: ChatStore, pg_method: get_scope_description;
 
     // ---- WikiStore ----

--- a/crates/atomic-core/src/storage/mod.rs
+++ b/crates/atomic-core/src/storage/mod.rs
@@ -530,6 +530,8 @@ dispatch! {
         => sqlite: keyword_search_chunks_sync, pg_trait: SearchStore, pg_method: keyword_search_chunks;
     fn vector_search_chunks_sync(&self, query_embedding: &[f32], limit: i32, threshold: f32, scope: &crate::search::ScopeFilter, created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<ChunkSearchResult>, AtomicCoreError>
         => sqlite: vector_search_chunks_sync, pg_trait: SearchStore, pg_method: vector_search_chunks;
+    fn atoms_passing_scope_sync(&self, atom_ids: &[String], scope: &crate::search::ScopeFilter) -> Result<HashSet<String>, AtomicCoreError>
+        => sqlite: atoms_passing_scope_sync, pg_trait: SearchStore, pg_method: atoms_passing_scope;
 
     // ---- ChatStore ----
     fn create_conversation_sync(&self, tag_ids: &[String], title: Option<&str>) -> Result<ConversationWithTags, AtomicCoreError>
@@ -540,6 +542,8 @@ dispatch! {
         => sqlite: get_conversation_sync, pg_trait: ChatStore, pg_method: get_conversation;
     fn update_conversation_sync(&self, id: &str, title: Option<&str>, is_archived: Option<bool>) -> Result<Conversation, AtomicCoreError>
         => sqlite: update_conversation_sync, pg_trait: ChatStore, pg_method: update_conversation;
+    fn set_conversation_title_if_unset_sync(&self, id: &str, title: &str) -> Result<bool, AtomicCoreError>
+        => sqlite: set_conversation_title_if_unset_sync, pg_trait: ChatStore, pg_method: set_conversation_title_if_unset;
     fn delete_conversation_sync(&self, id: &str) -> Result<(), AtomicCoreError>
         => sqlite: delete_conversation_sync, pg_trait: ChatStore, pg_method: delete_conversation;
     fn set_conversation_scope_sync(&self, conversation_id: &str, entries: &[ScopeEntry]) -> Result<ConversationWithTags, AtomicCoreError>

--- a/crates/atomic-core/src/storage/mod.rs
+++ b/crates/atomic-core/src/storage/mod.rs
@@ -519,9 +519,9 @@ dispatch! {
         => sqlite: rearm_pipeline_jobs_sync, pg_trait: ChunkStore, pg_method: rearm_pipeline_jobs;
 
     // ---- SearchStore ----
-    fn vector_search_sync(&self, query_embedding: &[f32], limit: i32, threshold: f32, tag_id: Option<&str>, created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<SemanticSearchResult>, AtomicCoreError>
+    fn vector_search_sync(&self, query_embedding: &[f32], limit: i32, threshold: f32, scope_tag_ids: &[String], created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<SemanticSearchResult>, AtomicCoreError>
         => sqlite: vector_search_sync, pg_trait: SearchStore, pg_method: vector_search;
-    fn keyword_search_sync(&self, query: &str, limit: i32, tag_id: Option<&str>, created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<SemanticSearchResult>, AtomicCoreError>
+    fn keyword_search_sync(&self, query: &str, limit: i32, scope_tag_ids: &[String], created_after: Option<&str>, kinds: &crate::models::KindFilter) -> Result<Vec<SemanticSearchResult>, AtomicCoreError>
         => sqlite: keyword_search_sync, pg_trait: SearchStore, pg_method: keyword_search;
     fn find_similar_sync(&self, atom_id: &str, limit: i32, threshold: f32) -> Result<Vec<SimilarAtomResult>, AtomicCoreError>
         => sqlite: find_similar_sync, pg_trait: SearchStore, pg_method: find_similar;
@@ -533,7 +533,7 @@ dispatch! {
     // ---- ChatStore ----
     fn create_conversation_sync(&self, tag_ids: &[String], title: Option<&str>) -> Result<ConversationWithTags, AtomicCoreError>
         => sqlite: create_conversation_sync, pg_trait: ChatStore, pg_method: create_conversation;
-    fn get_conversations_sync(&self, filter_tag_id: Option<&str>, limit: i32, offset: i32) -> Result<Vec<ConversationWithTags>, AtomicCoreError>
+    fn get_conversations_sync(&self, filter_tag_id: Option<&str>, limit: i32, offset: i32, include_archived: bool) -> Result<Vec<ConversationWithTags>, AtomicCoreError>
         => sqlite: get_conversations_sync, pg_trait: ChatStore, pg_method: get_conversations;
     fn get_conversation_sync(&self, conversation_id: &str) -> Result<Option<ConversationWithMessages>, AtomicCoreError>
         => sqlite: get_conversation_sync, pg_trait: ChatStore, pg_method: get_conversation;

--- a/crates/atomic-core/src/storage/postgres/chat.rs
+++ b/crates/atomic-core/src/storage/postgres/chat.rs
@@ -612,6 +612,26 @@ impl ChatStore for PostgresStorage {
         })
     }
 
+    async fn set_conversation_title_if_unset(
+        &self,
+        id: &str,
+        title: &str,
+    ) -> StorageResult<bool> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let result = sqlx::query(
+            "UPDATE conversations SET title = $1, updated_at = $2
+             WHERE id = $3 AND db_id = $4 AND title IS NULL",
+        )
+        .bind(title)
+        .bind(&now)
+        .bind(id)
+        .bind(&self.db_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+        Ok(result.rows_affected() > 0)
+    }
+
     async fn delete_conversation(&self, id: &str) -> StorageResult<()> {
         sqlx::query("DELETE FROM conversations WHERE id = $1 AND db_id = $2")
             .bind(id)
@@ -860,11 +880,10 @@ impl ChatStore for PostgresStorage {
         .await
         .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
+        // Names are a nicety; the scope itself is not. Tags that don't
+        // resolve still shape the paragraph, because retrieval applies the
+        // filter whether or not the prompt could name it.
         let names: HashMap<String, String> = rows.into_iter().collect();
-        if names.is_empty() {
-            Ok("You have access to a scoped set of atoms.".to_string())
-        } else {
-            Ok(crate::chat::describe_scope(scope, &names))
-        }
+        Ok(crate::chat::describe_scope(scope, &names))
     }
 }

--- a/crates/atomic-core/src/storage/postgres/chat.rs
+++ b/crates/atomic-core/src/storage/postgres/chat.rs
@@ -264,13 +264,15 @@ impl ChatStore for PostgresStorage {
         filter_tag_id: Option<&str>,
         limit: i32,
         offset: i32,
+        include_archived: bool,
     ) -> StorageResult<Vec<ConversationWithTags>> {
+        let max_archived = i32::from(include_archived);
         let conversations: Vec<Conversation> = if let Some(tag_id) = filter_tag_id {
             let rows = sqlx::query_as::<_, (String, Option<String>, String, String, i32)>(
                 "SELECT DISTINCT c.id, c.title, c.created_at, c.updated_at, c.is_archived
                  FROM conversations c
                  JOIN conversation_tags ct ON ct.conversation_id = c.id
-                 WHERE ct.tag_id = $1 AND c.is_archived = 0 AND c.db_id = $4 AND ct.db_id = $4
+                 WHERE ct.tag_id = $1 AND c.is_archived <= $5 AND c.db_id = $4 AND ct.db_id = $4
                  ORDER BY c.updated_at DESC
                  LIMIT $2 OFFSET $3",
             )
@@ -278,6 +280,7 @@ impl ChatStore for PostgresStorage {
             .bind(limit)
             .bind(offset)
             .bind(&self.db_id)
+            .bind(max_archived)
             .fetch_all(&self.pool)
             .await
             .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
@@ -297,13 +300,14 @@ impl ChatStore for PostgresStorage {
             let rows = sqlx::query_as::<_, (String, Option<String>, String, String, i32)>(
                 "SELECT id, title, created_at, updated_at, is_archived
                  FROM conversations
-                 WHERE is_archived = 0 AND db_id = $3
+                 WHERE is_archived <= $4 AND db_id = $3
                  ORDER BY updated_at DESC
                  LIMIT $1 OFFSET $2",
             )
             .bind(limit)
             .bind(offset)
             .bind(&self.db_id)
+            .bind(max_archived)
             .fetch_all(&self.pool)
             .await
             .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;

--- a/crates/atomic-core/src/storage/postgres/chat.rs
+++ b/crates/atomic-core/src/storage/postgres/chat.rs
@@ -2,6 +2,7 @@ use super::PostgresStorage;
 use crate::chat::truncate_preview;
 use crate::error::AtomicCoreError;
 use crate::models::*;
+use crate::search::ScopeFilter;
 use crate::storage::traits::*;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -11,9 +12,9 @@ async fn fetch_conversation_tags(
     pool: &sqlx::PgPool,
     conversation_id: &str,
     db_id: &str,
-) -> StorageResult<Vec<Tag>> {
-    let rows = sqlx::query_as::<_, (String, String, Option<String>, String, bool, String)>(
-        "SELECT t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target, t.autotag_description
+) -> StorageResult<Vec<ScopeTag>> {
+    let rows = sqlx::query_as::<_, (String, String, Option<String>, String, bool, String, String)>(
+        "SELECT t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target, t.autotag_description, ct.mode
          FROM tags t
          JOIN conversation_tags ct ON ct.tag_id = t.id
          WHERE ct.conversation_id = $1 AND ct.db_id = $2 AND t.db_id = $2
@@ -28,13 +29,18 @@ async fn fetch_conversation_tags(
     Ok(rows
         .into_iter()
         .map(
-            |(id, name, parent_id, created_at, is_autotag_target, autotag_description)| Tag {
-                id,
-                name,
-                parent_id,
-                created_at,
-                is_autotag_target,
-                autotag_description,
+            |(id, name, parent_id, created_at, is_autotag_target, autotag_description, mode)| {
+                ScopeTag {
+                    tag: Tag {
+                        id,
+                        name,
+                        parent_id,
+                        created_at,
+                        is_autotag_target,
+                        autotag_description,
+                    },
+                    mode: ScopeMode::from_db(&mode),
+                }
             },
         )
         .collect())
@@ -118,13 +124,25 @@ async fn batch_fetch_conversation_tags(
     pool: &sqlx::PgPool,
     conv_ids: &[String],
     db_id: &str,
-) -> StorageResult<HashMap<String, Vec<Tag>>> {
+) -> StorageResult<HashMap<String, Vec<ScopeTag>>> {
     if conv_ids.is_empty() {
         return Ok(HashMap::new());
     }
 
-    let rows = sqlx::query_as::<_, (String, String, String, Option<String>, String, bool, String)>(
-        "SELECT ct.conversation_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target, t.autotag_description
+    let rows = sqlx::query_as::<
+        _,
+        (
+            String,
+            String,
+            String,
+            Option<String>,
+            String,
+            bool,
+            String,
+            String,
+        ),
+    >(
+        "SELECT ct.conversation_id, t.id, t.name, t.parent_id, t.created_at, t.is_autotag_target, t.autotag_description, ct.mode
          FROM conversation_tags ct
          JOIN tags t ON ct.tag_id = t.id
          WHERE ct.conversation_id = ANY($1) AND ct.db_id = $2 AND t.db_id = $2
@@ -136,15 +154,20 @@ async fn batch_fetch_conversation_tags(
     .await
     .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
-    let mut map: HashMap<String, Vec<Tag>> = HashMap::new();
-    for (conv_id, id, name, parent_id, created_at, is_autotag_target, autotag_description) in rows {
-        map.entry(conv_id).or_default().push(Tag {
-            id,
-            name,
-            parent_id,
-            created_at,
-            is_autotag_target,
-            autotag_description,
+    let mut map: HashMap<String, Vec<ScopeTag>> = HashMap::new();
+    for (conv_id, id, name, parent_id, created_at, is_autotag_target, autotag_description, mode) in
+        rows
+    {
+        map.entry(conv_id).or_default().push(ScopeTag {
+            tag: Tag {
+                id,
+                name,
+                parent_id,
+                created_at,
+                is_autotag_target,
+                autotag_description,
+            },
+            mode: ScopeMode::from_db(&mode),
         });
     }
 
@@ -457,33 +480,60 @@ impl ChatStore for PostgresStorage {
             tool_calls_map.entry(message_id).or_default().push(tc);
         }
 
-        // Batch fetch citations
-        let cit_rows =
-            sqlx::query_as::<_, (String, String, String, Option<i32>, String, Option<f32>)>(
-                "SELECT id, message_id, atom_id, chunk_index, excerpt, relevance_score
-             FROM chat_citations
-             WHERE message_id = ANY($1) AND db_id = $2",
-            )
-            .bind(&msg_ids)
-            .bind(&self.db_id)
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
+        // Batch fetch citations. The wiki citation's tag name is joined
+        // rather than stored, so a renamed tag reads back under its
+        // current name.
+        let cit_rows = sqlx::query_as::<
+            _,
+            (
+                String,
+                String,
+                i32,
+                String,
+                Option<i32>,
+                String,
+                Option<f32>,
+                String,
+                Option<String>,
+            ),
+        >(
+            "SELECT c.id, c.message_id, c.citation_index, c.atom_id, c.chunk_index,
+                    c.excerpt, c.relevance_score, c.source_type, t.name
+             FROM chat_citations c
+             LEFT JOIN tags t
+                    ON t.id = c.atom_id AND t.db_id = c.db_id AND c.source_type = 'wiki'
+             WHERE c.message_id = ANY($1) AND c.db_id = $2
+             ORDER BY c.citation_index",
+        )
+        .bind(&msg_ids)
+        .bind(&self.db_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
         let mut citations_map: HashMap<String, Vec<ChatCitation>> = HashMap::new();
-        // The Postgres schema lacks citation_index; we assign based on order.
-        let mut per_message_idx: HashMap<String, i32> = HashMap::new();
-        for (id, message_id, atom_id, chunk_index, excerpt, relevance_score) in cit_rows {
-            let idx = per_message_idx.entry(message_id.clone()).or_insert(0);
-            *idx += 1;
+        for (
+            id,
+            message_id,
+            citation_index,
+            atom_id,
+            chunk_index,
+            excerpt,
+            relevance_score,
+            source_type,
+            source_title,
+        ) in cit_rows
+        {
             let cit = ChatCitation {
                 id,
                 message_id: message_id.clone(),
-                citation_index: *idx,
+                citation_index,
                 atom_id,
                 chunk_index,
                 excerpt,
                 relevance_score,
+                source_type,
+                source_title,
             };
             citations_map.entry(message_id).or_default().push(cit);
         }
@@ -575,7 +625,7 @@ impl ChatStore for PostgresStorage {
     async fn set_conversation_scope(
         &self,
         conversation_id: &str,
-        tag_ids: &[String],
+        entries: &[ScopeEntry],
     ) -> StorageResult<ConversationWithTags> {
         let now = chrono::Utc::now().to_rfc3339();
 
@@ -586,12 +636,13 @@ impl ChatStore for PostgresStorage {
             .await
             .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
-        for tag_id in tag_ids {
+        for entry in entries {
             sqlx::query(
-                "INSERT INTO conversation_tags (conversation_id, tag_id, db_id) VALUES ($1, $2, $3)",
+                "INSERT INTO conversation_tags (conversation_id, tag_id, mode, db_id) VALUES ($1, $2, $3, $4)",
             )
             .bind(conversation_id)
-            .bind(tag_id)
+            .bind(&entry.tag_id)
+            .bind(entry.mode.as_str())
             .bind(&self.db_id)
             .execute(&self.pool)
             .await
@@ -613,15 +664,17 @@ impl ChatStore for PostgresStorage {
         &self,
         conversation_id: &str,
         tag_id: &str,
+        mode: ScopeMode,
     ) -> StorageResult<ConversationWithTags> {
         let now = chrono::Utc::now().to_rfc3339();
 
         sqlx::query(
-            "INSERT INTO conversation_tags (conversation_id, tag_id, db_id) VALUES ($1, $2, $3)
-             ON CONFLICT DO NOTHING",
+            "INSERT INTO conversation_tags (conversation_id, tag_id, mode, db_id) VALUES ($1, $2, $3, $4)
+             ON CONFLICT (conversation_id, tag_id) DO UPDATE SET mode = EXCLUDED.mode",
         )
         .bind(conversation_id)
         .bind(tag_id)
+        .bind(mode.as_str())
         .bind(&self.db_id)
         .execute(&self.pool)
         .await
@@ -756,15 +809,17 @@ impl ChatStore for PostgresStorage {
     ) -> StorageResult<()> {
         for citation in citations {
             sqlx::query(
-                "INSERT INTO chat_citations (id, message_id, atom_id, chunk_index, excerpt, relevance_score, db_id)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                "INSERT INTO chat_citations (id, message_id, citation_index, atom_id, chunk_index, excerpt, relevance_score, source_type, db_id)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
             )
             .bind(&citation.id)
             .bind(message_id)
+            .bind(citation.citation_index)
             .bind(&citation.atom_id)
             .bind(citation.chunk_index)
             .bind(&citation.excerpt)
             .bind(citation.relevance_score)
+            .bind(&citation.source_type)
             .bind(&self.db_id)
             .execute(&self.pool)
             .await
@@ -773,9 +828,9 @@ impl ChatStore for PostgresStorage {
         Ok(())
     }
 
-    async fn get_scope_tag_ids(&self, conversation_id: &str) -> StorageResult<Vec<String>> {
-        let rows = sqlx::query_scalar::<_, String>(
-            "SELECT tag_id FROM conversation_tags WHERE conversation_id = $1 AND db_id = $2",
+    async fn get_conversation_scope(&self, conversation_id: &str) -> StorageResult<ScopeFilter> {
+        let rows = sqlx::query_as::<_, (String, String)>(
+            "SELECT tag_id, mode FROM conversation_tags WHERE conversation_id = $1 AND db_id = $2",
         )
         .bind(conversation_id)
         .bind(&self.db_id)
@@ -783,30 +838,33 @@ impl ChatStore for PostgresStorage {
         .await
         .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
-        Ok(rows)
+        let mut scope = ScopeFilter::default();
+        for (tag_id, mode) in rows {
+            scope.push(tag_id, ScopeMode::from_db(&mode));
+        }
+        Ok(scope)
     }
 
-    async fn get_scope_description(&self, tag_ids: &[String]) -> StorageResult<String> {
-        if tag_ids.is_empty() {
-            return Ok("You have access to ALL atoms in the knowledge base.".to_string());
+    async fn get_scope_description(&self, scope: &ScopeFilter) -> StorageResult<String> {
+        let roots = scope.roots();
+        if roots.is_empty() {
+            return Ok(crate::chat::describe_scope(scope, &HashMap::new()));
         }
 
-        let names = sqlx::query_scalar::<_, String>(
-            "SELECT name FROM tags WHERE id = ANY($1) AND db_id = $2",
+        let rows = sqlx::query_as::<_, (String, String)>(
+            "SELECT id, name FROM tags WHERE id = ANY($1) AND db_id = $2",
         )
-        .bind(tag_ids)
+        .bind(&roots)
         .bind(&self.db_id)
         .fetch_all(&self.pool)
         .await
         .map_err(|e| AtomicCoreError::DatabaseOperation(e.to_string()))?;
 
+        let names: HashMap<String, String> = rows.into_iter().collect();
         if names.is_empty() {
             Ok("You have access to a scoped set of atoms.".to_string())
         } else {
-            Ok(format!(
-                "You have access to atoms tagged with: {}. Focus your search on these topics.",
-                names.join(", ")
-            ))
+            Ok(crate::chat::describe_scope(scope, &names))
         }
     }
 }

--- a/crates/atomic-core/src/storage/postgres/migrations/024_chat_citations_source_type.sql
+++ b/crates/atomic-core/src/storage/postgres/migrations/024_chat_citations_source_type.sql
@@ -1,0 +1,27 @@
+-- Migration 024: chat citations carry their source type and their number.
+--
+-- `source_type` says how to read `atom_id`: 'atom' (an atom id, the default
+-- every pre-existing row keeps), 'wiki' (the tag id whose article was
+-- cited), 'finding' (the finding atom's id). One id column, one discriminator
+-- — exactly one id is ever meaningful per row.
+--
+-- `citation_index` is the `[N]` marker the answer actually wrote, which
+-- SQLite has stored since v1 but Postgres never had: the read path numbered
+-- rows by arrival order instead. That was survivable while citations were an
+-- access log written in registration order; now that only *cited* evidence is
+-- stored, an answer citing [2] and [5] must read back as 2 and 5 or every
+-- citation click resolves to the wrong source. Existing rows are backfilled
+-- in row order, which is the same guess the read path was already making.
+
+ALTER TABLE chat_citations ADD COLUMN IF NOT EXISTS source_type TEXT NOT NULL DEFAULT 'atom';
+ALTER TABLE chat_citations ADD COLUMN IF NOT EXISTS citation_index INTEGER NOT NULL DEFAULT 0;
+
+UPDATE chat_citations c
+SET citation_index = numbered.rn
+FROM (
+    SELECT id, row_number() OVER (PARTITION BY message_id, db_id) AS rn
+    FROM chat_citations
+) AS numbered
+WHERE c.id = numbered.id AND c.citation_index = 0;
+
+INSERT INTO schema_version (version) VALUES (24);

--- a/crates/atomic-core/src/storage/postgres/migrations/025_conversation_tags_mode.sql
+++ b/crates/atomic-core/src/storage/postgres/migrations/025_conversation_tags_mode.sql
@@ -1,0 +1,10 @@
+-- Migration 025: a conversation's scope tags carry the role they play.
+--
+-- 'include' (any of them admits an atom), 'require' (all of them must be
+-- present), 'exclude' (none may be). Existing rows default to 'include',
+-- which is exactly the OR scope they already meant — boolean scope makes
+-- today's behavior the degenerate case rather than a new mode.
+
+ALTER TABLE conversation_tags ADD COLUMN IF NOT EXISTS mode TEXT NOT NULL DEFAULT 'include';
+
+INSERT INTO schema_version (version) VALUES (25);

--- a/crates/atomic-core/src/storage/postgres/mod.rs
+++ b/crates/atomic-core/src/storage/postgres/mod.rs
@@ -165,6 +165,14 @@ const MIGRATIONS: &[(i32, &str)] = &[
         23,
         include_str!("migrations/023_wiki_links_nullable_target.sql"),
     ),
+    (
+        24,
+        include_str!("migrations/024_chat_citations_source_type.sql"),
+    ),
+    (
+        25,
+        include_str!("migrations/025_conversation_tags_mode.sql"),
+    ),
 ];
 
 /// Postgres-backed storage implementation using sqlx + pgvector.

--- a/crates/atomic-core/src/storage/postgres/search.rs
+++ b/crates/atomic-core/src/storage/postgres/search.rs
@@ -29,7 +29,7 @@ impl PostgresStorage {
             .keyword_search(
                 query_trimmed,
                 section_limit,
-                &[],
+                &crate::search::ScopeFilter::default(),
                 None,
                 &crate::models::KindFilter::All,
             )
@@ -57,7 +57,7 @@ impl SearchStore for PostgresStorage {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
@@ -108,20 +108,14 @@ impl SearchStore for PostgresStorage {
             .collect();
 
         // Scope filtering by tag if specified
-        let scope_atom_ids: std::collections::HashSet<String> = if scope_tag_ids.is_empty() {
+        let scope_atom_ids: std::collections::HashSet<String> = if scope.is_empty() {
             std::collections::HashSet::new()
         } else {
             let candidate_atom_ids: Vec<&str> = filtered
                 .iter()
                 .map(|(_, aid, _, _, _)| aid.as_str())
                 .collect();
-            pg_batch_atoms_with_scope_tags(
-                &self.pool,
-                &candidate_atom_ids,
-                scope_tag_ids,
-                &self.db_id,
-            )
-            .await?
+            pg_atoms_passing_scope(&self.pool, &candidate_atom_ids, scope, &self.db_id).await?
         };
         // Kind filtering. `None` = `KindFilter::All` (no filter applied).
         let kind_allowed: Option<std::collections::HashSet<String>> =
@@ -146,7 +140,7 @@ impl SearchStore for PostgresStorage {
         // Deduplicate by atom_id, keeping best score
         let mut atom_best: HashMap<String, (f32, String, i32)> = HashMap::new();
         for (_chunk_id, atom_id, content, chunk_index, similarity) in &filtered {
-            if !scope_tag_ids.is_empty() && !scope_atom_ids.contains(atom_id) {
+            if !scope.is_empty() && !scope_atom_ids.contains(atom_id) {
                 continue;
             }
             if let Some(ref allowed) = kind_allowed {
@@ -206,7 +200,7 @@ impl SearchStore for PostgresStorage {
         &self,
         query: &str,
         limit: i32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
@@ -253,20 +247,15 @@ impl SearchStore for PostgresStorage {
         .map_err(|e| AtomicCoreError::Search(format!("Keyword search failed: {}", e)))?;
 
         // Apply tag scope filter if specified
-        let filtered = if scope_tag_ids.is_empty() {
+        let filtered = if scope.is_empty() {
             rows
         } else {
             let candidate_atom_ids: Vec<&str> =
                 rows.iter().map(|(_, aid, _, _, _)| aid.as_str()).collect();
-            let matching = pg_batch_atoms_with_scope_tags(
-                &self.pool,
-                &candidate_atom_ids,
-                scope_tag_ids,
-                &self.db_id,
-            )
-            .await?;
+            let passing =
+                pg_atoms_passing_scope(&self.pool, &candidate_atom_ids, scope, &self.db_id).await?;
             rows.into_iter()
-                .filter(|(_, aid, _, _, _)| matching.contains(aid.as_str()))
+                .filter(|(_, aid, _, _, _)| passing.contains(aid.as_str()))
                 .collect()
         };
 
@@ -349,7 +338,7 @@ impl SearchStore for PostgresStorage {
         &self,
         query: &str,
         limit: i32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<ChunkSearchResult>> {
@@ -395,20 +384,15 @@ impl SearchStore for PostgresStorage {
         .map_err(|e| AtomicCoreError::Search(format!("Keyword chunk search failed: {}", e)))?;
 
         // Apply scope filter
-        let filtered = if scope_tag_ids.is_empty() {
+        let filtered = if scope.is_empty() {
             rows
         } else {
             let candidate_atom_ids: Vec<&str> =
                 rows.iter().map(|(_, aid, _, _, _)| aid.as_str()).collect();
-            let matching = pg_batch_atoms_with_scope_tags(
-                &self.pool,
-                &candidate_atom_ids,
-                scope_tag_ids,
-                &self.db_id,
-            )
-            .await?;
+            let passing =
+                pg_atoms_passing_scope(&self.pool, &candidate_atom_ids, scope, &self.db_id).await?;
             rows.into_iter()
-                .filter(|(_, aid, _, _, _)| matching.contains(aid.as_str()))
+                .filter(|(_, aid, _, _, _)| passing.contains(aid.as_str()))
                 .collect()
         };
 
@@ -449,7 +433,7 @@ impl SearchStore for PostgresStorage {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<ChunkSearchResult>> {
@@ -498,23 +482,18 @@ impl SearchStore for PostgresStorage {
             .collect();
 
         // Apply scope filter
-        let scoped = if scope_tag_ids.is_empty() {
+        let scoped = if scope.is_empty() {
             filtered
         } else {
             let candidate_atom_ids: Vec<&str> = filtered
                 .iter()
                 .map(|(_, aid, _, _, _)| aid.as_str())
                 .collect();
-            let matching = pg_batch_atoms_with_scope_tags(
-                &self.pool,
-                &candidate_atom_ids,
-                scope_tag_ids,
-                &self.db_id,
-            )
-            .await?;
+            let passing =
+                pg_atoms_passing_scope(&self.pool, &candidate_atom_ids, scope, &self.db_id).await?;
             filtered
                 .into_iter()
-                .filter(|(_, aid, _, _, _)| matching.contains(aid.as_str()))
+                .filter(|(_, aid, _, _, _)| passing.contains(aid.as_str()))
                 .collect()
         };
 
@@ -754,39 +733,53 @@ async fn pg_batch_fetch_tags(
     Ok(map)
 }
 
-/// Batch check which atom_ids have at least one of the specified scope tags.
-async fn pg_batch_atoms_with_scope_tags(
+/// Resolve which of `atom_ids` the scope filter admits. Mirrors the SQLite
+/// helper: one query maps each candidate to the scope *roots* it carries
+/// (walking each root's descendants), and the shared predicate in
+/// `ScopeFilter::admitted` turns that into the answer, so include/require/
+/// exclude means the same thing on both backends.
+async fn pg_atoms_passing_scope(
     pool: &sqlx::PgPool,
     atom_ids: &[&str],
-    scope_tag_ids: &[String],
+    scope: &crate::search::ScopeFilter,
     db_id: &str,
 ) -> Result<std::collections::HashSet<String>, AtomicCoreError> {
-    if atom_ids.is_empty() || scope_tag_ids.is_empty() {
+    if scope.is_empty() {
+        return Ok(atom_ids.iter().map(|id| id.to_string()).collect());
+    }
+    if atom_ids.is_empty() {
         return Ok(std::collections::HashSet::new());
     }
 
     let atom_id_strings: Vec<String> = atom_ids.iter().map(|s| s.to_string()).collect();
+    let roots = scope.roots();
 
-    // Use recursive CTE to include atoms tagged with descendants of the scope tags
-    let rows: Vec<(String,)> = sqlx::query_as(
-        "WITH RECURSIVE scope_tags(id) AS (
-            SELECT id FROM tags WHERE id = ANY($2) AND db_id = $3
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        "WITH RECURSIVE scope_tags(root_id, id) AS (
+            SELECT id, id FROM tags WHERE id = ANY($2) AND db_id = $3
             UNION ALL
-            SELECT t.id FROM tags t
+            SELECT st.root_id, t.id FROM tags t
             INNER JOIN scope_tags st ON t.parent_id = st.id
             WHERE t.db_id = $3
          )
-         SELECT DISTINCT atom_id FROM atom_tags
-         WHERE atom_id = ANY($1) AND tag_id IN (SELECT id FROM scope_tags) AND db_id = $3",
+         SELECT DISTINCT st.root_id, att.atom_id
+         FROM atom_tags att
+         INNER JOIN scope_tags st ON st.id = att.tag_id
+         WHERE att.atom_id = ANY($1) AND att.db_id = $3",
     )
     .bind(&atom_id_strings)
-    .bind(scope_tag_ids)
+    .bind(&roots)
     .bind(db_id)
     .fetch_all(pool)
     .await
     .map_err(|e| AtomicCoreError::Search(format!("Failed to check scope tags: {}", e)))?;
 
-    Ok(rows.into_iter().map(|(id,)| id).collect())
+    let mut matched: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
+    for (root_id, atom_id) in rows {
+        matched.entry(atom_id).or_default().insert(root_id);
+    }
+
+    Ok(scope.admitted(atom_ids.iter().copied(), &matched))
 }
 
 /// Batch lookup of which atom_ids match the given `KindFilter`. Caller is

--- a/crates/atomic-core/src/storage/postgres/search.rs
+++ b/crates/atomic-core/src/storage/postgres/search.rs
@@ -29,7 +29,7 @@ impl PostgresStorage {
             .keyword_search(
                 query_trimmed,
                 section_limit,
-                None,
+                &[],
                 None,
                 &crate::models::KindFilter::All,
             )
@@ -57,7 +57,7 @@ impl SearchStore for PostgresStorage {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        tag_id: Option<&str>,
+        scope_tag_ids: &[String],
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
@@ -108,7 +108,9 @@ impl SearchStore for PostgresStorage {
             .collect();
 
         // Scope filtering by tag if specified
-        let scope_atom_ids: std::collections::HashSet<String> = if let Some(tid) = tag_id {
+        let scope_atom_ids: std::collections::HashSet<String> = if scope_tag_ids.is_empty() {
+            std::collections::HashSet::new()
+        } else {
             let candidate_atom_ids: Vec<&str> = filtered
                 .iter()
                 .map(|(_, aid, _, _, _)| aid.as_str())
@@ -116,12 +118,10 @@ impl SearchStore for PostgresStorage {
             pg_batch_atoms_with_scope_tags(
                 &self.pool,
                 &candidate_atom_ids,
-                &[tid.to_string()],
+                scope_tag_ids,
                 &self.db_id,
             )
             .await?
-        } else {
-            std::collections::HashSet::new()
         };
         // Kind filtering. `None` = `KindFilter::All` (no filter applied).
         let kind_allowed: Option<std::collections::HashSet<String>> =
@@ -146,7 +146,7 @@ impl SearchStore for PostgresStorage {
         // Deduplicate by atom_id, keeping best score
         let mut atom_best: HashMap<String, (f32, String, i32)> = HashMap::new();
         for (_chunk_id, atom_id, content, chunk_index, similarity) in &filtered {
-            if tag_id.is_some() && !scope_atom_ids.contains(atom_id) {
+            if !scope_tag_ids.is_empty() && !scope_atom_ids.contains(atom_id) {
                 continue;
             }
             if let Some(ref allowed) = kind_allowed {
@@ -206,7 +206,7 @@ impl SearchStore for PostgresStorage {
         &self,
         query: &str,
         limit: i32,
-        tag_id: Option<&str>,
+        scope_tag_ids: &[String],
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
@@ -253,21 +253,21 @@ impl SearchStore for PostgresStorage {
         .map_err(|e| AtomicCoreError::Search(format!("Keyword search failed: {}", e)))?;
 
         // Apply tag scope filter if specified
-        let filtered = if let Some(tid) = tag_id {
+        let filtered = if scope_tag_ids.is_empty() {
+            rows
+        } else {
             let candidate_atom_ids: Vec<&str> =
                 rows.iter().map(|(_, aid, _, _, _)| aid.as_str()).collect();
             let matching = pg_batch_atoms_with_scope_tags(
                 &self.pool,
                 &candidate_atom_ids,
-                &[tid.to_string()],
+                scope_tag_ids,
                 &self.db_id,
             )
             .await?;
             rows.into_iter()
                 .filter(|(_, aid, _, _, _)| matching.contains(aid.as_str()))
                 .collect()
-        } else {
-            rows
         };
 
         // Apply kind filter post-pass (FTS index is kind-agnostic).

--- a/crates/atomic-core/src/storage/postgres/search.rs
+++ b/crates/atomic-core/src/storage/postgres/search.rs
@@ -624,6 +624,18 @@ impl SearchStore for PostgresStorage {
 
         Ok(final_results)
     }
+
+    async fn atoms_passing_scope(
+        &self,
+        atom_ids: &[String],
+        scope: &crate::search::ScopeFilter,
+    ) -> StorageResult<std::collections::HashSet<String>> {
+        if scope.is_empty() {
+            return Ok(atom_ids.iter().cloned().collect());
+        }
+        let ids: Vec<&str> = atom_ids.iter().map(String::as_str).collect();
+        pg_atoms_passing_scope(&self.pool, &ids, scope, &self.db_id).await
+    }
 }
 
 // ==================== Helper Functions ====================

--- a/crates/atomic-core/src/storage/sqlite/chat.rs
+++ b/crates/atomic-core/src/storage/sqlite/chat.rs
@@ -1,6 +1,7 @@
 use super::SqliteStorage;
 use crate::error::AtomicCoreError;
 use crate::models::*;
+use crate::search::ScopeFilter;
 use crate::storage::traits::*;
 use async_trait::async_trait;
 
@@ -68,27 +69,28 @@ impl SqliteStorage {
     pub(crate) fn set_conversation_scope_sync(
         &self,
         conversation_id: &str,
-        tag_ids: &[String],
+        entries: &[ScopeEntry],
     ) -> StorageResult<ConversationWithTags> {
         let conn = self
             .db
             .conn
             .lock()
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
-        crate::chat::set_conversation_scope(&conn, conversation_id, tag_ids)
+        crate::chat::set_conversation_scope(&conn, conversation_id, entries)
     }
 
     pub(crate) fn add_tag_to_scope_sync(
         &self,
         conversation_id: &str,
         tag_id: &str,
+        mode: ScopeMode,
     ) -> StorageResult<ConversationWithTags> {
         let conn = self
             .db
             .conn
             .lock()
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
-        crate::chat::add_tag_to_scope(&conn, conversation_id, tag_id)
+        crate::chat::add_tag_to_scope(&conn, conversation_id, tag_id, mode)
     }
 
     pub(crate) fn remove_tag_from_scope_sync(
@@ -158,25 +160,25 @@ impl SqliteStorage {
         crate::chat::save_citations(&conn, message_id, citations)
     }
 
-    pub(crate) fn get_scope_tag_ids_sync(
+    pub(crate) fn get_conversation_scope_sync(
         &self,
         conversation_id: &str,
-    ) -> StorageResult<Vec<String>> {
+    ) -> StorageResult<ScopeFilter> {
         let conn = self
             .db
             .conn
             .lock()
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
-        crate::chat::get_scope_tag_ids(&conn, conversation_id)
+        crate::chat::get_conversation_scope(&conn, conversation_id)
     }
 
-    pub(crate) fn get_scope_description_sync(&self, tag_ids: &[String]) -> StorageResult<String> {
+    pub(crate) fn get_scope_description_sync(&self, scope: &ScopeFilter) -> StorageResult<String> {
         let conn = self
             .db
             .conn
             .lock()
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
-        Ok(crate::chat::get_scope_description(&conn, tag_ids))
+        Ok(crate::chat::get_scope_description(&conn, scope))
     }
 }
 
@@ -256,13 +258,13 @@ impl ChatStore for SqliteStorage {
     async fn set_conversation_scope(
         &self,
         conversation_id: &str,
-        tag_ids: &[String],
+        entries: &[ScopeEntry],
     ) -> StorageResult<ConversationWithTags> {
         let storage = self.clone();
         let conversation_id = conversation_id.to_string();
-        let tag_ids = tag_ids.to_vec();
+        let entries = entries.to_vec();
         tokio::task::spawn_blocking(move || {
-            storage.set_conversation_scope_sync(&conversation_id, &tag_ids)
+            storage.set_conversation_scope_sync(&conversation_id, &entries)
         })
         .await
         .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
@@ -272,12 +274,13 @@ impl ChatStore for SqliteStorage {
         &self,
         conversation_id: &str,
         tag_id: &str,
+        mode: ScopeMode,
     ) -> StorageResult<ConversationWithTags> {
         let storage = self.clone();
         let conversation_id = conversation_id.to_string();
         let tag_id = tag_id.to_string();
         tokio::task::spawn_blocking(move || {
-            storage.add_tag_to_scope_sync(&conversation_id, &tag_id)
+            storage.add_tag_to_scope_sync(&conversation_id, &tag_id, mode)
         })
         .await
         .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
@@ -341,18 +344,18 @@ impl ChatStore for SqliteStorage {
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
     }
 
-    async fn get_scope_tag_ids(&self, conversation_id: &str) -> StorageResult<Vec<String>> {
+    async fn get_conversation_scope(&self, conversation_id: &str) -> StorageResult<ScopeFilter> {
         let storage = self.clone();
         let conversation_id = conversation_id.to_string();
-        tokio::task::spawn_blocking(move || storage.get_scope_tag_ids_sync(&conversation_id))
+        tokio::task::spawn_blocking(move || storage.get_conversation_scope_sync(&conversation_id))
             .await
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
     }
 
-    async fn get_scope_description(&self, tag_ids: &[String]) -> StorageResult<String> {
+    async fn get_scope_description(&self, scope: &ScopeFilter) -> StorageResult<String> {
         let storage = self.clone();
-        let tag_ids = tag_ids.to_vec();
-        tokio::task::spawn_blocking(move || storage.get_scope_description_sync(&tag_ids))
+        let scope = scope.clone();
+        tokio::task::spawn_blocking(move || storage.get_scope_description_sync(&scope))
             .await
             .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
     }

--- a/crates/atomic-core/src/storage/sqlite/chat.rs
+++ b/crates/atomic-core/src/storage/sqlite/chat.rs
@@ -53,6 +53,19 @@ impl SqliteStorage {
         crate::chat::update_conversation(&conn, id, title, is_archived)
     }
 
+    pub(crate) fn set_conversation_title_if_unset_sync(
+        &self,
+        id: &str,
+        title: &str,
+    ) -> StorageResult<bool> {
+        let conn = self
+            .db
+            .conn
+            .lock()
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?;
+        crate::chat::set_title_if_unset(&conn, id, title)
+    }
+
     pub(crate) fn delete_conversation_sync(&self, id: &str) -> StorageResult<()> {
         let conn = self
             .db
@@ -242,6 +255,21 @@ impl ChatStore for SqliteStorage {
         let title = title.map(|s| s.to_string());
         tokio::task::spawn_blocking(move || {
             storage.update_conversation_sync(&id, title.as_deref(), is_archived)
+        })
+        .await
+        .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
+    }
+
+    async fn set_conversation_title_if_unset(
+        &self,
+        id: &str,
+        title: &str,
+    ) -> StorageResult<bool> {
+        let storage = self.clone();
+        let id = id.to_string();
+        let title = title.to_string();
+        tokio::task::spawn_blocking(move || {
+            storage.set_conversation_title_if_unset_sync(&id, &title)
         })
         .await
         .map_err(|e| AtomicCoreError::Lock(e.to_string()))?

--- a/crates/atomic-core/src/storage/sqlite/chat.rs
+++ b/crates/atomic-core/src/storage/sqlite/chat.rs
@@ -24,9 +24,10 @@ impl SqliteStorage {
         filter_tag_id: Option<&str>,
         limit: i32,
         offset: i32,
+        include_archived: bool,
     ) -> StorageResult<Vec<ConversationWithTags>> {
         let conn = self.db.read_conn()?;
-        crate::chat::get_conversations(&conn, filter_tag_id, limit, offset)
+        crate::chat::get_conversations(&conn, filter_tag_id, limit, offset, include_archived)
     }
 
     pub(crate) fn get_conversation_sync(
@@ -201,11 +202,17 @@ impl ChatStore for SqliteStorage {
         filter_tag_id: Option<&str>,
         limit: i32,
         offset: i32,
+        include_archived: bool,
     ) -> StorageResult<Vec<ConversationWithTags>> {
         let storage = self.clone();
         let filter_tag_id = filter_tag_id.map(|s| s.to_string());
         tokio::task::spawn_blocking(move || {
-            storage.get_conversations_sync(filter_tag_id.as_deref(), limit, offset)
+            storage.get_conversations_sync(
+                filter_tag_id.as_deref(),
+                limit,
+                offset,
+                include_archived,
+            )
         })
         .await
         .map_err(|e| AtomicCoreError::Lock(e.to_string()))?

--- a/crates/atomic-core/src/storage/sqlite/search.rs
+++ b/crates/atomic-core/src/storage/sqlite/search.rs
@@ -4,7 +4,7 @@ use super::SqliteStorage;
 use crate::embedding::{distance_to_similarity, f32_vec_to_blob_public};
 use crate::error::AtomicCoreError;
 use crate::models::*;
-use crate::search;
+use crate::search::{self, atoms_passing_scope};
 use crate::storage::traits::*;
 use async_trait::async_trait;
 use rusqlite::OptionalExtension;
@@ -16,7 +16,7 @@ impl SqliteStorage {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
@@ -38,10 +38,11 @@ impl SqliteStorage {
         let chunk_map = batch_fetch_chunk_info(&conn, &chunk_ids)?;
 
         // Scope filtering
-        let scope_atom_ids: std::collections::HashSet<String> = if !scope_tag_ids.is_empty() {
+        let scope_atom_ids: std::collections::HashSet<String> = if !scope.is_empty() {
             let candidate_atom_ids: Vec<&str> =
                 chunk_map.values().map(|(aid, _, _)| aid.as_str()).collect();
-            batch_atoms_with_scope_tags(&conn, &candidate_atom_ids, scope_tag_ids)?
+            atoms_passing_scope(&conn, &candidate_atom_ids, scope)
+                .map_err(AtomicCoreError::Search)?
         } else {
             std::collections::HashSet::new()
         };
@@ -64,7 +65,7 @@ impl SqliteStorage {
         for (chunk_id, distance) in &filtered {
             let similarity = distance_to_similarity(*distance);
             if let Some((atom_id, content, chunk_index)) = chunk_map.get(chunk_id) {
-                if !scope_tag_ids.is_empty() && !scope_atom_ids.contains(atom_id) {
+                if !scope.is_empty() && !scope_atom_ids.contains(atom_id) {
                     continue;
                 }
                 if let Some(ref allowed) = kind_allowed {
@@ -125,7 +126,7 @@ impl SqliteStorage {
         &self,
         query: &str,
         limit: i32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
@@ -144,14 +145,15 @@ impl SqliteStorage {
             atom_fts_search_with_cutoff(&conn, &escaped_query, fetch_limit, created_after)?;
 
         // Apply tag scope filter if specified
-        let filtered = if scope_tag_ids.is_empty() {
+        let filtered = if scope.is_empty() {
             raw_results
         } else {
             let candidate_atom_ids: Vec<&str> = raw_results.iter().map(|r| r.0.as_str()).collect();
-            let matching = batch_atoms_with_scope_tags(&conn, &candidate_atom_ids, scope_tag_ids)?;
+            let passing = atoms_passing_scope(&conn, &candidate_atom_ids, scope)
+                .map_err(AtomicCoreError::Search)?;
             raw_results
                 .into_iter()
-                .filter(|r| matching.contains(r.0.as_str()))
+                .filter(|r| passing.contains(r.0.as_str()))
                 .collect::<Vec<_>>()
         };
 
@@ -207,7 +209,7 @@ impl SqliteStorage {
         &self,
         query: &str,
         limit: i32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<ChunkSearchResult>> {
@@ -223,14 +225,15 @@ impl SqliteStorage {
             fts_search_with_cutoff(&conn, &escaped_query, fetch_limit, created_after)?;
 
         // Apply tag scope filter if specified
-        let filtered = if scope_tag_ids.is_empty() {
+        let filtered = if scope.is_empty() {
             raw_results
         } else {
             let candidate_atom_ids: Vec<&str> = raw_results.iter().map(|r| r.1.as_str()).collect();
-            let matching = batch_atoms_with_scope_tags(&conn, &candidate_atom_ids, scope_tag_ids)?;
+            let passing = atoms_passing_scope(&conn, &candidate_atom_ids, scope)
+                .map_err(AtomicCoreError::Search)?;
             raw_results
                 .into_iter()
-                .filter(|r| matching.contains(r.1.as_str()))
+                .filter(|r| passing.contains(r.1.as_str()))
                 .collect()
         };
 
@@ -270,7 +273,7 @@ impl SqliteStorage {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<ChunkSearchResult>> {
@@ -292,10 +295,11 @@ impl SqliteStorage {
         let chunk_map = batch_fetch_chunk_info(&conn, &chunk_ids)?;
 
         // Apply tag scope filter
-        let scope_atom_ids: std::collections::HashSet<String> = if !scope_tag_ids.is_empty() {
+        let scope_atom_ids: std::collections::HashSet<String> = if !scope.is_empty() {
             let candidate_atom_ids: Vec<&str> =
                 chunk_map.values().map(|(aid, _, _)| aid.as_str()).collect();
-            batch_atoms_with_scope_tags(&conn, &candidate_atom_ids, scope_tag_ids)?
+            atoms_passing_scope(&conn, &candidate_atom_ids, scope)
+                .map_err(AtomicCoreError::Search)?
         } else {
             std::collections::HashSet::new()
         };
@@ -318,7 +322,7 @@ impl SqliteStorage {
         for (chunk_id, distance) in &filtered {
             let similarity = distance_to_similarity(*distance);
             if let Some((atom_id, content, chunk_index)) = chunk_map.get(chunk_id) {
-                if !scope_tag_ids.is_empty() && !scope_atom_ids.contains(atom_id) {
+                if !scope.is_empty() && !scope_atom_ids.contains(atom_id) {
                     continue;
                 }
                 if let Some(allowed) = &kind_allowed {
@@ -375,7 +379,7 @@ impl SqliteStorage {
         let atoms = self.keyword_search_sync(
             query,
             section_limit,
-            &[],
+            &crate::search::ScopeFilter::default(),
             None,
             &crate::models::KindFilter::All,
         )?;
@@ -399,13 +403,13 @@ impl SearchStore for SqliteStorage {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
         let storage = self.clone();
         let query_embedding = query_embedding.to_vec();
-        let scope_tag_ids = scope_tag_ids.to_vec();
+        let scope = scope.clone();
         let created_after = created_after.map(|s| s.to_string());
         let kinds = kinds.clone();
         tokio::task::spawn_blocking(move || {
@@ -413,7 +417,7 @@ impl SearchStore for SqliteStorage {
                 &query_embedding,
                 limit,
                 threshold,
-                &scope_tag_ids,
+                &scope,
                 created_after.as_deref(),
                 &kinds,
             )
@@ -426,23 +430,17 @@ impl SearchStore for SqliteStorage {
         &self,
         query: &str,
         limit: i32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
         let storage = self.clone();
         let query = query.to_string();
-        let scope_tag_ids = scope_tag_ids.to_vec();
+        let scope = scope.clone();
         let created_after = created_after.map(|s| s.to_string());
         let kinds = kinds.clone();
         tokio::task::spawn_blocking(move || {
-            storage.keyword_search_sync(
-                &query,
-                limit,
-                &scope_tag_ids,
-                created_after.as_deref(),
-                &kinds,
-            )
+            storage.keyword_search_sync(&query, limit, &scope, created_after.as_deref(), &kinds)
         })
         .await
         .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
@@ -465,20 +463,20 @@ impl SearchStore for SqliteStorage {
         &self,
         query: &str,
         limit: i32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<ChunkSearchResult>> {
         let storage = self.clone();
         let query = query.to_string();
-        let scope_tag_ids = scope_tag_ids.to_vec();
+        let scope = scope.clone();
         let created_after = created_after.map(|s| s.to_string());
         let kinds = kinds.clone();
         tokio::task::spawn_blocking(move || {
             storage.keyword_search_chunks_sync(
                 &query,
                 limit,
-                &scope_tag_ids,
+                &scope,
                 created_after.as_deref(),
                 &kinds,
             )
@@ -492,13 +490,13 @@ impl SearchStore for SqliteStorage {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        scope_tag_ids: &[String],
+        scope: &crate::search::ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<ChunkSearchResult>> {
         let storage = self.clone();
         let query_embedding = query_embedding.to_vec();
-        let scope_tag_ids = scope_tag_ids.to_vec();
+        let scope = scope.clone();
         let created_after = created_after.map(|s| s.to_string());
         let kinds = kinds.clone();
         tokio::task::spawn_blocking(move || {
@@ -506,7 +504,7 @@ impl SearchStore for SqliteStorage {
                 &query_embedding,
                 limit,
                 threshold,
-                &scope_tag_ids,
+                &scope,
                 created_after.as_deref(),
                 &kinds,
             )
@@ -1266,62 +1264,6 @@ fn batch_fetch_chunk_info(
         .into_iter()
         .map(|(id, atom_id, content, idx)| (id, (atom_id, content, idx)))
         .collect())
-}
-
-/// Batch check which atom_ids have at least one of the specified scope tags.
-fn batch_atoms_with_scope_tags(
-    conn: &rusqlite::Connection,
-    atom_ids: &[&str],
-    scope_tag_ids: &[String],
-) -> Result<std::collections::HashSet<String>, AtomicCoreError> {
-    if atom_ids.is_empty() || scope_tag_ids.is_empty() {
-        return Ok(std::collections::HashSet::new());
-    }
-
-    // Use recursive CTE to include atoms tagged with descendants of the scope tags
-    let atom_placeholders: Vec<&str> = atom_ids.iter().map(|_| "?").collect();
-    let tag_placeholders: Vec<&str> = scope_tag_ids.iter().map(|_| "?").collect();
-    let query = format!(
-        "WITH RECURSIVE scope_tags(id) AS (
-            SELECT id FROM tags WHERE id IN ({tag_ph})
-            UNION ALL
-            SELECT t.id FROM tags t
-            INNER JOIN scope_tags st ON t.parent_id = st.id
-         )
-         SELECT DISTINCT atom_id FROM atom_tags
-         WHERE atom_id IN ({atom_ph}) AND tag_id IN (SELECT id FROM scope_tags)",
-        tag_ph = tag_placeholders.join(","),
-        atom_ph = atom_placeholders.join(","),
-    );
-
-    // Bind order matches SQL: tag_ids first (CTE), then atom_ids (WHERE)
-    let mut params: Vec<&dyn rusqlite::ToSql> =
-        Vec::with_capacity(atom_ids.len() + scope_tag_ids.len());
-    for id in scope_tag_ids {
-        params.push(id);
-    }
-    for id in atom_ids {
-        params.push(id);
-    }
-
-    let mut stmt = conn
-        .prepare(&query)
-        .map_err(|e| AtomicCoreError::Search(format!("Failed to prepare scope query: {}", e)))?;
-    let rows = stmt
-        .query_map(rusqlite::params_from_iter(params), |row| {
-            row.get::<_, String>(0)
-        })
-        .map_err(|e| AtomicCoreError::Search(format!("Failed to execute scope query: {}", e)))?;
-
-    let mut matching = std::collections::HashSet::new();
-    for row in rows {
-        matching.insert(
-            row.map_err(|e| {
-                AtomicCoreError::Search(format!("Failed to read scope result: {}", e))
-            })?,
-        );
-    }
-    Ok(matching)
 }
 
 /// Batch lookup of which atom_ids match the given `KindFilter`. Returns the

--- a/crates/atomic-core/src/storage/sqlite/search.rs
+++ b/crates/atomic-core/src/storage/sqlite/search.rs
@@ -394,6 +394,21 @@ impl SqliteStorage {
             tags,
         })
     }
+
+    /// See [`SearchStore::atoms_passing_scope`]. Delegates to the shared
+    /// SQLite predicate every other retrieval path filters with.
+    pub(crate) fn atoms_passing_scope_sync(
+        &self,
+        atom_ids: &[String],
+        scope: &crate::search::ScopeFilter,
+    ) -> StorageResult<std::collections::HashSet<String>> {
+        if scope.is_empty() {
+            return Ok(atom_ids.iter().cloned().collect());
+        }
+        let conn = self.db.read_conn()?;
+        let ids: Vec<&str> = atom_ids.iter().map(String::as_str).collect();
+        atoms_passing_scope(&conn, &ids, scope).map_err(AtomicCoreError::Search)
+    }
 }
 
 #[async_trait]
@@ -511,6 +526,19 @@ impl SearchStore for SqliteStorage {
         })
         .await
         .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
+    }
+
+    async fn atoms_passing_scope(
+        &self,
+        atom_ids: &[String],
+        scope: &crate::search::ScopeFilter,
+    ) -> StorageResult<std::collections::HashSet<String>> {
+        let storage = self.clone();
+        let atom_ids = atom_ids.to_vec();
+        let scope = scope.clone();
+        tokio::task::spawn_blocking(move || storage.atoms_passing_scope_sync(&atom_ids, &scope))
+            .await
+            .map_err(|e| AtomicCoreError::Lock(e.to_string()))?
     }
 }
 

--- a/crates/atomic-core/src/storage/sqlite/search.rs
+++ b/crates/atomic-core/src/storage/sqlite/search.rs
@@ -16,7 +16,7 @@ impl SqliteStorage {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        tag_id: Option<&str>,
+        scope_tag_ids: &[String],
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
@@ -38,11 +38,10 @@ impl SqliteStorage {
         let chunk_map = batch_fetch_chunk_info(&conn, &chunk_ids)?;
 
         // Scope filtering
-        let scope_tag_ids: Vec<String> = tag_id.map(|t| vec![t.to_string()]).unwrap_or_default();
         let scope_atom_ids: std::collections::HashSet<String> = if !scope_tag_ids.is_empty() {
             let candidate_atom_ids: Vec<&str> =
                 chunk_map.values().map(|(aid, _, _)| aid.as_str()).collect();
-            batch_atoms_with_scope_tags(&conn, &candidate_atom_ids, &scope_tag_ids)?
+            batch_atoms_with_scope_tags(&conn, &candidate_atom_ids, scope_tag_ids)?
         } else {
             std::collections::HashSet::new()
         };
@@ -126,7 +125,7 @@ impl SqliteStorage {
         &self,
         query: &str,
         limit: i32,
-        tag_id: Option<&str>,
+        scope_tag_ids: &[String],
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
@@ -145,16 +144,15 @@ impl SqliteStorage {
             atom_fts_search_with_cutoff(&conn, &escaped_query, fetch_limit, created_after)?;
 
         // Apply tag scope filter if specified
-        let filtered = if let Some(tid) = tag_id {
-            let scope_tag_ids = vec![tid.to_string()];
+        let filtered = if scope_tag_ids.is_empty() {
+            raw_results
+        } else {
             let candidate_atom_ids: Vec<&str> = raw_results.iter().map(|r| r.0.as_str()).collect();
-            let matching = batch_atoms_with_scope_tags(&conn, &candidate_atom_ids, &scope_tag_ids)?;
+            let matching = batch_atoms_with_scope_tags(&conn, &candidate_atom_ids, scope_tag_ids)?;
             raw_results
                 .into_iter()
                 .filter(|r| matching.contains(r.0.as_str()))
                 .collect::<Vec<_>>()
-        } else {
-            raw_results
         };
 
         // Apply kind filter post-pass (FTS index is kind-agnostic).
@@ -377,7 +375,7 @@ impl SqliteStorage {
         let atoms = self.keyword_search_sync(
             query,
             section_limit,
-            None,
+            &[],
             None,
             &crate::models::KindFilter::All,
         )?;
@@ -401,13 +399,13 @@ impl SearchStore for SqliteStorage {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        tag_id: Option<&str>,
+        scope_tag_ids: &[String],
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
         let storage = self.clone();
         let query_embedding = query_embedding.to_vec();
-        let tag_id = tag_id.map(|s| s.to_string());
+        let scope_tag_ids = scope_tag_ids.to_vec();
         let created_after = created_after.map(|s| s.to_string());
         let kinds = kinds.clone();
         tokio::task::spawn_blocking(move || {
@@ -415,7 +413,7 @@ impl SearchStore for SqliteStorage {
                 &query_embedding,
                 limit,
                 threshold,
-                tag_id.as_deref(),
+                &scope_tag_ids,
                 created_after.as_deref(),
                 &kinds,
             )
@@ -428,20 +426,20 @@ impl SearchStore for SqliteStorage {
         &self,
         query: &str,
         limit: i32,
-        tag_id: Option<&str>,
+        scope_tag_ids: &[String],
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>> {
         let storage = self.clone();
         let query = query.to_string();
-        let tag_id = tag_id.map(|s| s.to_string());
+        let scope_tag_ids = scope_tag_ids.to_vec();
         let created_after = created_after.map(|s| s.to_string());
         let kinds = kinds.clone();
         tokio::task::spawn_blocking(move || {
             storage.keyword_search_sync(
                 &query,
                 limit,
-                tag_id.as_deref(),
+                &scope_tag_ids,
                 created_after.as_deref(),
                 &kinds,
             )

--- a/crates/atomic-core/src/storage/traits.rs
+++ b/crates/atomic-core/src/storage/traits.rs
@@ -598,6 +598,8 @@ pub trait ChunkStore: Send + Sync {
 #[async_trait]
 pub trait SearchStore: Send + Sync {
     /// Perform vector similarity search using embeddings.
+    /// `scope_tag_ids` restricts results to atoms tagged with any of those tags
+    /// or their descendants (OR semantics); empty means no scope filter.
     /// `created_after` is an optional ISO 8601 cutoff — only atoms created at or after
     /// this timestamp are returned. `kinds` is non-defaulted so every caller
     /// declares whether finding atoms are in scope (the UI path passes
@@ -607,12 +609,13 @@ pub trait SearchStore: Send + Sync {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        tag_id: Option<&str>,
+        scope_tag_ids: &[String],
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>>;
 
     /// Perform keyword search using full-text search.
+    /// `scope_tag_ids` follows `vector_search`'s scope semantics.
     /// `created_after` is an optional ISO 8601 cutoff — only atoms created at or after
     /// this timestamp are returned. `kinds` controls the atom-kind filter; see
     /// `vector_search` for the discipline.
@@ -620,7 +623,7 @@ pub trait SearchStore: Send + Sync {
         &self,
         query: &str,
         limit: i32,
-        tag_id: Option<&str>,
+        scope_tag_ids: &[String],
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>>;
@@ -670,11 +673,13 @@ pub trait ChatStore: Send + Sync {
     ) -> StorageResult<ConversationWithTags>;
 
     /// List conversations with optional tag filter and pagination.
+    /// Archived conversations are excluded unless `include_archived`.
     async fn get_conversations(
         &self,
         filter_tag_id: Option<&str>,
         limit: i32,
         offset: i32,
+        include_archived: bool,
     ) -> StorageResult<Vec<ConversationWithTags>>;
 
     /// Get a conversation with its full message history.

--- a/crates/atomic-core/src/storage/traits.rs
+++ b/crates/atomic-core/src/storage/traits.rs
@@ -660,6 +660,17 @@ pub trait SearchStore: Send + Sync {
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<ChunkSearchResult>>;
+
+    /// Which of `atom_ids` the scope admits, by the same rule the search
+    /// paths apply internally. Exposed because the tools that read an atom
+    /// *by id* (chat's `get_atom` / `get_finding`) have no query to hang a
+    /// scope on and must ask before handing content to the model. An empty
+    /// filter admits everything.
+    async fn atoms_passing_scope(
+        &self,
+        atom_ids: &[String],
+        scope: &ScopeFilter,
+    ) -> StorageResult<std::collections::HashSet<String>>;
 }
 
 // ==================== Chat Storage ====================
@@ -697,6 +708,16 @@ pub trait ChatStore: Send + Sync {
         title: Option<&str>,
         is_archived: Option<bool>,
     ) -> StorageResult<Conversation>;
+
+    /// Name a conversation only while it is still untitled, returning whether
+    /// the name landed. The auto-titler's write path: a user rename that
+    /// arrives while the title model is thinking must win, and only a
+    /// conditional UPDATE can promise that.
+    async fn set_conversation_title_if_unset(
+        &self,
+        id: &str,
+        title: &str,
+    ) -> StorageResult<bool>;
 
     /// Delete a conversation and all its messages.
     async fn delete_conversation(&self, id: &str) -> StorageResult<()>;

--- a/crates/atomic-core/src/storage/traits.rs
+++ b/crates/atomic-core/src/storage/traits.rs
@@ -13,6 +13,7 @@ use crate::compaction::{CompactionResult, TagMerge};
 use crate::error::AtomicCoreError;
 use crate::models::AtomCluster;
 use crate::models::*;
+use crate::search::ScopeFilter;
 use crate::{CreateAtomRequest, ListAtomsParams, UpdateAtomRequest};
 
 /// Result type alias for storage operations.
@@ -598,8 +599,9 @@ pub trait ChunkStore: Send + Sync {
 #[async_trait]
 pub trait SearchStore: Send + Sync {
     /// Perform vector similarity search using embeddings.
-    /// `scope_tag_ids` restricts results to atoms tagged with any of those tags
-    /// or their descendants (OR semantics); empty means no scope filter.
+    /// `scope` restricts results to atoms satisfying its include/require/exclude
+    /// lists (see [`crate::search::ScopeFilter`]); an empty filter means no
+    /// scope filtering.
     /// `created_after` is an optional ISO 8601 cutoff — only atoms created at or after
     /// this timestamp are returned. `kinds` is non-defaulted so every caller
     /// declares whether finding atoms are in scope (the UI path passes
@@ -609,13 +611,13 @@ pub trait SearchStore: Send + Sync {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        scope_tag_ids: &[String],
+        scope: &ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>>;
 
     /// Perform keyword search using full-text search.
-    /// `scope_tag_ids` follows `vector_search`'s scope semantics.
+    /// `scope` follows `vector_search`'s scope semantics.
     /// `created_after` is an optional ISO 8601 cutoff — only atoms created at or after
     /// this timestamp are returned. `kinds` controls the atom-kind filter; see
     /// `vector_search` for the discipline.
@@ -623,7 +625,7 @@ pub trait SearchStore: Send + Sync {
         &self,
         query: &str,
         limit: i32,
-        scope_tag_ids: &[String],
+        scope: &ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<SemanticSearchResult>>;
@@ -642,7 +644,7 @@ pub trait SearchStore: Send + Sync {
         &self,
         query: &str,
         limit: i32,
-        scope_tag_ids: &[String],
+        scope: &ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<ChunkSearchResult>>;
@@ -654,7 +656,7 @@ pub trait SearchStore: Send + Sync {
         query_embedding: &[f32],
         limit: i32,
         threshold: f32,
-        scope_tag_ids: &[String],
+        scope: &ScopeFilter,
         created_after: Option<&str>,
         kinds: &crate::models::KindFilter,
     ) -> StorageResult<Vec<ChunkSearchResult>>;
@@ -703,14 +705,16 @@ pub trait ChatStore: Send + Sync {
     async fn set_conversation_scope(
         &self,
         conversation_id: &str,
-        tag_ids: &[String],
+        entries: &[ScopeEntry],
     ) -> StorageResult<ConversationWithTags>;
 
-    /// Add a tag to a conversation's scope.
+    /// Put a tag in a conversation's scope under `mode`. A tag already in
+    /// scope changes mode rather than erroring.
     async fn add_tag_to_scope(
         &self,
         conversation_id: &str,
         tag_id: &str,
+        mode: ScopeMode,
     ) -> StorageResult<ConversationWithTags>;
 
     /// Remove a tag from a conversation's scope.
@@ -742,11 +746,11 @@ pub trait ChatStore: Send + Sync {
         citations: &[ChatCitation],
     ) -> StorageResult<()>;
 
-    /// Get the tag IDs that scope a conversation.
-    async fn get_scope_tag_ids(&self, conversation_id: &str) -> StorageResult<Vec<String>>;
+    /// Get the retrieval scope for a conversation.
+    async fn get_conversation_scope(&self, conversation_id: &str) -> StorageResult<ScopeFilter>;
 
     /// Get a human-readable scope description for the system prompt.
-    async fn get_scope_description(&self, tag_ids: &[String]) -> StorageResult<String>;
+    async fn get_scope_description(&self, scope: &ScopeFilter) -> StorageResult<String>;
 }
 
 // ==================== Wiki Storage ====================

--- a/crates/atomic-core/src/wiki/agentic.rs
+++ b/crates/atomic-core/src/wiki/agentic.rs
@@ -131,7 +131,7 @@ async fn handle_search(
     rc: &mut ResearchContext,
     storage: &StorageBackend,
     provider_config: &crate::providers::ProviderConfig,
-    scope_tag_ids: &[String],
+    scope: &crate::search::ScopeFilter,
     args: &serde_json::Value,
 ) -> String {
     let query = args
@@ -158,7 +158,7 @@ async fn handle_search(
 
     // Perform hybrid search: keyword + vector, merged via RRF
     let keyword_results = match storage
-        .keyword_search_chunks_sync(&query, limit * 2, scope_tag_ids, None, &kinds)
+        .keyword_search_chunks_sync(&query, limit * 2, scope, None, &kinds)
         .await
     {
         Ok(r) => r,
@@ -176,7 +176,7 @@ async fn handle_search(
                             &embeddings[0],
                             limit * 2,
                             0.3,
-                            scope_tag_ids,
+                            scope,
                             None,
                             &kinds,
                         )
@@ -333,7 +333,7 @@ fn handle_done(rc: &ResearchContext) -> String {
 async fn run_research(
     rc: &mut ResearchContext,
     storage: &StorageBackend,
-    scope_tag_ids: &[String],
+    scope: &crate::search::ScopeFilter,
     provider_config: &crate::providers::ProviderConfig,
     model: &str,
     max_source_tokens: usize,
@@ -398,7 +398,7 @@ async fn run_research(
                 .unwrap_or(serde_json::json!({}));
 
             let result = match name {
-                "search" => handle_search(rc, storage, provider_config, scope_tag_ids, &args).await,
+                "search" => handle_search(rc, storage, provider_config, scope, &args).await,
                 "select" => handle_select(rc, &args, max_source_tokens),
                 "done" => {
                     research_done = true;
@@ -528,7 +528,7 @@ pub(crate) async fn generate(
     run_research(
         &mut rc,
         &ctx.storage,
-        &scope_tag_ids,
+        &crate::search::ScopeFilter::including(scope_tag_ids.clone()),
         &ctx.provider_config,
         &ctx.wiki_model,
         max_tokens,
@@ -613,7 +613,7 @@ pub(crate) async fn research_for_update(
     run_research(
         &mut rc,
         &ctx.storage,
-        &scope_tag_ids,
+        &crate::search::ScopeFilter::including(scope_tag_ids.clone()),
         &ctx.provider_config,
         &ctx.wiki_model,
         max_tokens,

--- a/crates/atomic-core/tests/chat_agent_tests.rs
+++ b/crates/atomic-core/tests/chat_agent_tests.rs
@@ -1,0 +1,418 @@
+//! Agent-loop contracts that only show up end to end: what the caller sees
+//! while a turn streams, and how a turn ends when it doesn't end cleanly.
+//!
+//! All three run against the wiremock provider (`support::MockAiServer`), so
+//! they exercise the real streaming parser and the real tool dispatch — no
+//! live provider, no timing races (cancellation is driven from an event
+//! callback, not a sleep).
+
+mod support;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use atomic_core::{AtomicCore, ChatEvent};
+use support::{setup_core, Backend, MockAiServer};
+
+/// Collect every `ChatEvent` the turn emits, and optionally react to one.
+fn chat_event_collector(
+    on_event: impl Fn(&ChatEvent) + Send + Sync + 'static,
+) -> (
+    impl Fn(ChatEvent) + Send + Sync + 'static,
+    Arc<Mutex<Vec<ChatEvent>>>,
+) {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&events);
+    let callback = move |event: ChatEvent| {
+        on_event(&event);
+        sink.lock().expect("event sink").push(event);
+    };
+    (callback, events)
+}
+
+fn stream_deltas(events: &Arc<Mutex<Vec<ChatEvent>>>) -> Vec<String> {
+    events
+        .lock()
+        .expect("event sink")
+        .iter()
+        .filter_map(|event| match event {
+            ChatEvent::StreamDelta { content, .. } => Some(content.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+async fn new_conversation(core: &AtomicCore) -> String {
+    core.create_conversation(&[], Some("agent loop"))
+        .await
+        .expect("create conversation")
+        .conversation
+        .id
+}
+
+/// A conversation the way the UI creates one: no title, so the first
+/// exchange triggers title generation.
+async fn untitled_conversation(core: &AtomicCore) -> String {
+    core.create_conversation(&[], None)
+        .await
+        .expect("create conversation")
+        .conversation
+        .id
+}
+
+async fn conversation_title(core: &AtomicCore, conversation_id: &str) -> Option<String> {
+    core.get_conversation(conversation_id)
+        .await
+        .expect("load conversation")
+        .expect("conversation exists")
+        .conversation
+        .title
+}
+
+/// Poll `condition` until it holds. Title generation is detached from the
+/// turn, so tests wait on its effect rather than on a handle.
+async fn wait_until<F, Fut>(what: &str, mut condition: F)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !condition().await {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for {what}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+/// Give a detached title task time to reach the provider, for assertions
+/// that something did *not* happen. The task only reads the conversation
+/// before deciding, so this is orders of magnitude more than it needs.
+async fn settle() {
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+}
+
+/// Deltas reach the caller as the provider produces them: several small
+/// chunks, each carrying only its own text, concatenating to the final
+/// message. The pre-0.1 behavior emitted one delta holding the whole
+/// iteration's text, which this catches.
+#[tokio::test]
+async fn stream_deltas_arrive_incrementally() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = new_conversation(&core).await;
+
+    let (callback, events) = chat_event_collector(|_| {});
+    let message = core
+        .send_chat_message(
+            &conversation_id,
+            "what did I write about pelicans?",
+            callback,
+            None,
+        )
+        .await
+        .expect("chat turn");
+
+    let deltas = stream_deltas(&events);
+    assert!(
+        deltas.len() > 1,
+        "expected one event per provider chunk, got {deltas:?}"
+    );
+    assert_eq!(
+        deltas.concat(),
+        message.message.content,
+        "deltas must concatenate to the final message, not repeat it"
+    );
+    for delta in &deltas {
+        assert!(
+            delta != &message.message.content,
+            "a delta carrying the whole message means accumulation leaked back in"
+        );
+    }
+}
+
+/// A model that never stops calling tools used to end the turn with
+/// `Err("Max iterations reached")` and throw the work away. Now the loop
+/// spends one tool-free call to get a real answer and labels it.
+#[tokio::test]
+async fn iteration_cap_salvages_an_answer() {
+    let mock = MockAiServer::start().await;
+    mock.set_chat_force_tool_calls(true);
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = new_conversation(&core).await;
+
+    let (callback, _events) = chat_event_collector(|event| {
+        assert!(
+            !matches!(event, ChatEvent::Error { .. }),
+            "hitting the cap is not an error path anymore"
+        );
+    });
+    let message = core
+        .send_chat_message(&conversation_id, "keep digging", callback, None)
+        .await
+        .expect("cap must salvage, not fail");
+
+    assert!(
+        message.message.content.contains("Mock assistant reply"),
+        "the tool-free salvage call supplies the answer: {:?}",
+        message.message.content
+    );
+    assert!(
+        message.message.content.contains("reached tool-call limit"),
+        "the answer is labelled incomplete: {:?}",
+        message.message.content
+    );
+    assert!(
+        !message.tool_calls.is_empty(),
+        "the tool calls made before the cap are still persisted"
+    );
+
+    // And the salvaged answer is what the conversation now holds.
+    let stored = core
+        .get_conversation(&conversation_id)
+        .await
+        .expect("load conversation")
+        .expect("conversation exists");
+    let last = stored.messages.last().expect("assistant message persisted");
+    assert_eq!(last.message.role, "assistant");
+    assert_eq!(last.message.content, message.message.content);
+}
+
+/// A provider failure has to reach the UI over the event stream, not just as
+/// the HTTP body of a request the client may never read.
+#[tokio::test]
+async fn provider_failure_emits_a_chat_error_event() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = new_conversation(&core).await;
+    mock.set_chat_failure(Some(atomic_test_support::InjectedFailure::Unauthorized));
+
+    let (callback, events) = chat_event_collector(|_| {});
+    let result = core
+        .send_chat_message(&conversation_id, "anything", callback, None)
+        .await;
+
+    assert!(result.is_err(), "a dead provider still fails the call");
+    let errors: Vec<String> = events
+        .lock()
+        .expect("event sink")
+        .iter()
+        .filter_map(|event| match event {
+            ChatEvent::Error { error, .. } => Some(error.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(errors.len(), 1, "exactly one error event: {errors:?}");
+}
+
+/// An untitled conversation names itself off its first exchange, and the
+/// title reaches the caller on the event stream — the list and the header
+/// both update without a refetch.
+#[tokio::test]
+async fn first_exchange_names_the_conversation() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = untitled_conversation(&core).await;
+
+    let (callback, events) = chat_event_collector(|_| {});
+    core.send_chat_message(
+        &conversation_id,
+        "what did I write about pelicans?",
+        callback,
+        None,
+    )
+    .await
+    .expect("chat turn");
+
+    wait_until("the generated title to be persisted", || async {
+        conversation_title(&core, &conversation_id).await.is_some()
+    })
+    .await;
+
+    // The mock answers with `"Notes About Pelicans."` — quotes and full stop
+    // included, both of which the sanitizer has to drop.
+    assert_eq!(
+        conversation_title(&core, &conversation_id).await.as_deref(),
+        Some("Notes About Pelicans")
+    );
+    assert_eq!(mock.title_request_count(), 1);
+
+    let titles: Vec<(String, String)> = events
+        .lock()
+        .expect("event sink")
+        .iter()
+        .filter_map(|event| match event {
+            ChatEvent::ConversationUpdated {
+                conversation_id,
+                title,
+            } => Some((conversation_id.clone(), title.clone())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        titles,
+        vec![(conversation_id.clone(), "Notes About Pelicans".to_string())],
+        "exactly one ConversationUpdated, carrying the sanitized title"
+    );
+}
+
+/// A title that already exists is the user's — whether we generated it last
+/// turn or they typed it. The second exchange must not spend a call, let
+/// alone overwrite it.
+#[tokio::test]
+async fn an_existing_title_is_never_regenerated() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = untitled_conversation(&core).await;
+
+    let (callback, _events) = chat_event_collector(|_| {});
+    core.send_chat_message(&conversation_id, "first question", callback, None)
+        .await
+        .expect("first turn");
+    wait_until("the generated title to be persisted", || async {
+        conversation_title(&core, &conversation_id).await.is_some()
+    })
+    .await;
+
+    // Rename it the way the UI does, then take another turn.
+    core.update_conversation(&conversation_id, Some("Renamed by hand"), None)
+        .await
+        .expect("rename conversation");
+
+    let (callback, _events) = chat_event_collector(|_| {});
+    core.send_chat_message(&conversation_id, "second question", callback, None)
+        .await
+        .expect("second turn");
+    settle().await;
+
+    assert_eq!(
+        conversation_title(&core, &conversation_id).await.as_deref(),
+        Some("Renamed by hand"),
+        "the manual rename survives the next exchange"
+    );
+    assert_eq!(
+        mock.title_request_count(),
+        1,
+        "the second turn asked the model for nothing"
+    );
+}
+
+/// Titles are a nicety; the message they describe is not. A title model that
+/// refuses costs the exchange nothing and leaves the conversation untitled.
+#[tokio::test]
+async fn a_failed_title_attempt_leaves_the_conversation_untitled() {
+    let mock = MockAiServer::start().await;
+    mock.set_title_failure(Some(atomic_test_support::InjectedFailure::Unauthorized));
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = untitled_conversation(&core).await;
+
+    let (callback, events) = chat_event_collector(|_| {});
+    let message = core
+        .send_chat_message(&conversation_id, "what about pelicans?", callback, None)
+        .await
+        .expect("the turn succeeds regardless of the title model");
+    assert!(message.message.content.contains("Mock assistant reply"));
+
+    wait_until("the title attempt to reach the provider", || async {
+        mock.title_request_count() >= 1
+    })
+    .await;
+
+    assert_eq!(
+        conversation_title(&core, &conversation_id).await,
+        None,
+        "a refused title leaves the column NULL, not a stub"
+    );
+    let stored = core
+        .get_conversation(&conversation_id)
+        .await
+        .expect("load conversation")
+        .expect("conversation exists");
+    assert_eq!(
+        stored.messages.len(),
+        2,
+        "both sides of the exchange are persisted"
+    );
+    assert!(
+        !events
+            .lock()
+            .expect("event sink")
+            .iter()
+            .any(|event| matches!(event, ChatEvent::ConversationUpdated { .. })),
+        "no title event without a title"
+    );
+}
+
+/// Stopping mid-turn returns the partial answer through the normal path —
+/// no error, no wedged conversation — and stops calling tools immediately.
+#[tokio::test]
+async fn cancelling_mid_turn_persists_the_partial_answer() {
+    let mock = MockAiServer::start().await;
+    // Without this the mock wraps up after one tool call and there is no
+    // mid-turn to cancel.
+    mock.set_chat_force_tool_calls(true);
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = new_conversation(&core).await;
+
+    let cancel: atomic_core::ChatCancel = Arc::new(AtomicBool::new(false));
+    let trigger = Arc::clone(&cancel);
+    // Cancel the moment the first tool starts — deterministic, unlike a timer.
+    let (callback, _events) = chat_event_collector(move |event| {
+        if matches!(event, ChatEvent::ToolStart { .. }) {
+            trigger.store(true, Ordering::Relaxed);
+        }
+    });
+
+    let message = core
+        .send_chat_message(&conversation_id, "keep digging", callback, Some(cancel))
+        .await
+        .expect("a stopped turn still returns its message");
+
+    assert!(
+        message.message.content.contains("*(stopped)*"),
+        "the partial answer is marked stopped: {:?}",
+        message.message.content
+    );
+    assert_eq!(
+        message.tool_calls.len(),
+        1,
+        "the loop stopped at its next checkpoint instead of running to the cap"
+    );
+
+    let stored = core
+        .get_conversation(&conversation_id)
+        .await
+        .expect("load conversation")
+        .expect("conversation exists");
+    assert_eq!(
+        stored
+            .messages
+            .last()
+            .expect("assistant message persisted")
+            .message
+            .content,
+        message.message.content,
+    );
+}

--- a/crates/atomic-core/tests/chat_agent_tests.rs
+++ b/crates/atomic-core/tests/chat_agent_tests.rs
@@ -18,7 +18,7 @@ use atomic_core::{
     ScopeMode,
 };
 use serde_json::json;
-use support::{await_pipeline, event_collector, setup_core, Backend, MockAiServer};
+use support::{await_pipeline, event_collector, open_bare, setup_core, Backend, MockAiServer};
 
 /// Collect every `ChatEvent` the turn emits, and optionally react to one.
 fn chat_event_collector(
@@ -934,5 +934,477 @@ async fn require_and_exclude_shape_what_search_returns() {
             && system_prompt.contains("every one of: Sailing")
             && system_prompt.contains("Draft"),
         "the scope paragraph names all three lists: {system_prompt}"
+    );
+}
+
+// ==================== Scope binds every reading tool ====================
+//
+// Search enforces the scope inside its query, so nothing outside can come
+// back. Every other reading tool takes an *id* and would otherwise fetch it
+// unconditionally — which would make the system prompt's "will never appear …
+// you cannot widen it" a suggestion the model can decline. These pin the
+// refusals, one tool at a time, and then the whole chain end to end.
+
+/// A knowledge base with a public tag and a private one, the private tag's
+/// atom carrying a wiki article, and a conversation that excludes it.
+struct ExcludedFixture {
+    handle: support::CoreHandle,
+    private_tag: atomic_core::Tag,
+    private_atom: String,
+    public_atom: String,
+    conversation_id: String,
+}
+
+async fn excluded_fixture(core_url: &str) -> ExcludedFixture {
+    let handle = setup_core(Backend::Sqlite, core_url)
+        .await
+        .expect("sqlite core");
+    let core = &handle.core;
+
+    let public = core.create_tag("Pelicans", None).await.expect("public tag");
+    let private = core.create_tag("Therapy", None).await.expect("private tag");
+    let public_atom = seed_atom(core, "pelicans dive for fish", &[public.id.as_str()]).await;
+    let private_atom = seed_atom(
+        core,
+        "pelicans came up in a private session",
+        &[private.id.as_str()],
+    )
+    .await;
+    core.generate_wiki(&private.id, &private.name)
+        .await
+        .expect("generate the excluded tag's article");
+
+    let conversation_id = core
+        .create_conversation(&[], Some("scoped"))
+        .await
+        .expect("create conversation")
+        .conversation
+        .id;
+    core.add_tag_to_scope(&conversation_id, &private.id, ScopeMode::Exclude)
+        .await
+        .expect("exclude the private tag");
+
+    ExcludedFixture {
+        handle,
+        private_tag: private,
+        private_atom,
+        public_atom,
+        conversation_id,
+    }
+}
+
+/// Run one turn that calls `tool` with `args`, and return what the tool told
+/// the model.
+async fn tool_call_output(
+    core: &AtomicCore,
+    mock: &MockAiServer,
+    conversation_id: &str,
+    tool: &str,
+    args: serde_json::Value,
+) -> ChatMessageWithContext {
+    mock.set_chat_tool_call(Some((tool, args)));
+    let (callback, _events) = chat_event_collector(|_| {});
+    core.send_chat_message(conversation_id, "tell me about it", callback, None)
+        .await
+        .expect("chat turn")
+}
+
+/// The end-to-end bypass the four read tools opened: name an excluded tag in
+/// the prompt, read its article, walk its atoms. Every door is shut, and none
+/// of them leaks the content while shutting.
+#[tokio::test]
+async fn an_excluded_tag_cannot_be_read_through_any_tool() {
+    let mock = MockAiServer::start().await;
+    let fixture = excluded_fixture(&mock.base_url()).await;
+    let core = &fixture.handle.core;
+    let conversation_id = fixture.conversation_id.as_str();
+
+    // 1. The article. The densest read in the knowledge base, and the one the
+    //    exclude mode was most obviously bypassed by.
+    let wiki = tool_call_output(
+        core,
+        &mock,
+        conversation_id,
+        "get_wiki",
+        json!({ "tag": fixture.private_tag.name }),
+    )
+    .await;
+    let output = tool_output(&wiki);
+    assert!(
+        output.contains("outside this conversation's scope"),
+        "the article is refused, and the refusal says why: {output}"
+    );
+    assert!(
+        !output.contains("mock article body"),
+        "no part of the article reaches the model: {output}"
+    );
+    assert!(
+        wiki.citations.is_empty(),
+        "a refused read is not evidence: {:?}",
+        wiki.citations
+    );
+
+    // 2. The atom behind it, by id — the fallback once the article is shut.
+    let atom = tool_call_output(
+        core,
+        &mock,
+        conversation_id,
+        "get_atom",
+        json!({ "atom_id": fixture.private_atom }),
+    )
+    .await;
+    let output = tool_output(&atom);
+    assert!(
+        output.contains("outside this conversation's scope"),
+        "reading the excluded atom by id is refused: {output}"
+    );
+    assert!(
+        !output.contains("private session"),
+        "no content leaks with the refusal: {output}"
+    );
+    assert!(atom.citations.is_empty(), "and nothing became citable");
+
+    // 3. The tag tree, which is how the model would find either of them.
+    let tags = tool_call_output(core, &mock, conversation_id, "list_tags", json!({})).await;
+    let output = tool_output(&tags);
+    assert!(
+        !output.contains(&fixture.private_tag.name) && !output.contains(&fixture.private_tag.id),
+        "the excluded branch is not on the map: {output}"
+    );
+    assert!(
+        output.contains("Pelicans"),
+        "the rest of the tree still is: {output}"
+    );
+
+    // 4. Expanding the excluded branch by id, in case the model already knows it.
+    let expanded = tool_call_output(
+        core,
+        &mock,
+        conversation_id,
+        "list_tags",
+        json!({ "parent_id": fixture.private_tag.id }),
+    )
+    .await;
+    assert!(
+        tool_output(&expanded).contains("outside this conversation's scope"),
+        "an excluded branch cannot be expanded: {}",
+        tool_output(&expanded)
+    );
+
+    // And the atom that *is* in scope still reads normally — the scope closed
+    // a door, it didn't brick the tools.
+    let allowed = tool_call_output(
+        core,
+        &mock,
+        conversation_id,
+        "get_atom",
+        json!({ "atom_id": fixture.public_atom }),
+    )
+    .await;
+    assert!(
+        tool_output(&allowed).contains("dive for fish"),
+        "in-scope atoms read as before: {}",
+        tool_output(&allowed)
+    );
+    assert_eq!(
+        allowed.citations.len(),
+        1,
+        "and are citable: {:?}",
+        allowed.citations
+    );
+}
+
+/// An include scope is the other half: the listing narrows to what was
+/// included (plus the ancestors it hangs from), and an article outside it is
+/// refused even though nothing was explicitly excluded.
+#[tokio::test]
+async fn an_include_scope_hides_the_rest_of_the_tree() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let birds = core.create_tag("Birds", None).await.expect("Birds");
+    let pelicans = core
+        .create_tag("Pelicans", Some(&birds.id))
+        .await
+        .expect("Pelicans");
+    let finance = core.create_tag("Finance", None).await.expect("Finance");
+    seed_atom(&core, "pelicans dive for fish", &[pelicans.id.as_str()]).await;
+    seed_atom(&core, "pelicans of the balance sheet", &[finance.id.as_str()]).await;
+    core.generate_wiki(&finance.id, &finance.name)
+        .await
+        .expect("generate the out-of-scope article");
+
+    let conversation_id = core
+        .create_conversation(&[pelicans.id.clone()], Some("included"))
+        .await
+        .expect("create conversation")
+        .conversation
+        .id;
+
+    let tags = tool_call_output(&core, &mock, &conversation_id, "list_tags", json!({})).await;
+    let output = tool_output(&tags);
+    assert!(
+        output.contains("Pelicans") && output.contains("Birds"),
+        "the included branch shows, with the ancestor it hangs from: {output}"
+    );
+    assert!(
+        !output.contains("Finance"),
+        "nothing outside the include scope does: {output}"
+    );
+
+    let wiki = tool_call_output(
+        &core,
+        &mock,
+        &conversation_id,
+        "get_wiki",
+        json!({ "tag": "Finance" }),
+    )
+    .await;
+    assert!(
+        tool_output(&wiki).contains("outside this conversation's scope"),
+        "an article outside the include scope is refused: {}",
+        tool_output(&wiki)
+    );
+}
+
+/// Reports are configuration; their findings are content. A report whose
+/// finding the conversation can't read stays on the menu — with nothing on it
+/// that would let the model order the dish.
+#[tokio::test]
+async fn list_reports_withholds_a_finding_the_scope_excludes() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let tag = core.create_tag("Therapy", None).await.expect("create tag");
+    seed_atom(&core, "pelicans came up in session", &[tag.id.as_str()]).await;
+    let report = core
+        .create_report(CreateReportRequest {
+            name: "Session Notes".to_string(),
+            research_prompt: "Summarize the sessions.".to_string(),
+            source_scope_tag_ids: vec![tag.id.clone()],
+            schedule: "0 0 * * * *".to_string(),
+            // The finding lands under the excluded tag, which is what puts it
+            // outside this conversation.
+            output_atom_tags: vec![tag.id.clone()],
+            ..Default::default()
+        })
+        .await
+        .expect("create report");
+    let finding_atom_id = match core.run_report_now(&report.id).await.expect("run report") {
+        RunOutcome::Succeeded { finding_atom_id } => finding_atom_id,
+        other => panic!("expected a finding, got {other:?}"),
+    };
+
+    let conversation_id = core
+        .create_conversation(&[], Some("scoped"))
+        .await
+        .expect("create conversation")
+        .conversation
+        .id;
+    core.add_tag_to_scope(&conversation_id, &tag.id, ScopeMode::Exclude)
+        .await
+        .expect("exclude the tag");
+
+    let listing = tool_call_output(&core, &mock, &conversation_id, "list_reports", json!({})).await;
+    let output = tool_output(&listing);
+    assert!(
+        output.contains("Session Notes (report_id:"),
+        "the report itself is still listed: {output}"
+    );
+    assert!(
+        output.contains("latest finding: outside this conversation's scope"),
+        "but its finding is withheld, and says so: {output}"
+    );
+    assert!(
+        !output.contains(&finding_atom_id),
+        "the finding's id is not handed over either: {output}"
+    );
+
+    let read = tool_call_output(
+        &core,
+        &mock,
+        &conversation_id,
+        "get_finding",
+        json!({ "atom_id": finding_atom_id }),
+    )
+    .await;
+    let output = tool_output(&read);
+    assert!(
+        output.contains("outside this conversation's scope"),
+        "and reading it by id is refused: {output}"
+    );
+    assert!(
+        !output.contains("Mock Finding"),
+        "with none of its body: {output}"
+    );
+    assert!(read.citations.is_empty(), "and nothing became citable");
+}
+
+// ==================== Which model each leg rides ====================
+//
+// A chat turn spends on two different models: the agentic one that runs the
+// loop, and — after the turn — the cheap utility one that names the
+// conversation (`chat_title`: "naming a conversation is a cheap utility
+// completion ... and shouldn't bill at agentic-model rates"). Only
+// OpenRouter *has* two models to choose between; Ollama and OpenAI-compat
+// expose a single LLM that both legs must land on. The resolution therefore
+// reads differently per provider and is worth pinning per provider — a
+// regression here is invisible in behavior and visible only on the bill.
+
+/// The `model` on the conversation-title completion. The title leg is a
+/// plain, tool-free completion whose system prompt asks for "a conversation
+/// title"; that phrase is how the mock recognizes it too.
+fn title_request_model(mock: &MockAiServer) -> Option<String> {
+    mock.chat_request_bodies()
+        .into_iter()
+        .find(|body| {
+            body["messages"]
+                .as_array()
+                .is_some_and(|messages| {
+                    messages.iter().any(|message| {
+                        message["content"]
+                            .as_str()
+                            .is_some_and(|content| content.contains("conversation title"))
+                    })
+                })
+        })
+        .and_then(|body| body["model"].as_str().map(str::to_string))
+}
+
+/// The `model` on every streaming leg — the agent loop's own turns.
+fn chat_turn_models(mock: &MockAiServer) -> Vec<String> {
+    mock.chat_request_bodies()
+        .into_iter()
+        .filter(|body| body["stream"].as_bool().unwrap_or(false))
+        .filter_map(|body| body["model"].as_str().map(str::to_string))
+        .collect()
+}
+
+/// Run one untitled exchange and wait for the detached title task to land,
+/// so both legs' requests are on the mock by the time a test inspects them.
+/// `list_tags` keeps the turn off the search path, which would otherwise
+/// need an embedding in whatever space the provider under test declares.
+async fn one_titled_exchange(core: &AtomicCore, mock: &MockAiServer) {
+    mock.set_chat_tool_call(Some(("list_tags", json!({}))));
+    let conversation_id = untitled_conversation(core).await;
+    let (callback, _events) = chat_event_collector(|_| {});
+    core.send_chat_message(&conversation_id, "what do I know?", callback, None)
+        .await
+        .expect("chat turn");
+    wait_until("the generated title to be persisted", || async {
+        conversation_title(core, &conversation_id).await.is_some()
+    })
+    .await;
+}
+
+/// OpenRouter is the only provider with a tagging/agentic split, and the
+/// title has to take the cheap side of it: the loop rides `chat_model`, the
+/// title rides `tagging_model`. Swapping them would silently bill every new
+/// conversation's name at agentic rates.
+#[tokio::test]
+async fn openrouter_titles_ride_the_tagging_model_not_the_chat_model() {
+    let mock = MockAiServer::start().await;
+    let handle = open_bare(Backend::Sqlite).await.expect("sqlite core");
+    let core = handle.core;
+    for (key, value) in [
+        ("provider", "openrouter"),
+        ("openrouter_api_key", "mock-openrouter-key"),
+        // Bare URL: the provider normalizes `/v1` on itself.
+        ("openrouter_base_url", mock.base_url().as_str()),
+        ("tagging_model", "mock-tagging"),
+        ("chat_model", "mock-agentic"),
+    ] {
+        core.set_setting(key, value).await.expect("seed setting");
+    }
+
+    one_titled_exchange(&core, &mock).await;
+
+    let turns = chat_turn_models(&mock);
+    assert!(!turns.is_empty(), "the agent loop should have streamed");
+    for model in &turns {
+        assert_eq!(
+            model, "mock-agentic",
+            "the agent loop rides chat_model: {turns:?}"
+        );
+    }
+    assert_eq!(
+        title_request_model(&mock).as_deref(),
+        Some("mock-tagging"),
+        "the title rides tagging_model, not the agentic model"
+    );
+}
+
+/// Ollama exposes one LLM, so both legs land on `ollama_llm_model` — and
+/// the OpenRouter-only `chat_model` / `tagging_model` keys must not reroute
+/// either leg, even when they are set.
+#[tokio::test]
+async fn ollama_titles_ride_its_single_llm_model() {
+    let mock = MockAiServer::start().await;
+    let handle = open_bare(Backend::Sqlite).await.expect("sqlite core");
+    let core = handle.core;
+    for (key, value) in [
+        ("provider", "ollama"),
+        ("ollama_host", mock.base_url().as_str()),
+        ("ollama_llm_model", "mock-ollama-llm"),
+        // Residue from a previous OpenRouter configuration. Inert here.
+        ("tagging_model", "frontier/tagging"),
+        ("chat_model", "frontier/agentic"),
+    ] {
+        core.set_setting(key, value).await.expect("seed setting");
+    }
+
+    one_titled_exchange(&core, &mock).await;
+
+    let turns = chat_turn_models(&mock);
+    assert!(!turns.is_empty(), "the agent loop should have streamed");
+    for model in &turns {
+        assert_eq!(
+            model, "mock-ollama-llm",
+            "the loop rides Ollama's single LLM: {turns:?}"
+        );
+    }
+    assert_eq!(
+        title_request_model(&mock).as_deref(),
+        Some("mock-ollama-llm"),
+        "the title rides the same single LLM"
+    );
+}
+
+/// Same contract for OpenAI-compat: one configured LLM serves both legs and
+/// the OpenRouter model keys are ignored.
+#[tokio::test]
+async fn openai_compat_titles_ride_its_single_llm_model() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    for (key, value) in [
+        ("tagging_model", "frontier/tagging"),
+        ("chat_model", "frontier/agentic"),
+    ] {
+        core.set_setting(key, value).await.expect("seed setting");
+    }
+
+    one_titled_exchange(&core, &mock).await;
+
+    let turns = chat_turn_models(&mock);
+    assert!(!turns.is_empty(), "the agent loop should have streamed");
+    for model in &turns {
+        assert_eq!(
+            model, "mock-llm",
+            "the loop rides openai_compat_llm_model: {turns:?}"
+        );
+    }
+    assert_eq!(
+        title_request_model(&mock).as_deref(),
+        Some("mock-llm"),
+        "the title rides the same single LLM"
     );
 }

--- a/crates/atomic-core/tests/chat_agent_tests.rs
+++ b/crates/atomic-core/tests/chat_agent_tests.rs
@@ -1,8 +1,9 @@
 //! Agent-loop contracts that only show up end to end: what the caller sees
-//! while a turn streams, and how a turn ends when it doesn't end cleanly.
+//! while a turn streams, how a turn ends when it doesn't end cleanly, and
+//! which sources survive into the stored message.
 //!
-//! All three run against the wiremock provider (`support::MockAiServer`), so
-//! they exercise the real streaming parser and the real tool dispatch — no
+//! They all run against the wiremock provider (`support::MockAiServer`), so
+//! they exercise the real streaming parser and the real tool registry — no
 //! live provider, no timing races (cancellation is driven from an event
 //! callback, not a sleep).
 
@@ -11,8 +12,13 @@ mod support;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use atomic_core::{AtomicCore, ChatEvent};
-use support::{setup_core, Backend, MockAiServer};
+use atomic_core::reports::RunOutcome;
+use atomic_core::{
+    AtomicCore, ChatEvent, ChatMessageWithContext, CreateAtomRequest, CreateReportRequest,
+    ScopeMode,
+};
+use serde_json::json;
+use support::{await_pipeline, event_collector, setup_core, Backend, MockAiServer};
 
 /// Collect every `ChatEvent` the turn emits, and optionally react to one.
 fn chat_event_collector(
@@ -39,6 +45,52 @@ fn stream_deltas(events: &Arc<Mutex<Vec<ChatEvent>>>) -> Vec<String> {
             ChatEvent::StreamDelta { content, .. } => Some(content.clone()),
             _ => None,
         })
+        .collect()
+}
+
+/// Create an atom and wait for its pipeline, so the agent's search tool can
+/// actually find it.
+async fn seed_atom(core: &AtomicCore, content: &str, tag_ids: &[&str]) -> String {
+    let (callback, mut events) = event_collector();
+    let atom = core
+        .create_atom(
+            CreateAtomRequest {
+                content: content.to_string(),
+                tag_ids: tag_ids.iter().map(|id| id.to_string()).collect(),
+                ..Default::default()
+            },
+            callback,
+        )
+        .await
+        .expect("create atom")
+        .expect("atom was inserted");
+    await_pipeline(core, &mut events, &atom.atom.id).await;
+    atom.atom.id
+}
+
+/// What the turn's single tool call returned — the text the model was shown
+/// and the UI's tool card renders.
+fn tool_output(message: &ChatMessageWithContext) -> String {
+    message
+        .tool_calls
+        .first()
+        .expect("the turn called a tool")
+        .tool_output
+        .as_ref()
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// The tool names offered to the model on its first turn.
+fn offered_tools(mock: &MockAiServer) -> Vec<String> {
+    let bodies = mock.chat_request_bodies();
+    let first = bodies.first().expect("at least one chat request");
+    first["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|tool| tool["function"]["name"].as_str().map(str::to_string))
         .collect()
 }
 
@@ -362,6 +414,156 @@ async fn a_failed_title_attempt_leaves_the_conversation_untitled() {
     );
 }
 
+/// Sources are what an answer rests on, not a log of what the agent read.
+/// The search tool surfaces three atoms; the answer cites one; one citation
+/// is stored, under the number the answer actually wrote.
+#[tokio::test]
+async fn only_cited_sources_are_stored() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let mut seeded = Vec::new();
+    for content in [
+        "pelicans dive for fish along the coast",
+        "pelicans nest in large colonies on islands",
+        "pelicans carry water in enormous throat pouches",
+    ] {
+        seeded.push(seed_atom(&core, content, &[]).await);
+    }
+    let conversation_id = new_conversation(&core).await;
+
+    let (callback, events) = chat_event_collector(|_| {});
+    let message = core
+        .send_chat_message(&conversation_id, "pelicans", callback, None)
+        .await
+        .expect("chat turn");
+
+    let touched = events
+        .lock()
+        .expect("event sink")
+        .iter()
+        .find_map(|event| match event {
+            ChatEvent::ToolComplete { results_count, .. } => Some(*results_count),
+            _ => None,
+        })
+        .expect("the search tool ran");
+    assert_eq!(touched, 3, "the agent saw all three atoms");
+
+    // The mock's answer cites `[1]` and nothing else.
+    assert_eq!(
+        message.citations.len(),
+        1,
+        "uncited sources leave no rows: {:?}",
+        message.citations
+    );
+    assert_eq!(
+        message.citations[0].citation_index, 1,
+        "the stored index is the marker the answer wrote"
+    );
+    assert!(
+        seeded.contains(&message.citations[0].atom_id),
+        "the citation resolves to a seeded atom; got {:?}",
+        message.citations[0].atom_id
+    );
+
+    let stored = core
+        .get_conversation(&conversation_id)
+        .await
+        .expect("load conversation")
+        .expect("conversation exists");
+    assert_eq!(
+        stored
+            .messages
+            .last()
+            .expect("assistant message persisted")
+            .citations
+            .len(),
+        1,
+        "persistence agrees with the returned message"
+    );
+}
+
+/// A tool that fails says so on the event stream and in the persisted call,
+/// and the error text still reaches the model so it can recover.
+#[tokio::test]
+async fn a_failing_tool_reports_failure_and_tells_the_model() {
+    let mock = MockAiServer::start().await;
+    // An atom with no content is the cheapest deterministic tool failure.
+    mock.set_chat_tool_call(Some(("create_atom", json!({ "content": "   " }))));
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = new_conversation(&core).await;
+
+    let (callback, events) = chat_event_collector(|_| {});
+    let message = core
+        .send_chat_message(&conversation_id, "save this for me", callback, None)
+        .await
+        .expect("a failed tool does not fail the turn");
+
+    let failures: Vec<bool> = events
+        .lock()
+        .expect("event sink")
+        .iter()
+        .filter_map(|event| match event {
+            ChatEvent::ToolComplete { failed, .. } => Some(*failed),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(failures, vec![true], "the failure is live, not post-hoc");
+
+    let call = message.tool_calls.first().expect("the call is persisted");
+    assert_eq!(call.status, "failed");
+    let output = call
+        .tool_output
+        .as_ref()
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    assert!(
+        output.contains("Cannot create an empty atom"),
+        "the model is told what went wrong: {output:?}"
+    );
+    assert!(
+        message.message.content.contains("Mock assistant reply"),
+        "the turn still answers"
+    );
+}
+
+/// A tool this build doesn't register is a failed call, not an empty result
+/// the model might mistake for "nothing found".
+#[tokio::test]
+async fn a_tool_outside_the_registry_fails_the_call() {
+    let mock = MockAiServer::start().await;
+    mock.set_chat_tool_call(Some(("delete_everything", json!({}))));
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = new_conversation(&core).await;
+
+    let (callback, _events) = chat_event_collector(|_| {});
+    let message = core
+        .send_chat_message(&conversation_id, "do something drastic", callback, None)
+        .await
+        .expect("an unknown tool does not fail the turn");
+
+    let call = message.tool_calls.first().expect("the call is persisted");
+    assert_eq!(call.status, "failed");
+    assert!(
+        call.tool_output
+            .as_ref()
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .contains("Unknown tool: delete_everything"),
+        "the model learns the tool does not exist: {:?}",
+        call.tool_output
+    );
+}
+
 /// Stopping mid-turn returns the partial answer through the normal path —
 /// no error, no wedged conversation — and stops calling tools immediately.
 #[tokio::test]
@@ -414,5 +616,323 @@ async fn cancelling_mid_turn_persists_the_partial_answer() {
             .message
             .content,
         message.message.content,
+    );
+}
+
+// ==================== Knowledge-base structure tools ====================
+
+/// Everything the agent needs to reason about the knowledge base's shape —
+/// not just its atoms — is registered on every turn, with no context or
+/// caller opt-in required.
+#[tokio::test]
+async fn structure_tools_are_offered_on_every_turn() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+    let conversation_id = new_conversation(&core).await;
+
+    let (callback, _events) = chat_event_collector(|_| {});
+    core.send_chat_message(&conversation_id, "what do I know?", callback, None)
+        .await
+        .expect("chat turn");
+
+    let offered = offered_tools(&mock);
+    for tool in ["list_tags", "get_wiki", "list_reports", "get_finding"] {
+        assert!(
+            offered.contains(&tool.to_string()),
+            "{tool} must be callable; got {offered:?}"
+        );
+    }
+}
+
+/// `list_tags` answers "how is this knowledge base organized?": the tree,
+/// with ids to drill in by and counts that include sub-tags. A tag is not a
+/// source, so nothing it surfaces becomes citable.
+#[tokio::test]
+async fn list_tags_renders_the_tree_with_counts_and_ids() {
+    let mock = MockAiServer::start().await;
+    mock.set_chat_tool_call(Some(("list_tags", json!({}))));
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let parent = core.create_tag("Birds", None).await.expect("create parent");
+    let child = core
+        .create_tag("Pelicans", Some(&parent.id))
+        .await
+        .expect("create child");
+    seed_atom(&core, "pelicans dive for fish", &[child.id.as_str()]).await;
+
+    let conversation_id = new_conversation(&core).await;
+    let (callback, _events) = chat_event_collector(|_| {});
+    let message = core
+        .send_chat_message(&conversation_id, "how is this organized?", callback, None)
+        .await
+        .expect("chat turn");
+
+    let output = tool_output(&message);
+    assert!(
+        output.contains(&format!("Birds (1 atom, tag_id: {})", parent.id)),
+        "parents carry their descendants' atoms in the count: {output}"
+    );
+    assert!(
+        output.contains(&format!("Pelicans (1 atom, tag_id: {})", child.id)),
+        "children are rendered under their parent: {output}"
+    );
+    assert!(
+        message.citations.is_empty(),
+        "tags are navigation, not sources: {:?}",
+        message.citations
+    );
+}
+
+/// A wiki article is a first-class source: reading one makes it citable, and
+/// the answer's `[N]` stores a citation that points at the tag — with the
+/// tag's name resolved, so the UI can open the article.
+#[tokio::test]
+async fn a_cited_wiki_article_is_stored_as_a_wiki_source() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let tag = core.create_tag("Pelicans", None).await.expect("create tag");
+    seed_atom(&core, "pelicans dive for fish", &[tag.id.as_str()]).await;
+    core.generate_wiki(&tag.id, &tag.name)
+        .await
+        .expect("generate wiki article");
+
+    // Resolution is exact-then-case-insensitive, and the model rarely
+    // matches the user's capitalization.
+    mock.set_chat_tool_call(Some(("get_wiki", json!({ "tag": "pelicans" }))));
+    let conversation_id = new_conversation(&core).await;
+    let (callback, _events) = chat_event_collector(|_| {});
+    let message = core
+        .send_chat_message(&conversation_id, "summarize pelicans", callback, None)
+        .await
+        .expect("chat turn");
+
+    let output = tool_output(&message);
+    assert!(
+        output.starts_with(&format!(
+            "[1] (wiki article for tag: Pelicans, tag_id: {}",
+            tag.id
+        )),
+        "the model is shown the number it must cite: {output}"
+    );
+    assert!(
+        !output.contains("mock article body. ["),
+        "the article's own citation markers are stripped — they number a \
+         different source list: {output}"
+    );
+
+    let citation = match message.citations.as_slice() {
+        [citation] => citation,
+        other => panic!("expected exactly the cited wiki article, got {other:?}"),
+    };
+    assert_eq!(citation.source_type, "wiki");
+    assert_eq!(
+        citation.atom_id, tag.id,
+        "a wiki citation points at its tag"
+    );
+    assert_eq!(citation.citation_index, 1);
+    assert_eq!(citation.source_title.as_deref(), Some("Pelicans"));
+
+    // And it survives the round trip, name included — the read path joins
+    // the tag rather than trusting a stored copy.
+    let stored = core
+        .get_conversation(&conversation_id)
+        .await
+        .expect("load conversation")
+        .expect("conversation exists");
+    let reloaded = stored
+        .messages
+        .last()
+        .expect("assistant message persisted")
+        .citations
+        .first()
+        .expect("the citation persisted")
+        .clone();
+    assert_eq!(reloaded.source_type, "wiki");
+    assert_eq!(reloaded.atom_id, tag.id);
+    assert_eq!(reloaded.source_title.as_deref(), Some("Pelicans"));
+}
+
+/// Reports are the other synthesized surface: the agent can see what
+/// research already ran and read a finding, and citing one stores a citation
+/// the finding reader can open.
+#[tokio::test]
+async fn reports_are_listable_and_a_cited_finding_is_stored_as_a_finding_source() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let tag = core
+        .create_tag("ReportScope", None)
+        .await
+        .expect("create tag");
+    seed_atom(&core, "pelicans dive for fish", &[tag.id.as_str()]).await;
+    let report = core
+        .create_report(CreateReportRequest {
+            name: "Pelican Watch".to_string(),
+            research_prompt: "Summarize what is known about pelicans.".to_string(),
+            source_scope_tag_ids: vec![tag.id.clone()],
+            schedule: "0 0 * * * *".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("create report");
+    let finding_atom_id = match core.run_report_now(&report.id).await.expect("run report") {
+        RunOutcome::Succeeded { finding_atom_id } => finding_atom_id,
+        other => panic!("expected a finding, got {other:?}"),
+    };
+
+    // list_reports is the menu…
+    mock.set_chat_tool_call(Some(("list_reports", json!({}))));
+    let conversation_id = new_conversation(&core).await;
+    let (callback, _events) = chat_event_collector(|_| {});
+    let listing = core
+        .send_chat_message(&conversation_id, "what research runs?", callback, None)
+        .await
+        .expect("chat turn");
+
+    let output = tool_output(&listing);
+    assert!(
+        output.contains(&format!("Pelican Watch (report_id: {}", report.id)),
+        "reports are listed with the id get_finding needs: {output}"
+    );
+    assert!(
+        output.contains("latest finding: ") && output.contains(&finding_atom_id),
+        "each report carries its most recent finding: {output}"
+    );
+    assert!(
+        listing.citations.is_empty(),
+        "a listing is not evidence: {:?}",
+        listing.citations
+    );
+
+    // …and get_finding is the read, which is citable.
+    mock.set_chat_tool_call(Some(("get_finding", json!({ "atom_id": finding_atom_id }))));
+    let (callback, _events) = chat_event_collector(|_| {});
+    let read = core
+        .send_chat_message(&conversation_id, "what did it find?", callback, None)
+        .await
+        .expect("chat turn");
+
+    let output = tool_output(&read);
+    assert!(
+        output.starts_with("[1] (finding from report: Pelican Watch"),
+        "the finding's provenance leads its content: {output}"
+    );
+
+    let citation = match read.citations.as_slice() {
+        [citation] => citation,
+        other => panic!("expected exactly the cited finding, got {other:?}"),
+    };
+    assert_eq!(citation.source_type, "finding");
+    assert_eq!(citation.atom_id, finding_atom_id);
+    assert_eq!(
+        citation.source_title, None,
+        "a finding names itself from its own atom"
+    );
+}
+
+/// Boolean scope is enforced where retrieval happens, not by asking the model
+/// nicely: a conversation that includes one tag, requires a second and
+/// excludes a third only ever sees the atom that satisfies all three.
+#[tokio::test]
+async fn require_and_exclude_shape_what_search_returns() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let rust = core.create_tag("Rust", None).await.expect("create Rust");
+    let sailing = core
+        .create_tag("Sailing", None)
+        .await
+        .expect("create Sailing");
+    let draft = core.create_tag("Draft", None).await.expect("create Draft");
+
+    let in_scope = seed_atom(
+        &core,
+        "pelicans satisfy every scope tag",
+        &[rust.id.as_str(), sailing.id.as_str()],
+    )
+    .await;
+    seed_atom(&core, "pelicans miss the required tag", &[rust.id.as_str()]).await;
+    seed_atom(
+        &core,
+        "pelicans carry the excluded tag",
+        &[rust.id.as_str(), sailing.id.as_str(), draft.id.as_str()],
+    )
+    .await;
+
+    let conversation_id = core
+        .create_conversation(&[rust.id.clone()], Some("boolean scope"))
+        .await
+        .expect("create conversation")
+        .conversation
+        .id;
+    core.add_tag_to_scope(&conversation_id, &sailing.id, ScopeMode::Require)
+        .await
+        .expect("require Sailing");
+    core.add_tag_to_scope(&conversation_id, &draft.id, ScopeMode::Exclude)
+        .await
+        .expect("exclude Draft");
+
+    let (callback, events) = chat_event_collector(|_| {});
+    let message = core
+        .send_chat_message(&conversation_id, "pelicans", callback, None)
+        .await
+        .expect("chat turn");
+
+    let results = events
+        .lock()
+        .expect("event sink")
+        .iter()
+        .find_map(|event| match event {
+            ChatEvent::ToolComplete { results_count, .. } => Some(*results_count),
+            _ => None,
+        })
+        .expect("the search tool ran");
+    assert_eq!(
+        results, 1,
+        "only the atom passing include + require + exclude reaches the model"
+    );
+
+    let output = tool_output(&message);
+    assert!(
+        output.contains(&in_scope),
+        "the surviving result is the atom that satisfies the whole scope: {output}"
+    );
+    assert!(
+        !output.contains("required tag") && !output.contains("excluded tag"),
+        "atoms outside the scope never reach the model: {output}"
+    );
+
+    // The prompt tells the model the same contract retrieval enforces.
+    // Seeding atoms also hits the provider for auto-tagging; only the chat
+    // turn offers tools.
+    let system_prompt = mock
+        .chat_request_bodies()
+        .into_iter()
+        .find(|body| body["tools"].as_array().is_some_and(|t| !t.is_empty()))
+        .expect("a chat turn request")["messages"][0]["content"]
+        .as_str()
+        .expect("system prompt")
+        .to_string();
+    assert!(
+        system_prompt.contains("any of: Rust")
+            && system_prompt.contains("every one of: Sailing")
+            && system_prompt.contains("Draft"),
+        "the scope paragraph names all three lists: {system_prompt}"
     );
 }

--- a/crates/atomic-core/tests/integration_tests.rs
+++ b/crates/atomic-core/tests/integration_tests.rs
@@ -267,7 +267,7 @@ async fn test_conversation_lifecycle() {
     assert_eq!(conv.tags.len(), 1);
 
     // List conversations
-    let convs = core.get_conversations(None, 10, 0).await.unwrap();
+    let convs = core.get_conversations(None, 10, 0, false).await.unwrap();
     assert_eq!(convs.len(), 1);
 
     // Update title
@@ -443,7 +443,7 @@ async fn test_empty_database_queries() {
     assert_eq!(page.total_count, 0);
     assert!(core.get_source_list().await.unwrap().is_empty());
     assert!(core
-        .get_conversations(None, 10, 0)
+        .get_conversations(None, 10, 0, false)
         .await
         .unwrap()
         .is_empty());

--- a/crates/atomic-core/tests/provider_injection_tests.rs
+++ b/crates/atomic-core/tests/provider_injection_tests.rs
@@ -269,6 +269,7 @@ async fn explicit_config_pins_per_task_models_sqlite() {
         &conversation.conversation.id,
         "what do my notes say about explicit configs?",
         |_| {},
+        None,
     )
     .await
     .expect("chat through the explicit config");

--- a/crates/atomic-core/tests/report_agent_tests.rs
+++ b/crates/atomic-core/tests/report_agent_tests.rs
@@ -1,0 +1,296 @@
+//! Report-run contracts that only show up end to end: which tools the
+//! research loop actually executes, what the final pass is handed, how a run
+//! ends, and which numbered sources survive into the stored finding.
+//!
+//! They run against the wiremock provider (`support::MockAiServer`), whose
+//! non-streaming tool leg is scripted per turn (`set_research_tool_rounds`),
+//! so a run exercises the real tool dispatch, the real citation numbering,
+//! and the real long-form final pass. Scheduled reports must behave
+//! identically across refactors of the loop underneath them — that is what
+//! this file pins.
+
+mod support;
+
+use atomic_core::reports::RunOutcome;
+use atomic_core::{
+    AtomicCore, CitationPolicy, CreateAtomRequest, CreateReportRequest, Report,
+    ReportFindingCitation,
+};
+use serde_json::{json, Value};
+use support::{await_pipeline, event_collector, setup_core, Backend, MockAiServer};
+
+/// Create an atom and wait for its pipeline, so report scope resolution and
+/// the agent's `semantic_search` tool both see it.
+async fn seed_atom(core: &AtomicCore, content: &str, tag_ids: &[&str]) -> String {
+    let (callback, mut events) = event_collector();
+    let atom = core
+        .create_atom(
+            CreateAtomRequest {
+                content: content.to_string(),
+                tag_ids: tag_ids.iter().map(|id| id.to_string()).collect(),
+                ..Default::default()
+            },
+            callback,
+        )
+        .await
+        .expect("create atom")
+        .expect("atom was inserted");
+    await_pipeline(core, &mut events, &atom.atom.id).await;
+    atom.atom.id
+}
+
+/// A report scoped to `tag_id`. Everything else is the authoring default —
+/// context scope "all", captured kinds only — so the tests differ only in the
+/// knobs they name.
+async fn create_report(
+    core: &AtomicCore,
+    tag_id: &str,
+    citation_policy: CitationPolicy,
+    max_tool_iterations: Option<i32>,
+) -> Report {
+    core.create_report(CreateReportRequest {
+        name: "Pelican Watch".to_string(),
+        research_prompt: "Summarize what is known about pelicans.".to_string(),
+        source_scope_tag_ids: vec![tag_id.to_string()],
+        citation_policy,
+        max_tool_iterations,
+        schedule: "0 0 * * * *".to_string(),
+        ..Default::default()
+    })
+    .await
+    .expect("create report")
+}
+
+async fn run_to_finding(
+    core: &AtomicCore,
+    report: &Report,
+) -> (String, Vec<ReportFindingCitation>) {
+    let outcome = core.run_report_now(&report.id).await.expect("run report");
+    let atom_id = match outcome {
+        RunOutcome::Succeeded { finding_atom_id } => finding_atom_id,
+        other => panic!("expected a finding, got {other:?}"),
+    };
+    let citations = core
+        .list_citations_for_finding(&atom_id)
+        .await
+        .expect("load finding citations");
+    (atom_id, citations)
+}
+
+/// The messages of the run's last chat request — the transcript the final
+/// pass was asked to write the report from, tool results included.
+fn final_pass_messages(mock: &MockAiServer) -> Vec<Value> {
+    let bodies = mock.chat_request_bodies();
+    let last = bodies.last().expect("at least one chat request");
+    last["messages"].as_array().expect("messages array").clone()
+}
+
+fn tool_results(messages: &[Value]) -> Vec<String> {
+    messages
+        .iter()
+        .filter(|message| message["role"] == "tool")
+        .filter_map(|message| message["content"].as_str().map(str::to_string))
+        .collect()
+}
+
+/// A full research run: the agent reads a source atom, searches the context
+/// corpus, calls `done`, and the final pass writes a finding whose `[N]`
+/// marker becomes a stored citation pointing at a source atom.
+#[tokio::test]
+async fn agentic_run_researches_then_writes_a_cited_finding() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let tag = core
+        .create_tag("ReportScope", None)
+        .await
+        .expect("create tag");
+    // Seeded oldest first; the source list is newest-first, so `sources[0]`
+    // is `[1]` in the prompt.
+    let older = seed_atom(&core, "Pelicans nest in colonies.", &[tag.id.as_str()]).await;
+    let newer = seed_atom(&core, "Pelicans dive for fish.", &[tag.id.as_str()]).await;
+    let sources = [newer.clone(), older.clone()];
+    // Untagged, so it is context rather than source: `source_only` must show
+    // it to the agent without making it citable.
+    seed_atom(&core, "Pelicans hold water in their pouches.", &[]).await;
+
+    let report = create_report(&core, &tag.id, CitationPolicy::SourceOnly, None).await;
+    mock.set_research_tool_rounds(vec![
+        vec![("read_atom", json!({ "atom_id": newer, "limit": 10 }))],
+        // Both calls in the final round must execute before the loop stops.
+        vec![
+            (
+                "semantic_search",
+                json!({ "query": "pelicans", "limit": 3 }),
+            ),
+            ("done", json!({})),
+        ],
+    ]);
+    mock.reset_counts();
+
+    let (_atom_id, citations) = run_to_finding(&core, &report).await;
+
+    assert_eq!(
+        mock.chat_request_count(),
+        3,
+        "two research turns and one final pass: {:?}",
+        mock.chat_request_models()
+    );
+
+    let results = tool_results(&final_pass_messages(&mock));
+    assert_eq!(results.len(), 3, "one result per tool call: {results:?}");
+    assert!(
+        results[0].contains("(lines 1-1 of 1)") && results[0].contains("Pelicans dive for fish."),
+        "read_atom returns a line window of the atom: {:?}",
+        results[0]
+    );
+    assert!(
+        results[1].contains("(context only, not citable)")
+            && results[1].contains("Pelicans hold water in their pouches."),
+        "source_only shows context results without a citation number: {:?}",
+        results[1]
+    );
+    assert!(
+        !results[1].contains(&older) && !results[1].contains(&newer),
+        "source atoms are excluded from their own report's context searches: {:?}",
+        results[1]
+    );
+    assert_eq!(
+        results[2], "Acknowledged. Write the report in your next message.",
+        "done acknowledges and hands over to the final pass"
+    );
+
+    // The mock finding cites `[1]`, which is the first atom of the source
+    // list — the numbering the prompt handed the model.
+    assert_eq!(citations.len(), 1, "one marker, one row: {citations:?}");
+    assert_eq!(citations[0].position, 1);
+    assert_eq!(
+        citations[0].cited_atom_id, sources[0],
+        "[1] is the first source atom"
+    );
+    assert!(
+        citations[0].excerpt.contains("Pelicans dive for fish."),
+        "the stored excerpt is the source's own text: {:?}",
+        citations[0].excerpt
+    );
+}
+
+/// `done` ends research where it is called: the loop does not spend another
+/// turn asking the model what to do next, it goes straight to the final pass.
+#[tokio::test]
+async fn done_ends_research_at_the_turn_it_is_called() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let tag = core
+        .create_tag("ReportScope", None)
+        .await
+        .expect("create tag");
+    seed_atom(&core, "Pelicans nest in colonies.", &[tag.id.as_str()]).await;
+
+    // A generous cap the run must not use: `done` on the second turn is what
+    // stops it.
+    let report = create_report(&core, &tag.id, CitationPolicy::SourceOnly, Some(8)).await;
+    mock.set_research_tool_rounds(vec![
+        vec![("semantic_search", json!({ "query": "pelicans" }))],
+        vec![("done", json!({}))],
+    ]);
+    mock.reset_counts();
+
+    let (_atom_id, citations) = run_to_finding(&core, &report).await;
+
+    assert_eq!(
+        mock.chat_request_count(),
+        3,
+        "two research turns plus the final pass, not the eight-turn budget"
+    );
+    assert_eq!(citations.len(), 1, "the finding still cites its source");
+}
+
+/// Out of tool-call budget the run does not fail or salvage — it writes the
+/// report from whatever it gathered, which is the contract the scheduler
+/// relies on to keep producing findings.
+#[tokio::test]
+async fn exhausting_the_iteration_budget_still_writes_a_finding() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let tag = core
+        .create_tag("ReportScope", None)
+        .await
+        .expect("create tag");
+    seed_atom(&core, "Pelicans nest in colonies.", &[tag.id.as_str()]).await;
+
+    let report = create_report(&core, &tag.id, CitationPolicy::SourceOnly, Some(2)).await;
+    // A model that researches forever: the cap is the only thing that stops
+    // it.
+    mock.set_research_tool_rounds(vec![vec![(
+        "semantic_search",
+        json!({ "query": "pelicans" }),
+    )]]);
+    mock.set_research_force_tool_calls(true);
+    mock.reset_counts();
+
+    let (_atom_id, citations) = run_to_finding(&core, &report).await;
+
+    assert_eq!(
+        mock.chat_request_count(),
+        3,
+        "the cap allows two research turns; the final pass still runs"
+    );
+    let results = tool_results(&final_pass_messages(&mock));
+    assert_eq!(
+        results.len(),
+        2,
+        "the final pass sees both rounds of research: {results:?}"
+    );
+    assert_eq!(citations.len(), 1, "a capped run still produces citations");
+}
+
+/// `source_and_context` is the same loop with a different citation
+/// admission: search results get the next free number and are advertised as
+/// citable, where `source_only` refuses them one.
+#[tokio::test]
+async fn source_and_context_numbers_search_results_after_the_source_list() {
+    let mock = MockAiServer::start().await;
+    let handle = setup_core(Backend::Sqlite, &mock.base_url())
+        .await
+        .expect("sqlite core");
+    let core = handle.core;
+
+    let tag = core
+        .create_tag("ReportScope", None)
+        .await
+        .expect("create tag");
+    seed_atom(&core, "Pelicans nest in colonies.", &[tag.id.as_str()]).await;
+    seed_atom(&core, "Pelicans dive for fish.", &[tag.id.as_str()]).await;
+    seed_atom(&core, "Pelicans hold water in their pouches.", &[]).await;
+
+    let report = create_report(&core, &tag.id, CitationPolicy::SourceAndContext, None).await;
+    mock.set_research_tool_rounds(vec![vec![
+        (
+            "semantic_search",
+            json!({ "query": "pelicans", "limit": 3 }),
+        ),
+        ("done", json!({})),
+    ]]);
+    mock.reset_counts();
+
+    run_to_finding(&core, &report).await;
+
+    let results = tool_results(&final_pass_messages(&mock));
+    assert!(
+        results[0].contains("[3] citable"),
+        "two source atoms hold [1] and [2], so the context hit is [3]: {:?}",
+        results[0]
+    );
+}

--- a/crates/atomic-server/src/auth.rs
+++ b/crates/atomic-server/src/auth.rs
@@ -136,6 +136,7 @@ mod tests {
             dangerously_skip_setup_token: false,
             setup_claim_lock: tokio::sync::Mutex::new(()),
             setup_claim_limiter: crate::state::SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
         });
         // Leak the tempdir so the DB stays alive during the test
         std::mem::forget(temp);

--- a/crates/atomic-server/src/lib.rs
+++ b/crates/atomic-server/src/lib.rs
@@ -119,6 +119,7 @@ use utoipa::OpenApi;
         routes::chat::add_tag_to_scope,
         routes::chat::remove_tag_from_scope,
         routes::chat::send_chat_message,
+        routes::chat::cancel_chat_message,
         // Providers
         routes::ollama::test_ollama,
         routes::ollama::get_ollama_models,

--- a/crates/atomic-server/src/main.rs
+++ b/crates/atomic-server/src/main.rs
@@ -544,6 +544,7 @@ async fn run_server(
         dangerously_skip_setup_token,
         setup_claim_lock: tokio::sync::Mutex::new(()),
         setup_claim_limiter: SetupClaimLimiter::new(),
+        chat_cancellations: Default::default(),
     });
 
     // Create MCP transport outside HttpServer::new() so all Actix workers share

--- a/crates/atomic-server/src/mcp_auth.rs
+++ b/crates/atomic-server/src/mcp_auth.rs
@@ -178,6 +178,7 @@ mod tests {
             dangerously_skip_setup_token: false,
             setup_claim_lock: tokio::sync::Mutex::new(()),
             setup_claim_limiter: crate::state::SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
         });
         std::mem::forget(temp);
         (state, raw_token)

--- a/crates/atomic-server/src/routes/chat.rs
+++ b/crates/atomic-server/src/routes/chat.rs
@@ -225,3 +225,244 @@ pub async fn cancel_chat_message(
         .cancel(scope.as_deref(), &conversation_id);
     HttpResponse::Accepted().json(serde_json::json!({ "cancelled": cancelled }))
 }
+
+#[cfg(test)]
+mod tests {
+    //! The cancel route's ownership contract.
+    //!
+    //! Cancellation is the one chat operation that acts on a turn started by
+    //! a *different* request, so it cannot authorize itself by loading a row
+    //! — the registry is a process-global map and a conversation id is a
+    //! guessable UUID. What keeps a multi-tenant composition honest is that
+    //! registration and cancellation both key on
+    //! [`crate::db_extractor::RequestJobScope`], the extension the composing
+    //! layer stamps with the account id. These tests pin that: a scope that
+    //! did not start a turn cannot stop it, however right it gets the id.
+
+    use super::*;
+    use crate::db_extractor::RequestJobScope;
+    use crate::{
+        export_jobs::ExportJobManager, log_buffer::LogBuffer,
+        migration_jobs::MigrationJobManager, state::SetupClaimLimiter,
+    };
+    use actix_web::body::MessageBody;
+    use actix_web::dev::{ServiceRequest, ServiceResponse};
+    use actix_web::middleware::{from_fn, Next};
+    use actix_web::{test as actix_test, App, HttpMessage};
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use tokio::sync::{broadcast, Mutex};
+
+    /// Header the test middleware reads to stand in for a composing layer's
+    /// authenticated account. Absent = the standalone server, which installs
+    /// no scope at all.
+    const SCOPE_HEADER: &str = "x-test-scope";
+
+    fn test_state() -> web::Data<AppState> {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let manager = Arc::new(atomic_core::DatabaseManager::new(temp.path()).expect("manager"));
+        let (event_tx, _rx) = broadcast::channel(16);
+        let state = web::Data::new(AppState {
+            manager,
+            event_tx,
+            public_url: None,
+            log_buffer: LogBuffer::new(16),
+            export_jobs: ExportJobManager::for_tests(temp.path().join("exports")),
+            migration_jobs: MigrationJobManager::for_tests(temp.path().join("migrations")),
+            setup_token: None,
+            dangerously_skip_setup_token: true,
+            setup_claim_lock: Mutex::new(()),
+            setup_claim_limiter: SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
+        });
+        // The SQLite files must outlive the state that has them open; the
+        // process exits before anything would clean them up anyway.
+        std::mem::forget(temp);
+        state
+    }
+
+    /// Stand-in for the composing layer's auth middleware (atomic-cloud's
+    /// `CloudAuth` inserts exactly this extension, with the account id).
+    async fn install_scope(
+        req: ServiceRequest,
+        next: Next<impl MessageBody + 'static>,
+    ) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+        let scope = req
+            .headers()
+            .get(SCOPE_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        if let Some(scope) = scope {
+            req.extensions_mut().insert(RequestJobScope(scope));
+        }
+        next.call(req).await
+    }
+
+    fn cancel_request(conversation_id: &str, scope: Option<&str>) -> actix_http::Request {
+        let mut req = actix_test::TestRequest::post().uri(&format!(
+            "/api/conversations/{conversation_id}/messages/cancel"
+        ));
+        if let Some(scope) = scope {
+            req = req.insert_header((SCOPE_HEADER, scope));
+        }
+        req.to_request()
+    }
+
+    macro_rules! cancel_app {
+        ($state:expr) => {
+            actix_test::init_service(
+                App::new()
+                    .app_data($state)
+                    .route(
+                        "/api/conversations/{id}/messages/cancel",
+                        web::post().to(cancel_chat_message),
+                    )
+                    .wrap(from_fn(install_scope)),
+            )
+            .await
+        };
+    }
+
+    /// Send a cancel and return its `cancelled` flag, asserting the route
+    /// always accepts.
+    async fn cancelled<S, B>(app: &S, request: actix_http::Request) -> bool
+    where
+        S: actix_web::dev::Service<actix_http::Request, Response = ServiceResponse<B>, Error = actix_web::Error>,
+        B: MessageBody,
+    {
+        let res = actix_test::call_service(app, request).await;
+        assert_eq!(res.status(), 202, "cancelling is always accepted");
+        let body: serde_json::Value = actix_test::read_body_json(res).await;
+        body["cancelled"].as_bool().expect("cancelled flag")
+    }
+
+    /// One tenant cannot stop another's turn by guessing the conversation
+    /// id: the cancel reports nothing was running and the victim's flag stays
+    /// down. The owning scope then stops it.
+    #[actix_web::test]
+    async fn a_foreign_scope_cannot_cancel_a_turn_it_did_not_start() {
+        let state = test_state();
+        let app = cancel_app!(state.clone());
+
+        // Tenant B has a turn running on conversation `shared-id`.
+        let turn = state
+            .chat_cancellations
+            .begin(Some("tenant-b".to_string()), "shared-id");
+        let flag = turn.flag();
+
+        // Tenant A knows the id and asks for it to stop.
+        assert!(
+            !cancelled(&app, cancel_request("shared-id", Some("tenant-a"))).await,
+            "a foreign scope must find nothing to cancel"
+        );
+        assert!(
+            !flag.load(Ordering::Relaxed),
+            "tenant B's turn must still be running"
+        );
+
+        // The owning scope stops it.
+        assert!(cancelled(&app, cancel_request("shared-id", Some("tenant-b"))).await);
+        assert!(flag.load(Ordering::Relaxed), "the owner's cancel lands");
+    }
+
+    /// An unscoped request (the standalone server) is its own scope, not a
+    /// wildcard: it cannot reach a scoped turn, and a scoped request cannot
+    /// reach an unscoped one.
+    #[actix_web::test]
+    async fn the_absent_scope_is_a_scope_of_its_own() {
+        let state = test_state();
+        let app = cancel_app!(state.clone());
+
+        let scoped = state
+            .chat_cancellations
+            .begin(Some("tenant-b".to_string()), "c1");
+        let scoped_flag = scoped.flag();
+        let unscoped = state.chat_cancellations.begin(None, "c2");
+        let unscoped_flag = unscoped.flag();
+
+        assert!(!cancelled(&app, cancel_request("c1", None)).await);
+        assert!(!scoped_flag.load(Ordering::Relaxed));
+
+        assert!(!cancelled(&app, cancel_request("c2", Some("tenant-b"))).await);
+        assert!(!unscoped_flag.load(Ordering::Relaxed));
+
+        // Each still reaches its own.
+        assert!(cancelled(&app, cancel_request("c2", None)).await);
+        assert!(unscoped_flag.load(Ordering::Relaxed));
+    }
+
+    /// Cancelling is idempotent and never 404s: nothing running is a valid
+    /// state to ask for a stop from, and the client's next move (clear the
+    /// streaming UI) is the same either way.
+    #[actix_web::test]
+    async fn cancelling_nothing_is_accepted() {
+        let state = test_state();
+        let app = cancel_app!(state);
+        assert!(!cancelled(&app, cancel_request("never-existed", None)).await);
+    }
+
+    /// The turn guard deregisters on drop, so a later cancel finds nothing —
+    /// and a superseding turn on the same conversation owns the entry, so
+    /// the older guard's drop must not evict it.
+    #[actix_web::test]
+    async fn a_finished_turn_deregisters_and_a_superseding_turn_owns_the_entry() {
+        let state = test_state();
+        let registry = &state.chat_cancellations;
+
+        {
+            let _turn = registry.begin(None, "c1");
+            assert!(registry.cancel(None, "c1"), "a live turn is cancellable");
+        }
+        assert!(
+            !registry.cancel(None, "c1"),
+            "a finished turn leaves nothing behind"
+        );
+
+        // A retry racing its predecessor: the second registration wins, and
+        // the first guard dropping must not take it with it.
+        let first = registry.begin(None, "c2");
+        let second = registry.begin(None, "c2");
+        let second_flag = second.flag();
+        drop(first);
+        assert!(
+            registry.cancel(None, "c2"),
+            "the superseding turn is still registered"
+        );
+        assert!(second_flag.load(Ordering::Relaxed));
+    }
+
+    /// Superseding a turn means stopping it. Once a second turn takes the
+    /// key, no cancel can reach the first — so if `begin` doesn't raise its
+    /// flag, the displaced turn streams to completion into a conversation
+    /// whose next answer is already being written, with nothing able to stop
+    /// it.
+    #[actix_web::test]
+    async fn a_superseded_turn_is_cancelled_by_the_one_replacing_it() {
+        let state = test_state();
+        let registry = &state.chat_cancellations;
+
+        let first = registry.begin(None, "c1");
+        let first_flag = first.flag();
+        assert!(!first_flag.load(Ordering::Relaxed));
+
+        let second = registry.begin(None, "c1");
+        assert!(
+            first_flag.load(Ordering::Relaxed),
+            "the displaced turn is told to stop"
+        );
+        assert!(
+            !second.flag().load(Ordering::Relaxed),
+            "and the one replacing it is not"
+        );
+
+        // Tenancy still holds: a turn in another scope keys separately and is
+        // untouched by a same-id registration here.
+        let other = registry.begin(Some("tenant-a".to_string()), "c1");
+        let other_flag = other.flag();
+        let _third = registry.begin(None, "c1");
+        assert!(
+            !other_flag.load(Ordering::Relaxed),
+            "another tenant's turn on the same conversation id is not displaced"
+        );
+    }
+}

--- a/crates/atomic-server/src/routes/chat.rs
+++ b/crates/atomic-server/src/routes/chat.rs
@@ -102,9 +102,11 @@ pub async fn delete_conversation(db: Db, path: web::Path<String>) -> HttpRespons
 
 #[derive(Deserialize, Serialize, ToSchema)]
 pub struct SetScopeBody {
-    /// Tag IDs for the conversation scope
+    /// The conversation's scope. Each entry is either `{"tag_id": "...",
+    /// "mode": "include"|"require"|"exclude"}` or a bare tag id, which means
+    /// include — the shape clients sent before modes existed.
     #[serde(default)]
-    pub tag_ids: Vec<String>,
+    pub tag_ids: Vec<atomic_core::ScopeEntry>,
 }
 
 #[utoipa::path(put, path = "/api/conversations/{id}/scope", params(("id" = String, Path, description = "Conversation ID")), request_body = SetScopeBody, responses((status = 200, description = "Scope updated")), tag = "chat")]
@@ -114,14 +116,18 @@ pub async fn set_conversation_scope(
     body: web::Json<SetScopeBody>,
 ) -> HttpResponse {
     let id = path.into_inner();
-    let tag_ids = body.into_inner().tag_ids;
-    ok_or_error(db.0.set_conversation_scope(&id, &tag_ids).await)
+    let entries = body.into_inner().tag_ids;
+    ok_or_error(db.0.set_conversation_scope(&id, &entries).await)
 }
 
 #[derive(Deserialize, Serialize, ToSchema)]
 pub struct AddTagBody {
     /// Tag ID to add to scope
     pub tag_id: String,
+    /// The role the tag plays: `include` (default), `require`, or `exclude`.
+    /// Re-adding a tag already in scope changes its mode.
+    #[serde(default)]
+    pub mode: atomic_core::ScopeMode,
 }
 
 #[utoipa::path(post, path = "/api/conversations/{id}/scope/tags", params(("id" = String, Path, description = "Conversation ID")), request_body = AddTagBody, responses((status = 200, description = "Tag added to scope")), tag = "chat")]
@@ -131,8 +137,8 @@ pub async fn add_tag_to_scope(
     body: web::Json<AddTagBody>,
 ) -> HttpResponse {
     let id = path.into_inner();
-    let tag_id = body.into_inner().tag_id;
-    ok_or_error(db.0.add_tag_to_scope(&id, &tag_id).await)
+    let body = body.into_inner();
+    ok_or_error(db.0.add_tag_to_scope(&id, &body.tag_id, body.mode).await)
 }
 
 #[utoipa::path(delete, path = "/api/conversations/{id}/scope/tags/{tag_id}", params(("id" = String, Path, description = "Conversation ID"), ("tag_id" = String, Path, description = "Tag ID")), responses((status = 200, description = "Tag removed from scope")), tag = "chat")]

--- a/crates/atomic-server/src/routes/chat.rs
+++ b/crates/atomic-server/src/routes/chat.rs
@@ -1,10 +1,11 @@
 //! Chat / Conversation routes
 
-use crate::db_extractor::Db;
+use crate::db_extractor::{job_scope, Db};
 use crate::error::{ok_or_error, ApiErrorResponse};
 use crate::event_bridge::chat_event_callback;
 use crate::event_channel::EventChannel;
-use actix_web::{web, HttpResponse};
+use crate::state::AppState;
+use actix_web::{web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
@@ -39,15 +40,23 @@ pub struct GetConversationsQuery {
     pub limit: Option<i32>,
     /// Offset for pagination
     pub offset: Option<i32>,
+    /// Include archived conversations (default: false)
+    pub include_archived: Option<bool>,
 }
 
 #[utoipa::path(get, path = "/api/conversations", params(GetConversationsQuery), responses((status = 200, description = "List of conversations", body = Vec<atomic_core::ConversationWithTags>)), tag = "chat")]
 pub async fn get_conversations(db: Db, query: web::Query<GetConversationsQuery>) -> HttpResponse {
     let limit = query.limit.unwrap_or(50);
     let offset = query.offset.unwrap_or(0);
+    let include_archived = query.include_archived.unwrap_or(false);
     ok_or_error(
-        db.0.get_conversations(query.filter_tag_id.as_deref(), limit, offset)
-            .await,
+        db.0.get_conversations(
+            query.filter_tag_id.as_deref(),
+            limit,
+            offset,
+            include_archived,
+        )
+        .await,
     )
 }
 
@@ -146,6 +155,8 @@ pub struct SendMessageBody {
 
 #[utoipa::path(post, path = "/api/conversations/{id}/messages", params(("id" = String, Path, description = "Conversation ID")), request_body = SendMessageBody, responses((status = 200, description = "Assistant response (streaming events via WebSocket)", body = atomic_core::ChatMessageWithContext)), tag = "chat")]
 pub async fn send_chat_message(
+    req: HttpRequest,
+    state: web::Data<AppState>,
     events: EventChannel,
     db: Db,
     path: web::Path<String>,
@@ -153,7 +164,13 @@ pub async fn send_chat_message(
 ) -> HttpResponse {
     let conversation_id = path.into_inner();
     let body = body.into_inner();
-    let on_event = chat_event_callback(events.0.clone());
+    let events_tx = events.0.clone();
+    let on_event = chat_event_callback(events_tx.clone());
+
+    // Registered for the whole turn; the guard deregisters on every exit.
+    let turn = state
+        .chat_cancellations
+        .begin(job_scope(&req), &conversation_id);
 
     let result = if body.canvas_context.is_some() || body.page_context.is_some() {
         db.0.send_chat_message_with_canvas(
@@ -162,15 +179,43 @@ pub async fn send_chat_message(
             on_event,
             body.canvas_context,
             body.page_context,
+            Some(turn.flag()),
         )
         .await
     } else {
-        db.0.send_chat_message(&conversation_id, &body.content, on_event)
+        db.0.send_chat_message(&conversation_id, &body.content, on_event, Some(turn.flag()))
             .await
     };
 
     match result {
         Ok(message) => HttpResponse::Ok().json(message),
-        Err(e) => crate::error::error_response(e),
+        Err(e) => {
+            // The client watches WebSocket events during the turn and may
+            // never read this body (navigation, disconnect, a proxy timing
+            // out the long request) — put the failure on the event stream too
+            // so the conversation surfaces it either way.
+            let _ = events_tx.send(crate::state::ServerEvent::ChatError {
+                conversation_id: conversation_id.clone(),
+                error: e.to_string(),
+            });
+            crate::error::error_response(e)
+        }
     }
+}
+
+#[utoipa::path(post, path = "/api/conversations/{id}/messages/cancel", params(("id" = String, Path, description = "Conversation ID")), responses((status = 202, description = "Cancellation requested")), tag = "chat")]
+pub async fn cancel_chat_message(
+    req: HttpRequest,
+    state: web::Data<AppState>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let conversation_id = path.into_inner();
+    let scope = job_scope(&req);
+    // Idempotent: nothing running is a valid state to ask for a stop from,
+    // and the caller's next move (clear the streaming UI) is the same either
+    // way. `cancelled` reports whether a turn was actually signalled.
+    let cancelled = state
+        .chat_cancellations
+        .cancel(scope.as_deref(), &conversation_id);
+    HttpResponse::Accepted().json(serde_json::json!({ "cancelled": cancelled }))
 }

--- a/crates/atomic-server/src/routes/mod.rs
+++ b/crates/atomic-server/src/routes/mod.rs
@@ -300,6 +300,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         "/conversations/{id}/messages",
         web::post().to(chat::send_chat_message),
     );
+    cfg.route(
+        "/conversations/{id}/messages/cancel",
+        web::post().to(chat::cancel_chat_message),
+    );
 
     // Ollama
     cfg.route("/ollama/test", web::post().to(ollama::test_ollama));

--- a/crates/atomic-server/src/routes/oauth.rs
+++ b/crates/atomic-server/src/routes/oauth.rs
@@ -736,6 +736,7 @@ mod tests {
             dangerously_skip_setup_token: false,
             setup_claim_lock: tokio::sync::Mutex::new(()),
             setup_claim_limiter: crate::state::SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
         });
         std::mem::forget(temp);
         state
@@ -760,6 +761,7 @@ mod tests {
             dangerously_skip_setup_token: false,
             setup_claim_lock: tokio::sync::Mutex::new(()),
             setup_claim_limiter: crate::state::SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
         });
         std::mem::forget(temp);
         state

--- a/crates/atomic-server/src/routes/setup.rs
+++ b/crates/atomic-server/src/routes/setup.rs
@@ -185,6 +185,7 @@ mod tests {
             dangerously_skip_setup_token,
             setup_claim_lock: Mutex::new(()),
             setup_claim_limiter: SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
         });
         std::mem::forget(temp);
         state

--- a/crates/atomic-server/src/state.rs
+++ b/crates/atomic-server/src/state.rs
@@ -89,6 +89,90 @@ impl SetupClaimLimiter {
     }
 }
 
+/// Cancellation flags for chat turns currently running in this process.
+///
+/// A turn registers when `POST /conversations/{id}/messages` starts and
+/// deregisters when the handler returns (the [`ChatTurn`] guard covers every
+/// exit, including early errors and client disconnects). `POST
+/// .../messages/cancel` raises the flag; `atomic-core`'s agent loop notices at
+/// its next checkpoint and finalizes the partial answer.
+///
+/// Entries are keyed by `(scope, conversation_id)` — the scope being the
+/// composing layer's [`crate::db_extractor::RequestJobScope`], as with the job
+/// registries — so a multi-tenant composition can't cancel another tenant's
+/// turn by guessing a conversation id. The standalone server has no scope and
+/// keys on `None`.
+#[derive(Default)]
+pub struct ChatCancellations {
+    turns: Mutex<HashMap<(Option<String>, String), atomic_core::ChatCancel>>,
+}
+
+impl ChatCancellations {
+    /// Register a starting turn. Dropping the returned guard deregisters it.
+    pub fn begin(&self, scope: Option<String>, conversation_id: &str) -> ChatTurn<'_> {
+        let key = (scope, conversation_id.to_string());
+        let flag = atomic_core::ChatCancel::default();
+        if let Ok(mut turns) = self.turns.lock() {
+            // A second turn on the same conversation (double-send, or a retry
+            // racing its predecessor) supersedes the first; the older guard's
+            // pointer check keeps it from removing this entry on drop.
+            turns.insert(key.clone(), Arc::clone(&flag));
+        }
+        ChatTurn {
+            registry: self,
+            key,
+            flag,
+        }
+    }
+
+    /// Raise the flag for a running turn. `false` when nothing was running,
+    /// which callers treat as success — cancelling is idempotent.
+    pub fn cancel(&self, scope: Option<&str>, conversation_id: &str) -> bool {
+        let key = (scope.map(str::to_string), conversation_id.to_string());
+        let Ok(turns) = self.turns.lock() else {
+            return false;
+        };
+        match turns.get(&key) {
+            Some(flag) => {
+                flag.store(true, std::sync::atomic::Ordering::Relaxed);
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn end(&self, key: &(Option<String>, String), flag: &atomic_core::ChatCancel) {
+        if let Ok(mut turns) = self.turns.lock() {
+            if turns
+                .get(key)
+                .is_some_and(|current| Arc::ptr_eq(current, flag))
+            {
+                turns.remove(key);
+            }
+        }
+    }
+}
+
+/// RAII registration of one in-flight chat turn. See [`ChatCancellations`].
+pub struct ChatTurn<'a> {
+    registry: &'a ChatCancellations,
+    key: (Option<String>, String),
+    flag: atomic_core::ChatCancel,
+}
+
+impl ChatTurn<'_> {
+    /// The flag to hand to `atomic-core`'s agent loop.
+    pub fn flag(&self) -> atomic_core::ChatCancel {
+        Arc::clone(&self.flag)
+    }
+}
+
+impl Drop for ChatTurn<'_> {
+    fn drop(&mut self) {
+        self.registry.end(&self.key, &self.flag);
+    }
+}
+
 /// Shared application state for all route handlers
 pub struct AppState {
     pub manager: Arc<DatabaseManager>,
@@ -109,6 +193,8 @@ pub struct AppState {
     pub setup_claim_lock: AsyncMutex<()>,
     /// Rate-limits setup claim attempts by client IP.
     pub setup_claim_limiter: SetupClaimLimiter,
+    /// Cancellation flags for chat turns running in this process.
+    pub chat_cancellations: ChatCancellations,
 }
 
 impl AppState {
@@ -269,6 +355,7 @@ pub enum ServerEvent {
         conversation_id: String,
         tool_call_id: String,
         results_count: i32,
+        failed: bool,
     },
     ChatComplete {
         conversation_id: String,
@@ -282,6 +369,10 @@ pub enum ServerEvent {
     ChatError {
         conversation_id: String,
         error: String,
+    },
+    ChatConversationUpdated {
+        conversation_id: String,
+        title: String,
     },
 }
 
@@ -456,10 +547,12 @@ impl From<atomic_core::ChatEvent> for ServerEvent {
                 conversation_id,
                 tool_call_id,
                 results_count,
+                failed,
             } => ServerEvent::ChatToolComplete {
                 conversation_id,
                 tool_call_id,
                 results_count,
+                failed,
             },
             atomic_core::ChatEvent::Complete {
                 conversation_id,
@@ -489,6 +582,13 @@ impl From<atomic_core::ChatEvent> for ServerEvent {
                 conversation_id: _,
                 event,
             } => ServerEvent::from(event),
+            atomic_core::ChatEvent::ConversationUpdated {
+                conversation_id,
+                title,
+            } => ServerEvent::ChatConversationUpdated {
+                conversation_id,
+                title,
+            },
             atomic_core::ChatEvent::Error {
                 conversation_id,
                 error,

--- a/crates/atomic-server/src/state.rs
+++ b/crates/atomic-server/src/state.rs
@@ -114,9 +114,15 @@ impl ChatCancellations {
         let flag = atomic_core::ChatCancel::default();
         if let Ok(mut turns) = self.turns.lock() {
             // A second turn on the same conversation (double-send, or a retry
-            // racing its predecessor) supersedes the first; the older guard's
-            // pointer check keeps it from removing this entry on drop.
-            turns.insert(key.clone(), Arc::clone(&flag));
+            // racing its predecessor) supersedes the first. Superseding means
+            // stopping it: the displaced turn is now unreachable — no cancel
+            // can find its flag once this one takes the key — so raise it here
+            // or it streams to completion into a conversation whose next
+            // answer is already being written. The older guard's pointer check
+            // keeps it from removing this entry when it finally drops.
+            if let Some(displaced) = turns.insert(key.clone(), Arc::clone(&flag)) {
+                displaced.store(true, std::sync::atomic::Ordering::Relaxed);
+            }
         }
         ChatTurn {
             registry: self,

--- a/crates/atomic-server/tests/api_atoms.rs
+++ b/crates/atomic-server/tests/api_atoms.rs
@@ -47,6 +47,7 @@ impl TestCtx {
             dangerously_skip_setup_token: false,
             setup_claim_lock: tokio::sync::Mutex::new(()),
             setup_claim_limiter: atomic_server::state::SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
         });
         TestCtx {
             _temp: temp,

--- a/crates/atomic-server/tests/e2e_chat.rs
+++ b/crates/atomic-server/tests/e2e_chat.rs
@@ -548,3 +548,150 @@ async fn run_chat_requires_auth(backend: Backend) {
 
     server.stop().await;
 }
+
+// ==================== 6. Cancelling a running turn ====================
+
+#[actix_web::test]
+async fn cancel_stops_a_running_turn_sqlite() {
+    run_cancel_stops_a_running_turn(Backend::Sqlite).await;
+}
+
+#[actix_web::test]
+async fn cancel_stops_a_running_turn_postgres() {
+    if std::env::var("ATOMIC_TEST_DATABASE_URL").is_err() {
+        eprintln!("cancel_stops_a_running_turn_postgres: skipping (ATOMIC_TEST_DATABASE_URL not set)");
+        return;
+    }
+    run_cancel_stops_a_running_turn(Backend::Postgres).await;
+}
+
+/// `POST /api/conversations/{id}/messages/cancel` reaches the turn started
+/// by a *different* in-flight request and stops it, and the stopped turn
+/// still returns its (marked) message through the normal path.
+///
+/// The registry that makes this work lives in `AppState`, so nothing below
+/// the HTTP layer can prove the wiring: the send handler has to register the
+/// turn under the same key the cancel handler looks it up by, and the flag
+/// has to reach `atomic-core`'s agent loop.
+async fn run_cancel_stops_a_running_turn(backend: Backend) {
+    let Some(ctx) = TestCtx::new(backend).await else {
+        return;
+    };
+    // A model that never stops researching, answering slowly — so the turn
+    // is reliably still running when the cancel arrives.
+    ctx.mock.set_chat_force_tool_calls(true);
+    ctx.mock
+        .set_chat_delay(Some(Duration::from_millis(200)));
+
+    let server = spawn_live_server(&ctx).await;
+    let client = reqwest::Client::new();
+    let conv_id = create_conversation(&client, &server.base_url, &ctx.token, &[]).await;
+
+    let send_handle = {
+        let base_url = server.base_url.clone();
+        let token = ctx.token.clone();
+        let conv_id = conv_id.clone();
+        tokio::spawn(async move {
+            let resp = reqwest::Client::new()
+                .post(format!(
+                    "{}/api/conversations/{}/messages",
+                    base_url, conv_id
+                ))
+                .bearer_auth(&token)
+                .json(&json!({ "content": "keep digging forever" }))
+                .send()
+                .await
+                .expect("POST /api/conversations/{id}/messages");
+            assert!(
+                resp.status().is_success(),
+                "a stopped turn still returns 200, got {}",
+                resp.status()
+            );
+            resp.json::<Value>().await.expect("parse chat reply")
+        })
+    };
+
+    // Retry until the turn has registered — cancelling before the handler
+    // starts is a legitimate no-op, not a failure.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let mut signalled = false;
+    while !signalled {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the turn never became cancellable"
+        );
+        let resp = client
+            .post(format!(
+                "{}/api/conversations/{}/messages/cancel",
+                server.base_url, conv_id
+            ))
+            .bearer_auth(&ctx.token)
+            .send()
+            .await
+            .expect("POST .../messages/cancel");
+        assert_eq!(
+            resp.status().as_u16(),
+            202,
+            "cancelling is always accepted, running or not"
+        );
+        let body: Value = resp.json().await.expect("parse cancel reply");
+        signalled = body["cancelled"].as_bool().expect("cancelled flag");
+        if !signalled {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    let reply = send_handle.await.expect("send task joined");
+    let content = reply["content"].as_str().unwrap_or_default();
+    assert!(
+        content.contains("*(stopped)*"),
+        "the partial answer is marked stopped; got {reply}"
+    );
+
+    // And that is what the conversation now holds.
+    let stored: Value = client
+        .get(format!(
+            "{}/api/conversations/{}",
+            server.base_url, conv_id
+        ))
+        .bearer_auth(&ctx.token)
+        .send()
+        .await
+        .expect("GET conversation")
+        .json()
+        .await
+        .expect("parse conversation");
+    let last = stored["messages"]
+        .as_array()
+        .and_then(|messages| messages.last())
+        .cloned()
+        .expect("assistant message persisted");
+    assert_eq!(last["role"], "assistant");
+    assert_eq!(last["content"], content);
+
+    server.stop().await;
+}
+
+#[actix_web::test]
+async fn cancel_requires_auth_sqlite() {
+    let Some(ctx) = TestCtx::new(Backend::Sqlite).await else {
+        return;
+    };
+    let server = spawn_live_server(&ctx).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/api/conversations/00000000-0000-0000-0000-000000000000/messages/cancel",
+            server.base_url
+        ))
+        .send()
+        .await
+        .expect("cancel without auth");
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "cancel is behind the same bearer gate as the turn it stops"
+    );
+
+    server.stop().await;
+}

--- a/crates/atomic-server/tests/mcp_inspector.rs
+++ b/crates/atomic-server/tests/mcp_inspector.rs
@@ -49,6 +49,7 @@ impl TestServer {
             dangerously_skip_setup_token: false,
             setup_claim_lock: tokio::sync::Mutex::new(()),
             setup_claim_limiter: SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
         });
         let transport = AtomicMcpTransport::new(manager, event_tx, Duration::from_secs(30));
         let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();

--- a/crates/atomic-server/tests/support/mod.rs
+++ b/crates/atomic-server/tests/support/mod.rs
@@ -184,6 +184,7 @@ impl TestCtx {
             dangerously_skip_setup_token: opts.dangerously_skip_setup_token,
             setup_claim_lock: tokio::sync::Mutex::new(()),
             setup_claim_limiter: SetupClaimLimiter::new(),
+            chat_cancellations: Default::default(),
         });
 
         Some(TestCtx {

--- a/crates/atomic-test-support/src/lib.rs
+++ b/crates/atomic-test-support/src/lib.rs
@@ -8,9 +8,12 @@
 //! ## What lives here
 //!
 //! - `MockAiServer`: a wiremock-backed server that responds to
-//!   `/v1/embeddings` and `/v1/chat/completions` with deterministic output.
-//! - `EMBED_DIM` and `EDGE_SIMILARITY_THRESHOLD`: shared constants pinned
-//!   to the default provider/embedding-pipeline config so tests don't drift.
+//!   `/v1/embeddings` and `/v1/chat/completions` (OpenAI-compat and
+//!   OpenRouter) plus `/api/embed` and `/api/chat` (Ollama) with
+//!   deterministic output.
+//! - `EMBED_DIM`, `OLLAMA_EMBED_DIM` and `EDGE_SIMILARITY_THRESHOLD`: shared
+//!   constants pinned to the default provider/embedding-pipeline config so
+//!   tests don't drift.
 //! - `truncate_postgres_for_test`: ready-made truncation helper for the
 //!   per-DB tables used by integration tests. Behind the `postgres`
 //!   feature so default consumers don't pull sqlx.
@@ -30,7 +33,9 @@ pub mod mock_url;
 #[cfg(feature = "postgres")]
 pub mod postgres_helpers;
 
-pub use mock_ai::{InjectedFailure, MockAiServer, EDGE_SIMILARITY_THRESHOLD, EMBED_DIM};
+pub use mock_ai::{
+    InjectedFailure, MockAiServer, EDGE_SIMILARITY_THRESHOLD, EMBED_DIM, OLLAMA_EMBED_DIM,
+};
 pub use mock_url::{MockUrlServer, SLOW_FEED_DELAY};
 
 #[cfg(feature = "postgres")]

--- a/crates/atomic-test-support/src/mock_ai.rs
+++ b/crates/atomic-test-support/src/mock_ai.rs
@@ -86,6 +86,10 @@ struct MockAiCounters {
     /// arrival order — lets tests assert *which* model an operation selected,
     /// not just that a call happened.
     chat_models: Mutex<Vec<String>>,
+    /// Every `/v1/chat/completions` request body, in arrival order. Lets a
+    /// test assert what an agent actually sent the model — which tool results
+    /// came back, and what a final pass was asked to write from.
+    chat_bodies: Mutex<Vec<Value>>,
     /// When set, `/v1/embeddings` serves this failure instead of embeddings.
     embedding_failure: Mutex<Option<InjectedFailure>>,
     /// When set, `/v1/chat/completions` serves this failure instead of a
@@ -99,6 +103,20 @@ struct MockAiCounters {
     /// another tool call instead of wrapping up — a model that never stops
     /// researching, which is how tests reach the agent loop's iteration cap.
     chat_force_tool_calls: AtomicBool,
+    /// When set, the tool-call leg asks for this `(tool_name, arguments)`
+    /// instead of `search_atoms`, so a test can drive any registered tool —
+    /// or one the registry doesn't have — through the real loop.
+    chat_tool_call: Mutex<Option<(String, Value)>>,
+    /// Script for the non-streaming tool-bearing leg — the research loops
+    /// reports and wiki generation run. One entry per model turn, each a
+    /// round of `(tool_name, arguments)` calls issued together. Empty (the
+    /// default) means the leg calls `done` on its first turn.
+    research_tool_rounds: Mutex<Vec<Vec<(String, Value)>>>,
+    /// When true the research leg never falls back to `done`: once the script
+    /// runs out it repeats its last round, so the loop can only end at its
+    /// own iteration cap. With no script there is nothing to repeat and the
+    /// leg still calls `done`.
+    research_force_tool_calls: AtomicBool,
     /// Conversation-title requests seen so far. Counted separately from
     /// `chat_requests` because title generation is fire-and-forget: a test
     /// waits on this to know the detached task actually ran.
@@ -162,6 +180,16 @@ impl MockAiServer {
             .clone()
     }
 
+    /// Every chat-completions request body so far, in arrival order — the
+    /// messages an agent actually sent, tool results included.
+    pub fn chat_request_bodies(&self) -> Vec<Value> {
+        self.counters
+            .chat_bodies
+            .lock()
+            .expect("chat_bodies lock")
+            .clone()
+    }
+
     /// Make `/v1/embeddings` fail with `failure` until cleared with `None`.
     /// Requests are still counted while failing.
     pub fn set_embedding_failure(&self, failure: Option<InjectedFailure>) {
@@ -200,6 +228,47 @@ impl MockAiServer {
             .store(force, Ordering::Relaxed);
     }
 
+    /// Make the tool-call leg request `(tool_name, arguments)` instead of
+    /// `search_atoms`. Clear with `None`.
+    pub fn set_chat_tool_call(&self, call: Option<(&str, Value)>) {
+        *self
+            .counters
+            .chat_tool_call
+            .lock()
+            .expect("chat_tool_call lock") =
+            call.map(|(name, arguments)| (name.to_string(), arguments));
+    }
+
+    /// Script the non-streaming research leg (reports, wiki) turn by turn:
+    /// `rounds[n]` is the set of tool calls the model makes on its nth turn,
+    /// and the leg calls `done` once the script runs out. An empty script is
+    /// the default — `done` immediately, no research.
+    pub fn set_research_tool_rounds(&self, rounds: Vec<Vec<(&str, Value)>>) {
+        *self
+            .counters
+            .research_tool_rounds
+            .lock()
+            .expect("research_tool_rounds lock") = rounds
+            .into_iter()
+            .map(|round| {
+                round
+                    .into_iter()
+                    .map(|(name, arguments)| (name.to_string(), arguments))
+                    .collect()
+            })
+            .collect();
+    }
+
+    /// Keep the research leg on its script's last round forever instead of
+    /// falling back to `done`, so a run can only end at its own iteration
+    /// cap. Pair it with [`Self::set_research_tool_rounds`] — with no script
+    /// there is nothing to repeat.
+    pub fn set_research_force_tool_calls(&self, force: bool) {
+        self.counters
+            .research_force_tool_calls
+            .store(force, Ordering::Relaxed);
+    }
+
     /// Conversation-title completions requested so far. Zero means the
     /// detached title task never reached the provider.
     pub fn title_request_count(&self) -> usize {
@@ -224,6 +293,11 @@ impl MockAiServer {
             .chat_models
             .lock()
             .expect("chat_models lock")
+            .clear();
+        self.counters
+            .chat_bodies
+            .lock()
+            .expect("chat_bodies lock")
             .clear();
     }
 }
@@ -271,12 +345,18 @@ fn embed_text(text: &str) -> Vec<f32> {
 ///   deterministic text, closing with `finish_reason: stop`.
 ///
 /// `force_tool_calls` keeps a tool-bearing request on the tool-call leg
-/// forever (see [`MockAiServer::set_chat_force_tool_calls`]).
+/// forever (see [`MockAiServer::set_chat_force_tool_calls`]); `tool_call`
+/// replaces the tool the leg asks for (see
+/// [`MockAiServer::set_chat_tool_call`]).
 ///
 /// The provider parser is line-oriented (`data: ...\n`) and accepts the
 /// stream as a single body payload, so we don't need true chunked transfer
 /// to satisfy it.
-fn streaming_chat_response(body: &Value, force_tool_calls: bool) -> ResponseTemplate {
+fn streaming_chat_response(
+    body: &Value,
+    force_tool_calls: bool,
+    tool_call: Option<(String, Value)>,
+) -> ResponseTemplate {
     let has_tool_results = body
         .get("messages")
         .and_then(|v| v.as_array())
@@ -298,6 +378,9 @@ fn streaming_chat_response(body: &Value, force_tool_calls: bool) -> ResponseTemp
     let sse_body = if answer_with_text {
         // Final leg: emit the assistant text. Split across two deltas so
         // tests exercise incremental streaming rather than one-shot content.
+        // The trailing `[1]` is the citation contract in miniature: the
+        // runtime stores only the evidence the answer actually cites, so an
+        // answer with no markers produces no citations at all.
         let chunks = [
             json!({
                 "choices": [{
@@ -307,7 +390,7 @@ fn streaming_chat_response(body: &Value, force_tool_calls: bool) -> ResponseTemp
             }),
             json!({
                 "choices": [{
-                    "delta": { "content": "grounded in the search results." },
+                    "delta": { "content": "grounded in the search results. [1]" },
                     "finish_reason": null,
                 }]
             }),
@@ -320,16 +403,23 @@ fn streaming_chat_response(body: &Value, force_tool_calls: bool) -> ResponseTemp
         ];
         sse_concat(&chunks)
     } else {
-        // First leg: ask the runtime to run `search_atoms`. The query is
-        // lifted from the most recent user message so the search hits the
-        // seeded atoms verbatim. The tool-call id must be unique per
-        // response — the runtime persists tool calls by this id, and
-        // concurrent conversations would otherwise collide on it.
-        let query = latest_user_query(body).unwrap_or_else(|| "atomic".to_string());
-        let arguments = json!({ "query": query, "limit": 5 }).to_string();
+        // First leg: ask the runtime to run a tool — `search_atoms` by
+        // default, with the query lifted from the most recent user message
+        // so the search hits the seeded atoms verbatim. The tool-call id
+        // must be unique per response — the runtime persists tool calls by
+        // this id, and concurrent conversations would otherwise collide.
+        let (tool_name, arguments) = tool_call.unwrap_or_else(|| {
+            let query = latest_user_query(body).unwrap_or_else(|| "atomic".to_string());
+            (
+                "search_atoms".to_string(),
+                json!({ "query": query, "limit": 5 }),
+            )
+        });
+        let arguments = arguments.to_string();
         static TOOL_CALL_SEQ: AtomicUsize = AtomicUsize::new(0);
         let call_id = format!(
-            "call_mock_search_{}",
+            "call_mock_{}_{}",
+            tool_name,
             TOOL_CALL_SEQ.fetch_add(1, Ordering::Relaxed)
         );
         let chunks = [
@@ -341,7 +431,7 @@ fn streaming_chat_response(body: &Value, force_tool_calls: bool) -> ResponseTemp
                             "id": call_id,
                             "type": "function",
                             "function": {
-                                "name": "search_atoms",
+                                "name": tool_name,
                                 "arguments": arguments,
                             }
                         }]
@@ -362,6 +452,77 @@ fn streaming_chat_response(body: &Value, force_tool_calls: bool) -> ResponseTemp
     ResponseTemplate::new(200)
         .insert_header("Content-Type", "text/event-stream")
         .set_body_raw(sse_body.into_bytes(), "text/event-stream")
+}
+
+/// Build a non-streaming `chat/completions` response for a research loop —
+/// the shape reports and wiki generation drive through `complete_with_tools`,
+/// where the model researches with tools and calls `done` when it has enough.
+///
+/// Which turn the model is on is recovered by counting the assistant messages
+/// that already carry tool calls, so `rounds[n]` is served on the nth turn
+/// however many calls each round makes. Past the end of the script the leg
+/// calls `done` — which, with the default empty script, is the first turn.
+/// `force` keeps it on the script's last round instead (see
+/// [`MockAiServer::set_research_force_tool_calls`]).
+fn research_chat_response(
+    body: &Value,
+    rounds: &[Vec<(String, Value)>],
+    force: bool,
+) -> ResponseTemplate {
+    let done_round = vec![("done".to_string(), json!({}))];
+    let turn = completed_tool_rounds(body);
+    let round = rounds
+        .get(turn)
+        .or_else(|| force.then(|| rounds.last()).flatten())
+        .unwrap_or(&done_round);
+
+    // Ids must be unique per call — both loops key their tool-result messages
+    // by id, and a repeated id makes the transcript ambiguous.
+    static TOOL_CALL_SEQ: AtomicUsize = AtomicUsize::new(0);
+    let tool_calls: Vec<Value> = round
+        .iter()
+        .map(|(name, arguments)| {
+            json!({
+                "id": format!("call_mock_{}_{}", name, TOOL_CALL_SEQ.fetch_add(1, Ordering::Relaxed)),
+                "type": "function",
+                "function": { "name": name, "arguments": arguments.to_string() }
+            })
+        })
+        .collect();
+
+    ResponseTemplate::new(200).set_body_json(json!({
+        "id": "mock-cmpl",
+        "object": "chat.completion",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": tool_calls,
+            },
+            "finish_reason": "tool_calls"
+        }]
+    }))
+}
+
+/// Model turns already spent on tools — the index of the round being asked
+/// for now.
+fn completed_tool_rounds(body: &Value) -> usize {
+    body.get("messages")
+        .and_then(|v| v.as_array())
+        .map(|messages| {
+            messages
+                .iter()
+                .filter(|message| {
+                    message.get("role").and_then(|r| r.as_str()) == Some("assistant")
+                        && message
+                            .get("tool_calls")
+                            .and_then(|calls| calls.as_array())
+                            .is_some_and(|calls| !calls.is_empty())
+                })
+                .count()
+        })
+        .unwrap_or(0)
 }
 
 fn sse_concat(chunks: &[Value]) -> String {
@@ -511,6 +672,11 @@ impl Respond for ChatResponder {
                 .expect("chat_models lock")
                 .push(model.to_string());
         }
+        self.counters
+            .chat_bodies
+            .lock()
+            .expect("chat_bodies lock")
+            .push(body.clone());
 
         // Streaming chat (agent loop). `stream: true` is answered with SSE
         // whatever else the request carries — see `streaming_chat_response`
@@ -527,36 +693,32 @@ impl Respond for ChatResponder {
             .unwrap_or(false);
         if is_streaming {
             let force = self.counters.chat_force_tool_calls.load(Ordering::Relaxed);
-            return with_delay(streaming_chat_response(&body, force));
+            let tool_call = self
+                .counters
+                .chat_tool_call
+                .lock()
+                .expect("chat_tool_call lock")
+                .clone();
+            return with_delay(streaming_chat_response(&body, force, tool_call));
         }
 
-        // Non-streaming chat with tools — used by the reports agentic loop.
-        // The agent expects either a tool call (research) or a content
-        // response with no tool calls (loop terminator). We short-circuit
-        // by calling `done` immediately, which keeps the research phase
-        // out of the report e2e tests (search-based tool flow is already
-        // covered by slice 3c's chat suite).
+        // Non-streaming chat with tools — the research loops reports and wiki
+        // generation run. Unscripted, it calls `done` immediately, which
+        // keeps the research phase out of tests that only care about what a
+        // run writes. `set_research_tool_rounds` scripts the research turns
+        // for the tests that do care.
         if !is_streaming && has_tools {
-            return with_delay(ResponseTemplate::new(200).set_body_json(json!({
-                "id": "mock-cmpl",
-                "object": "chat.completion",
-                "choices": [{
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": "",
-                        "tool_calls": [{
-                            "id": "call_done",
-                            "type": "function",
-                            "function": {
-                                "name": "done",
-                                "arguments": "{}"
-                            }
-                        }]
-                    },
-                    "finish_reason": "tool_calls"
-                }]
-            })));
+            let rounds = self
+                .counters
+                .research_tool_rounds
+                .lock()
+                .expect("research_tool_rounds lock")
+                .clone();
+            let force = self
+                .counters
+                .research_force_tool_calls
+                .load(Ordering::Relaxed);
+            return with_delay(research_chat_response(&body, &rounds, force));
         }
 
         // Inspect the requested schema name so this responder can serve

--- a/crates/atomic-test-support/src/mock_ai.rs
+++ b/crates/atomic-test-support/src/mock_ai.rs
@@ -15,7 +15,7 @@
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
@@ -95,6 +95,18 @@ struct MockAiCounters {
     /// failure) is held for this long before being sent — latency injection
     /// for tests that need requests to genuinely overlap in flight.
     chat_delay: Mutex<Option<std::time::Duration>>,
+    /// When true, a streaming request that offers tools always answers with
+    /// another tool call instead of wrapping up — a model that never stops
+    /// researching, which is how tests reach the agent loop's iteration cap.
+    chat_force_tool_calls: AtomicBool,
+    /// Conversation-title requests seen so far. Counted separately from
+    /// `chat_requests` because title generation is fire-and-forget: a test
+    /// waits on this to know the detached task actually ran.
+    title_requests: AtomicUsize,
+    /// When set, conversation-title requests serve this failure instead of a
+    /// title. Scoped to titles so the exchange that triggers one still
+    /// succeeds.
+    title_failure: Mutex<Option<InjectedFailure>>,
 }
 
 impl MockAiServer {
@@ -178,9 +190,36 @@ impl MockAiServer {
         *self.counters.chat_delay.lock().expect("chat_delay lock") = delay;
     }
 
+    /// Make every tool-bearing streaming request answer with another tool
+    /// call, so an agent loop runs until its own iteration cap stops it. A
+    /// request that offers no tools still answers with text — there is no
+    /// valid tool call to make.
+    pub fn set_chat_force_tool_calls(&self, force: bool) {
+        self.counters
+            .chat_force_tool_calls
+            .store(force, Ordering::Relaxed);
+    }
+
+    /// Conversation-title completions requested so far. Zero means the
+    /// detached title task never reached the provider.
+    pub fn title_request_count(&self) -> usize {
+        self.counters.title_requests.load(Ordering::Relaxed)
+    }
+
+    /// Make conversation-title requests fail with `failure` until cleared
+    /// with `None`. Requests are still counted while failing.
+    pub fn set_title_failure(&self, failure: Option<InjectedFailure>) {
+        *self
+            .counters
+            .title_failure
+            .lock()
+            .expect("title_failure lock") = failure;
+    }
+
     pub fn reset_counts(&self) {
         self.counters.embedding_requests.store(0, Ordering::Relaxed);
         self.counters.chat_requests.store(0, Ordering::Relaxed);
+        self.counters.title_requests.store(0, Ordering::Relaxed);
         self.counters
             .chat_models
             .lock()
@@ -228,13 +267,16 @@ fn embed_text(text: &str) -> Vec<f32> {
 /// - First turn: a single `tool_calls` delta requesting `search_atoms` with
 ///   a query plucked from the most recent user message. Closes with
 ///   `finish_reason: tool_calls`.
-/// - Tool results present: a single content delta with deterministic text,
-///   closes with `finish_reason: stop`.
+/// - Tool results present, or no tools offered at all: content deltas with
+///   deterministic text, closing with `finish_reason: stop`.
+///
+/// `force_tool_calls` keeps a tool-bearing request on the tool-call leg
+/// forever (see [`MockAiServer::set_chat_force_tool_calls`]).
 ///
 /// The provider parser is line-oriented (`data: ...\n`) and accepts the
 /// stream as a single body payload, so we don't need true chunked transfer
 /// to satisfy it.
-fn streaming_chat_response(body: &Value) -> ResponseTemplate {
+fn streaming_chat_response(body: &Value, force_tool_calls: bool) -> ResponseTemplate {
     let has_tool_results = body
         .get("messages")
         .and_then(|v| v.as_array())
@@ -243,13 +285,29 @@ fn streaming_chat_response(body: &Value) -> ResponseTemplate {
                 .any(|m| m.get("role").and_then(|r| r.as_str()) == Some("tool"))
         })
         .unwrap_or(false);
+    let tools_offered = body
+        .get("tools")
+        .and_then(|v| v.as_array())
+        .map(|tools| !tools.is_empty())
+        .unwrap_or(false);
+    // Without tools on the request there is nothing to call, so the only
+    // honest answer is prose — that's the shape of the agent loop's
+    // no-tools salvage call.
+    let answer_with_text = !tools_offered || (has_tool_results && !force_tool_calls);
 
-    let sse_body = if has_tool_results {
-        // Second leg: agent has tool results, emit final assistant text.
+    let sse_body = if answer_with_text {
+        // Final leg: emit the assistant text. Split across two deltas so
+        // tests exercise incremental streaming rather than one-shot content.
         let chunks = [
             json!({
                 "choices": [{
-                    "delta": { "content": "Mock assistant reply grounded in the search results." },
+                    "delta": { "content": "Mock assistant reply " },
+                    "finish_reason": null,
+                }]
+            }),
+            json!({
+                "choices": [{
+                    "delta": { "content": "grounded in the search results." },
                     "finish_reason": null,
                 }]
             }),
@@ -454,13 +512,10 @@ impl Respond for ChatResponder {
                 .push(model.to_string());
         }
 
-        // Streaming chat (agent loop). Detected by `stream: true` plus a
-        // `tools` array — the chat agent always sends tools, while wiki /
+        // Streaming chat (agent loop). `stream: true` is answered with SSE
+        // whatever else the request carries — see `streaming_chat_response`
+        // for how it picks between a tool call and final text. Wiki and
         // tagging only stream when explicitly enabled (they don't, today).
-        // Branch on whether the message log already contains tool results:
-        //   - no tool results yet → emit a tool_calls SSE that requests
-        //     `search_atoms`.
-        //   - tool results present → emit a final text-content SSE.
         let is_streaming = body
             .get("stream")
             .and_then(|v| v.as_bool())
@@ -470,8 +525,9 @@ impl Respond for ChatResponder {
             .and_then(|v| v.as_array())
             .map(|t| !t.is_empty())
             .unwrap_or(false);
-        if is_streaming && has_tools {
-            return with_delay(streaming_chat_response(&body));
+        if is_streaming {
+            let force = self.counters.chat_force_tool_calls.load(Ordering::Relaxed);
+            return with_delay(streaming_chat_response(&body, force));
         }
 
         // Non-streaming chat with tools — used by the reports agentic loop.
@@ -517,6 +573,31 @@ impl Respond for ChatResponder {
             .pointer("/response_format/json_schema/name")
             .and_then(|v| v.as_str())
             .map(str::to_string);
+
+        // Conversation titles: a plain completion whose system prompt asks
+        // for "a conversation title". The answer is deliberately decorated
+        // (wrapping quotes, trailing period) so tests see the caller's
+        // sanitizer do its job rather than a pre-cleaned string.
+        if request_text.contains("conversation title") {
+            self.counters.title_requests.fetch_add(1, Ordering::Relaxed);
+            if let Some(failure) = *self
+                .counters
+                .title_failure
+                .lock()
+                .expect("title_failure lock")
+            {
+                return with_delay(failure.response());
+            }
+            return with_delay(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "mock-cmpl",
+                "object": "chat.completion",
+                "choices": [{
+                    "index": 0,
+                    "message": { "role": "assistant", "content": "\"Notes About Pelicans.\"" },
+                    "finish_reason": "stop",
+                }],
+            })));
+        }
 
         if wire_schema.is_none() && request_text.contains("citations_used:") {
             if request_text.contains("wikifail") {

--- a/crates/atomic-test-support/src/mock_ai.rs
+++ b/crates/atomic-test-support/src/mock_ai.rs
@@ -1,5 +1,6 @@
 //! Wiremock-backed mock of the OpenAI-compat `/v1/embeddings` and
-//! `/v1/chat/completions` endpoints.
+//! `/v1/chat/completions` endpoints, plus Ollama's `/api/embed` and
+//! `/api/chat`.
 //!
 //! The provider in `atomic-core/src/providers/openai_compat.rs` is the real
 //! reqwest client — `MockAiServer::start` just stands up an HTTP listener
@@ -7,11 +8,30 @@
 //! point at `base_url()`, then exercise the full pipeline (chunk → embed →
 //! tag → edges) against deterministic responses.
 //!
+//! ## Dialects
+//!
+//! One server speaks all three provider wire formats, so the same knobs and
+//! counters drive a test whichever provider it points at:
+//!
+//! - **OpenAI-compat** (`/v1/...`): the original surface. `OpenAICompatProvider`
+//!   hits it directly.
+//! - **OpenRouter** (`/v1/...`): byte-identical to the above — the provider
+//!   normalizes a bare `base_url` by appending `/v1`, so pointing
+//!   `openrouter_base_url` at [`MockAiServer::base_url`] lands on the same
+//!   routes.
+//! - **Ollama** (`/api/chat`, `/api/embed`): a genuinely different wire
+//!   format — NDJSON rather than SSE, tool-call arguments as JSON objects
+//!   rather than strings, no ids and no `index` on tool calls. Served by
+//!   [`OllamaChatResponder`] / [`OllamaEmbedResponder`] so agent-runtime
+//!   behavior can be proven against the framing Ollama actually produces
+//!   instead of only against the OpenAI shape.
+//!
 //! ## Mock responder modes
 //!
-//! [`ChatResponder`] currently emits **tag extraction** results keyed off
-//! the request's `response_format.json_schema.name`. Slice 3 will extend
-//! this with wiki-article and chat-tool-call modes.
+//! [`ChatResponder`] emits tag extraction, wiki/long-form, research-loop,
+//! conversation-title, and streaming agent-loop responses, keyed off the
+//! request body (see its `respond`). The Ollama responder covers the subset
+//! the chat era needs: streaming turns and conversation titles.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -27,6 +47,15 @@ use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
 /// `vec_chunks float[1536]` schema so no dimension reconciliation kicks
 /// in mid-test.
 pub const EMBED_DIM: usize = 1536;
+
+/// Embedding width the **Ollama** dialect serves. Ollama's provider derives
+/// the stored width from the model *name* rather than the response
+/// (`providers::ollama::get_embedding_dimension`), whose fallback for an
+/// unregistered name is 768. A test pointing an Ollama-configured core at
+/// this mock therefore has to be embedding at 768, so `/api/embed` answers
+/// at that width — returning [`EMBED_DIM`] there would store vectors wider
+/// than the column the same config just declared.
+pub const OLLAMA_EMBED_DIM: usize = 768;
 
 /// Similarity threshold used by the pipeline when building semantic edges.
 /// Exposed here so tests can sanity-check that crafted atom pairs fall on
@@ -121,10 +150,34 @@ struct MockAiCounters {
     /// `chat_requests` because title generation is fire-and-forget: a test
     /// waits on this to know the detached task actually ran.
     title_requests: AtomicUsize,
+    /// When set, every streaming request is answered with this body verbatim
+    /// instead of a generated one — the escape hatch for pinning a parser
+    /// against wire shapes the generated responses don't produce (arguments
+    /// split across deltas, several tool calls interleaved, provider
+    /// metadata, a stream that ends without its sentinel).
+    stream_script: Mutex<Option<String>>,
     /// When set, conversation-title requests serve this failure instead of a
     /// title. Scoped to titles so the exchange that triggers one still
     /// succeeds.
     title_failure: Mutex<Option<InjectedFailure>>,
+}
+
+impl MockAiCounters {
+    /// The scripted streaming body, if one is set. Served verbatim; the
+    /// content type is the SSE one, which every dialect's parser ignores
+    /// (all three read the body as bytes and split on newlines).
+    fn scripted_stream(&self) -> Option<ResponseTemplate> {
+        let script = self
+            .stream_script
+            .lock()
+            .expect("stream_script lock")
+            .clone()?;
+        Some(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Type", "text/event-stream")
+                .set_body_raw(script.into_bytes(), "text/event-stream"),
+        )
+    }
 }
 
 impl MockAiServer {
@@ -148,6 +201,25 @@ impl MockAiServer {
         Mock::given(method("POST"))
             .and(path("/v1/chat/completions"))
             .respond_with(ChatResponder {
+                counters: counters.clone(),
+            })
+            .mount(&server)
+            .await;
+
+        // Ollama's surface, on the same listener and the same counters: a
+        // test switches dialect by pointing `ollama_host` here instead of
+        // `openai_compat_base_url`, and every knob/assertion still applies.
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .respond_with(OllamaEmbedResponder {
+                counters: counters.clone(),
+            })
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/chat"))
+            .respond_with(OllamaChatResponder {
                 counters: counters.clone(),
             })
             .mount(&server)
@@ -269,6 +341,27 @@ impl MockAiServer {
             .store(force, Ordering::Relaxed);
     }
 
+    /// Answer every **streaming** request with `body` verbatim, whichever
+    /// dialect's endpoint it arrives on. Clear with `None`.
+    ///
+    /// The generated streaming responses are deliberately tidy — one
+    /// complete tool call per delta, no provider metadata, always a closing
+    /// sentinel — which leaves a provider's accumulator and metadata
+    /// handling untested. This hands a test the exact bytes instead, so it
+    /// can pin what the parser does with arguments dribbled across a dozen
+    /// deltas, two tool calls interleaved by index, or a stream that simply
+    /// stops.
+    ///
+    /// The caller supplies framing: `data: {...}\n\n` for the SSE dialects,
+    /// one JSON object per line for Ollama.
+    pub fn set_stream_script(&self, body: Option<&str>) {
+        *self
+            .counters
+            .stream_script
+            .lock()
+            .expect("stream_script lock") = body.map(str::to_string);
+    }
+
     /// Conversation-title completions requested so far. Zero means the
     /// detached title task never reached the provider.
     pub fn title_request_count(&self) -> usize {
@@ -302,11 +395,19 @@ impl MockAiServer {
     }
 }
 
-/// Bag-of-words style unit-vector embedder. Two texts sharing words land
-/// at the same positions → high cosine similarity → edge crosses the 0.5
-/// threshold. Disjoint texts end up near-orthogonal.
+/// Bag-of-words style unit-vector embedder at [`EMBED_DIM`]. Two texts
+/// sharing words land at the same positions → high cosine similarity → edge
+/// crosses the 0.5 threshold. Disjoint texts end up near-orthogonal.
 fn embed_text(text: &str) -> Vec<f32> {
-    let mut vec = vec![0.0f32; EMBED_DIM];
+    embed_text_at(text, EMBED_DIM)
+}
+
+/// [`embed_text`] at an explicit width, so a dialect whose provider pins a
+/// different dimension (Ollama, [`OLLAMA_EMBED_DIM`]) gets vectors its own
+/// vector column accepts. The hashing is width-relative, so the same text
+/// still embeds deterministically — just in a different space.
+fn embed_text_at(text: &str, dim: usize) -> Vec<f32> {
+    let mut vec = vec![0.0f32; dim];
     for word in text.split_whitespace() {
         let normalized: String = word
             .chars()
@@ -318,7 +419,7 @@ fn embed_text(text: &str) -> Vec<f32> {
         }
         let mut h = DefaultHasher::new();
         normalized.hash(&mut h);
-        let idx = (h.finish() as usize) % EMBED_DIM;
+        let idx = (h.finish() as usize) % dim;
         vec[idx] += 1.0;
     }
     let norm: f32 = vec.iter().map(|v| v * v).sum::<f32>().sqrt();
@@ -357,6 +458,95 @@ fn streaming_chat_response(
     force_tool_calls: bool,
     tool_call: Option<(String, Value)>,
 ) -> ResponseTemplate {
+    let sse_body = match stream_leg(body, force_tool_calls, tool_call) {
+        StreamLeg::Text(fragments) => {
+            let mut chunks: Vec<Value> = fragments
+                .iter()
+                .map(|text| {
+                    json!({
+                        "choices": [{
+                            "delta": { "content": text },
+                            "finish_reason": null,
+                        }]
+                    })
+                })
+                .collect();
+            chunks.push(json!({
+                "choices": [{
+                    "delta": {},
+                    "finish_reason": "stop",
+                }]
+            }));
+            sse_concat(&chunks)
+        }
+        StreamLeg::ToolCall {
+            id,
+            name,
+            arguments,
+        } => {
+            let chunks = [
+                json!({
+                    "choices": [{
+                        "delta": {
+                            "tool_calls": [{
+                                "index": 0,
+                                "id": id,
+                                "type": "function",
+                                // OpenAI-shaped tool calls carry arguments as
+                                // a *string* of JSON, accumulated across
+                                // deltas by the provider.
+                                "function": {
+                                    "name": name,
+                                    "arguments": arguments.to_string(),
+                                }
+                            }]
+                        },
+                        "finish_reason": null,
+                    }]
+                }),
+                json!({
+                    "choices": [{
+                        "delta": {},
+                        "finish_reason": "tool_calls",
+                    }]
+                }),
+            ];
+            sse_concat(&chunks)
+        }
+    };
+
+    ResponseTemplate::new(200)
+        .insert_header("Content-Type", "text/event-stream")
+        .set_body_raw(sse_body.into_bytes(), "text/event-stream")
+}
+
+/// What a streaming turn answers with, before any wire format is chosen.
+/// Shared by every dialect so the *decision* (tool call vs. prose) is one
+/// implementation and only the framing differs — which is exactly the axis
+/// a cross-provider test wants to vary.
+enum StreamLeg {
+    /// Assistant prose, pre-split into the fragments the provider should
+    /// surface as separate deltas.
+    Text(Vec<String>),
+    /// One tool call. `arguments` is the JSON *value*; each dialect encodes
+    /// it the way its wire format does (string for OpenAI, object for
+    /// Ollama).
+    ToolCall {
+        id: String,
+        name: String,
+        arguments: Value,
+    },
+}
+
+/// Pick the leg for a streaming request: a tool call while there is
+/// research to do, prose once tool results are in — or immediately when the
+/// request offers no tools at all, which is the shape of the agent loop's
+/// iteration-cap salvage call.
+fn stream_leg(
+    body: &Value,
+    force_tool_calls: bool,
+    tool_call: Option<(String, Value)>,
+) -> StreamLeg {
     let has_tool_results = body
         .get("messages")
         .and_then(|v| v.as_array())
@@ -373,85 +563,41 @@ fn streaming_chat_response(
     // Without tools on the request there is nothing to call, so the only
     // honest answer is prose — that's the shape of the agent loop's
     // no-tools salvage call.
-    let answer_with_text = !tools_offered || (has_tool_results && !force_tool_calls);
+    if !tools_offered || (has_tool_results && !force_tool_calls) {
+        // Final leg: the assistant text, split so tests exercise incremental
+        // streaming rather than one-shot content. The trailing `[1]` is the
+        // citation contract in miniature: the runtime stores only the
+        // evidence the answer actually cites, so an answer with no markers
+        // produces no citations at all.
+        return StreamLeg::Text(vec![
+            "Mock assistant reply ".to_string(),
+            "grounded in the search results. [1]".to_string(),
+        ]);
+    }
 
-    let sse_body = if answer_with_text {
-        // Final leg: emit the assistant text. Split across two deltas so
-        // tests exercise incremental streaming rather than one-shot content.
-        // The trailing `[1]` is the citation contract in miniature: the
-        // runtime stores only the evidence the answer actually cites, so an
-        // answer with no markers produces no citations at all.
-        let chunks = [
-            json!({
-                "choices": [{
-                    "delta": { "content": "Mock assistant reply " },
-                    "finish_reason": null,
-                }]
-            }),
-            json!({
-                "choices": [{
-                    "delta": { "content": "grounded in the search results. [1]" },
-                    "finish_reason": null,
-                }]
-            }),
-            json!({
-                "choices": [{
-                    "delta": {},
-                    "finish_reason": "stop",
-                }]
-            }),
-        ];
-        sse_concat(&chunks)
-    } else {
-        // First leg: ask the runtime to run a tool — `search_atoms` by
-        // default, with the query lifted from the most recent user message
-        // so the search hits the seeded atoms verbatim. The tool-call id
-        // must be unique per response — the runtime persists tool calls by
-        // this id, and concurrent conversations would otherwise collide.
-        let (tool_name, arguments) = tool_call.unwrap_or_else(|| {
-            let query = latest_user_query(body).unwrap_or_else(|| "atomic".to_string());
-            (
-                "search_atoms".to_string(),
-                json!({ "query": query, "limit": 5 }),
-            )
-        });
-        let arguments = arguments.to_string();
-        static TOOL_CALL_SEQ: AtomicUsize = AtomicUsize::new(0);
-        let call_id = format!(
-            "call_mock_{}_{}",
-            tool_name,
-            TOOL_CALL_SEQ.fetch_add(1, Ordering::Relaxed)
-        );
-        let chunks = [
-            json!({
-                "choices": [{
-                    "delta": {
-                        "tool_calls": [{
-                            "index": 0,
-                            "id": call_id,
-                            "type": "function",
-                            "function": {
-                                "name": tool_name,
-                                "arguments": arguments,
-                            }
-                        }]
-                    },
-                    "finish_reason": null,
-                }]
-            }),
-            json!({
-                "choices": [{
-                    "delta": {},
-                    "finish_reason": "tool_calls",
-                }]
-            }),
-        ];
-        sse_concat(&chunks)
-    };
-
-    ResponseTemplate::new(200)
-        .insert_header("Content-Type", "text/event-stream")
-        .set_body_raw(sse_body.into_bytes(), "text/event-stream")
+    // First leg: ask the runtime to run a tool — `search_atoms` by default,
+    // with the query lifted from the most recent user message so the search
+    // hits the seeded atoms verbatim. The tool-call id must be unique per
+    // response — the runtime persists tool calls by this id, and concurrent
+    // conversations would otherwise collide.
+    let (name, arguments) = tool_call.unwrap_or_else(|| {
+        let query = latest_user_query(body).unwrap_or_else(|| "atomic".to_string());
+        (
+            "search_atoms".to_string(),
+            json!({ "query": query, "limit": 5 }),
+        )
+    });
+    static TOOL_CALL_SEQ: AtomicUsize = AtomicUsize::new(0);
+    let id = format!(
+        "call_mock_{}_{}",
+        name,
+        TOOL_CALL_SEQ.fetch_add(1, Ordering::Relaxed)
+    );
+    StreamLeg::ToolCall {
+        id,
+        name,
+        arguments,
+    }
 }
 
 /// Build a non-streaming `chat/completions` response for a research loop —
@@ -692,6 +838,9 @@ impl Respond for ChatResponder {
             .map(|t| !t.is_empty())
             .unwrap_or(false);
         if is_streaming {
+            if let Some(script) = self.counters.scripted_stream() {
+                return with_delay(script);
+            }
             let force = self.counters.chat_force_tool_calls.load(Ordering::Relaxed);
             let tool_call = self
                 .counters
@@ -894,4 +1043,203 @@ impl Respond for ChatResponder {
         }));
         with_delay(response)
     }
+}
+
+// ==================== Ollama dialect ====================
+
+/// `POST /api/embed` — Ollama's batch embedding endpoint. Same deterministic
+/// embedder as the OpenAI surface, at [`OLLAMA_EMBED_DIM`] (see that
+/// constant for why the width differs), and wrapped in Ollama's
+/// `{ "embeddings": [[..]] }` envelope rather than OpenAI's `data` list.
+struct OllamaEmbedResponder {
+    counters: Arc<MockAiCounters>,
+}
+
+impl Respond for OllamaEmbedResponder {
+    fn respond(&self, req: &Request) -> ResponseTemplate {
+        self.counters
+            .embedding_requests
+            .fetch_add(1, Ordering::Relaxed);
+        if let Some(failure) = *self
+            .counters
+            .embedding_failure
+            .lock()
+            .expect("embedding_failure lock")
+        {
+            return failure.response();
+        }
+        let body: Value = match serde_json::from_slice(&req.body) {
+            Ok(v) => v,
+            Err(_) => return ResponseTemplate::new(400),
+        };
+        let Some(inputs) = body.get("input").and_then(|v| v.as_array()) else {
+            return ResponseTemplate::new(400);
+        };
+        let embeddings: Vec<Vec<f32>> = inputs
+            .iter()
+            .map(|text| embed_text_at(text.as_str().unwrap_or_default(), OLLAMA_EMBED_DIM))
+            .collect();
+        ResponseTemplate::new(200).set_body_json(json!({
+            "model": body.get("model").cloned().unwrap_or(Value::Null),
+            "embeddings": embeddings,
+        }))
+    }
+}
+
+/// `POST /api/chat` — Ollama's single chat endpoint, streaming and not.
+///
+/// The framing is the point. Where OpenAI streams `data: {...}` SSE frames
+/// and accumulates tool-call arguments from string deltas, Ollama streams
+/// **newline-delimited JSON objects**, terminated by one carrying
+/// `done: true`, and emits each tool call complete in a single frame with
+/// its arguments as a **JSON object** and no id and no `index`. The
+/// provider synthesizes ids locally. Reproducing that faithfully is what
+/// lets an agent-runtime test prove delta emission, tool accumulation and
+/// cancellation against Ollama rather than against the OpenAI shape wearing
+/// an Ollama label.
+struct OllamaChatResponder {
+    counters: Arc<MockAiCounters>,
+}
+
+impl Respond for OllamaChatResponder {
+    fn respond(&self, req: &Request) -> ResponseTemplate {
+        self.counters.chat_requests.fetch_add(1, Ordering::Relaxed);
+        let delay = *self.counters.chat_delay.lock().expect("chat_delay lock");
+        let with_delay = |response: ResponseTemplate| match delay {
+            Some(d) => response.set_delay(d),
+            None => response,
+        };
+        if let Some(failure) = *self
+            .counters
+            .chat_failure
+            .lock()
+            .expect("chat_failure lock")
+        {
+            return with_delay(failure.response());
+        }
+        let body: Value = match serde_json::from_slice(&req.body) {
+            Ok(v) => v,
+            Err(_) => return with_delay(ResponseTemplate::new(400)),
+        };
+        if let Some(model) = body.get("model").and_then(|v| v.as_str()) {
+            self.counters
+                .chat_models
+                .lock()
+                .expect("chat_models lock")
+                .push(model.to_string());
+        }
+        self.counters
+            .chat_bodies
+            .lock()
+            .expect("chat_bodies lock")
+            .push(body.clone());
+
+        if body
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            if let Some(script) = self.counters.scripted_stream() {
+                return with_delay(script);
+            }
+            let force = self.counters.chat_force_tool_calls.load(Ordering::Relaxed);
+            let tool_call = self
+                .counters
+                .chat_tool_call
+                .lock()
+                .expect("chat_tool_call lock")
+                .clone();
+            return with_delay(ollama_stream_response(&body, force, tool_call));
+        }
+
+        // Conversation titles are the one non-streaming call the chat era
+        // makes, and the model it rides is provider-specific — so it has to
+        // be answerable in this dialect too. Same deliberately decorated
+        // answer as the OpenAI surface, so the same sanitizer assertions
+        // hold whichever provider produced it.
+        let request_text = body.to_string().to_lowercase();
+        if request_text.contains("conversation title") {
+            self.counters.title_requests.fetch_add(1, Ordering::Relaxed);
+            if let Some(failure) = *self
+                .counters
+                .title_failure
+                .lock()
+                .expect("title_failure lock")
+            {
+                return with_delay(failure.response());
+            }
+            return with_delay(ollama_message_response("\"Notes About Pelicans.\""));
+        }
+
+        // Anything else non-streaming (tagging's structured `format` call,
+        // the research loops' `complete_with_tools`) gets an empty, valid
+        // answer. Those surfaces are covered against the OpenAI dialect;
+        // scripting them here too would be duplicating the responder, not
+        // the coverage.
+        with_delay(ollama_message_response("{}"))
+    }
+}
+
+/// Ollama's NDJSON stream: one JSON object per line, the last carrying
+/// `done: true`. Content arrives as `message.content` fragments; tool calls
+/// arrive whole, with object-valued arguments and no ids.
+fn ollama_stream_response(
+    body: &Value,
+    force_tool_calls: bool,
+    tool_call: Option<(String, Value)>,
+) -> ResponseTemplate {
+    let mut lines: Vec<Value> = Vec::new();
+    match stream_leg(body, force_tool_calls, tool_call) {
+        StreamLeg::Text(fragments) => {
+            for text in fragments {
+                lines.push(json!({
+                    "model": "mock-ollama",
+                    "message": { "role": "assistant", "content": text },
+                    "done": false,
+                }));
+            }
+        }
+        StreamLeg::ToolCall {
+            // Ollama never sends a tool-call id; the provider mints one.
+            id: _,
+            name,
+            arguments,
+        } => {
+            lines.push(json!({
+                "model": "mock-ollama",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{ "function": { "name": name, "arguments": arguments } }],
+                },
+                "done": false,
+            }));
+        }
+    }
+    // The terminating frame. The provider stops reading at the first
+    // `done: true`, so nothing may follow it.
+    lines.push(json!({
+        "model": "mock-ollama",
+        "message": { "role": "assistant", "content": "" },
+        "done": true,
+        "done_reason": "stop",
+    }));
+
+    let ndjson = lines
+        .iter()
+        .map(|line| format!("{line}\n"))
+        .collect::<String>();
+    ResponseTemplate::new(200)
+        .insert_header("Content-Type", "application/x-ndjson")
+        .set_body_raw(ndjson.into_bytes(), "application/x-ndjson")
+}
+
+/// A non-streaming Ollama `/api/chat` answer carrying prose.
+fn ollama_message_response(content: &str) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(json!({
+        "model": "mock-ollama",
+        "message": { "role": "assistant", "content": content },
+        "done": true,
+        "done_reason": "stop",
+    }))
 }

--- a/docs/manual/api/websocket-events.md
+++ b/docs/manual/api/websocket-events.md
@@ -83,6 +83,7 @@ These power progress UI for Obsidian import, URL ingestion, browser clipping, iO
 - `ChatComplete`
 - `ChatCanvasAction`
 - `ChatError`
+- `ChatConversationUpdated`
 
 The message send endpoint returns a final response, but the UI receives streaming deltas and tool events over WebSocket.
 

--- a/docs/manual/api/websocket-events.md
+++ b/docs/manual/api/websocket-events.md
@@ -87,6 +87,12 @@ These power progress UI for Obsidian import, URL ingestion, browser clipping, iO
 
 The message send endpoint returns a final response, but the UI receives streaming deltas and tool events over WebSocket.
 
+### `ChatStreamDelta.content` is incremental
+
+Each `ChatStreamDelta` carries **only the new text** produced since the previous delta. Clients append them; the concatenation of every delta for a `conversation_id` is the assistant's answer, and `ChatComplete` carries the authoritative full message.
+
+This is a behavior change under an unchanged event name. Earlier builds sent the **cumulative** text so far in each delta, so a client written against them could replace its buffer on every delta and still render correctly. That client now renders only the last fragment. If you maintain a raw WebSocket client, switch it from replace to append — there is no version flag to branch on, and no way to tell the two shapes apart from a single delta.
+
 ## Dashboard Events
 
 - `DashboardFeaturedChanged`

--- a/docs/manual/concepts/chat.md
+++ b/docs/manual/concepts/chat.md
@@ -33,6 +33,8 @@ Every turn has the same core tools — your atoms, the synthesized layers above 
 
 More tools appear conditionally: `get_current_page_context` when the app sent page context (see below), and `zoom_to_cluster` / `focus_atom` when you are chatting over the canvas.
 
+Every reading tool answers within the conversation's scope — see [Scoped Conversations](#scoped-conversations).
+
 ## Citations
 
 The Sources list under an answer holds only the sources the answer actually cited. Every tool result the agent sees is numbered, and the `[N]` markers in the finished text decide which of those numbered sources are stored — material the agent read but never cited leaves no trace, and a number the model invents is dropped. A source surfaced more than once in a turn keeps its first number, so `[2]` means the same thing everywhere in an answer.
@@ -57,7 +59,9 @@ Conversations can be scoped to specific tags, giving you focused answers about a
 
 An atom is in scope when it satisfies all three rules at once. With nothing included, the base set is your whole knowledge base and the remaining rules narrow it — so an exclude-only scope means "everything except this". A tag always covers its child tags.
 
-The scope is enforced by search itself, not by asking the model to behave: the assistant is told what the scope is, and cannot widen it. Reading a specific atom, wiki article, or report finding by id is deliberately unscoped — the scope shapes what the agent can *find*, not what you can point it at.
+The scope is enforced by the tools, not by asking the model to behave: the assistant is told what the scope is, and cannot widen it. Every read goes through the same rule — search results, the tag tree `list_tags` returns, the article `get_wiki` reads, the findings `list_reports` names and `get_finding` opens, and any atom fetched by id. A request for something outside the scope comes back as a refusal that says so, with none of the content attached.
+
+The one deliberate exception is the page context you share with a message: what you are currently looking at reaches the assistant because you chose to share it (see [Page Context](#page-context)). It is never turned into a citation when the scope excludes it, so an answer can't come to rest on it.
 
 ## Conversations
 

--- a/docs/manual/concepts/chat.md
+++ b/docs/manual/concepts/chat.md
@@ -24,7 +24,13 @@ Conversations can be scoped to specific tags. When scoped, the agent only search
 
 Chat conversations are persisted. You can revisit previous conversations and continue where you left off. Each conversation tracks messages and scoped tags.
 
-Conversations can also be renamed, archived, or deleted through the API/UI.
+Conversations can also be renamed, archived, or deleted through the API/UI. Archived conversations are hidden from the list until you ask for them (`include_archived=true`).
+
+After the first exchange, an untitled conversation names itself: one short completion on the **tagging** model turns the opening question and answer into a title of at most six words. It runs in the background — a failure costs the exchange nothing and simply leaves the conversation untitled — and never overwrites a title that already exists, so a rename is final.
+
+## Page Context
+
+Messages sent from the app carry a small description of what you were looking at (the open atom, the wiki you were reading, the tag filter in effect) so the assistant can answer "this" questions. The composer shows what is attached, and dismissing that chip stops page context from being sent for the rest of the conversation.
 
 ## API and Events
 
@@ -37,8 +43,11 @@ The primary endpoints are:
 - `DELETE /api/conversations/{id}`
 - `PUT /api/conversations/{id}/scope`
 - `POST /api/conversations/{id}/messages`
+- `POST /api/conversations/{id}/messages/cancel`
 
-Streaming event names exposed to the frontend include `chat-stream-delta`, `chat-tool-start`, `chat-tool-complete`, `chat-complete`, `chat-canvas-action`, and `chat-error`.
+Streaming event names exposed to the frontend include `chat-stream-delta`, `chat-tool-start`, `chat-tool-complete`, `chat-complete`, `chat-canvas-action`, `chat-conversation-updated` (an auto-generated title landed), and `chat-error`. Each `chat-stream-delta` carries one incremental chunk of assistant text — clients append them; `chat-complete` carries the authoritative full message.
+
+Cancelling is cooperative and idempotent: the endpoint answers `202` whether or not a turn was running, and a running turn stops at its next checkpoint, persisting the partial answer with a trailing `*(stopped)*` marker.
 
 ## Provider Notes
 

--- a/docs/manual/concepts/chat.md
+++ b/docs/manual/concepts/chat.md
@@ -7,7 +7,7 @@ Chat is an agentic RAG system that lets you ask questions grounded in your Atomi
 
 ## How It Works
 
-The chat agent has tools to search your atoms during conversation. When you ask a question:
+The chat agent has tools to search and read your knowledge base during conversation. When you ask a question:
 
 1. The agent decides whether to search your notes.
 2. It formulates search queries and retrieves relevant chunks.
@@ -16,9 +16,48 @@ The chat agent has tools to search your atoms during conversation. When you ask 
 
 Chat can emit tool-start and tool-complete events, citations, and canvas actions. The REST call that sends a message returns the final assistant message, while the UI updates from streaming events as the model responds.
 
+## Tools
+
+Every turn has the same core tools — your atoms, the synthesized layers above them, and two write tools:
+
+| Tool | What It Does |
+|------|--------------|
+| `search_atoms` | Hybrid keyword + semantic search over the atoms in scope. Optional `since_days` recency filter for time-sensitive questions |
+| `get_atom` | Read one atom's full content by ID, paginated by line (500 at a time by default) |
+| `list_tags` | The hierarchical tag tree with atom counts (counts include sub-tags) — the map of how your knowledge is organized, and the source of `tag_id` values for other tools. Returns the top of the tree and one level below it; `parent_id` expands a branch further |
+| `get_wiki` | Read the wiki article for a tag by name or ID — the synthesized overview of everything stored under that topic, instead of stitching many search results together. Paginated like `get_atom` |
+| `list_reports` | The scheduled research reports configured in this database, each with its most recent finding |
+| `get_finding` | Read one report finding in full, with the report it came from. Paginated like `get_atom` |
+| `create_atom` | Create a new atom — only when you explicitly ask for one |
+| `edit_atom` | Targeted markdown edits to an existing atom: `replace`, `insert_after`, `append`, `replace_all`. Also only on request |
+
+More tools appear conditionally: `get_current_page_context` when the app sent page context (see below), and `zoom_to_cluster` / `focus_atom` when you are chatting over the canvas.
+
+## Citations
+
+The Sources list under an answer holds only the sources the answer actually cited. Every tool result the agent sees is numbered, and the `[N]` markers in the finished text decide which of those numbered sources are stored — material the agent read but never cited leaves no trace, and a number the model invents is dropped. A source surfaced more than once in a turn keeps its first number, so `[2]` means the same thing everywhere in an answer.
+
+Citations are typed by what they point at:
+
+- **Atom** — from `search_atoms`, `get_atom`, or an atom the agent just created or edited.
+- **Wiki article** — from `get_wiki`, labeled with the tag whose article it is.
+- **Finding** — from `get_finding`.
+
+Clicking a `[N]` marker, or a chip in the Sources list, opens a popover with the cited excerpt and a link to the source. Atoms and wiki articles open scrolled to that excerpt; findings open in the finding reader, at the top.
+
+Wiki articles and findings carry `[N]` markers of their own, pointing at *their* sources. Those are stripped before the text reaches the model, so every number in an answer resolves against this turn's sources. Over the API, a citation row carries `source_type` (`atom`, `wiki`, or `finding`), a `source_title` for wiki citations, and an `atom_id` that is read according to the source type — the tag ID for a wiki article, the atom ID otherwise.
+
 ## Scoped Conversations
 
-Conversations can be scoped to specific tags. When scoped, the agent only searches atoms under those tags, giving you focused answers about a particular topic.
+Conversations can be scoped to specific tags, giving you focused answers about a particular topic. Each scope tag plays one of three roles, and clicking a tag chip in the chat header cycles between them:
+
+- **Include** — a result may carry any of the included tags. This is the default, and a scope of includes alone is a plain "any of these topics" filter.
+- **Require** — every result must carry this tag. Use it to intersect: include *Rust*, require *Reading List*.
+- **Exclude** — no result may carry this tag, even if another rule would have admitted it.
+
+An atom is in scope when it satisfies all three rules at once. With nothing included, the base set is your whole knowledge base and the remaining rules narrow it — so an exclude-only scope means "everything except this". A tag always covers its child tags.
+
+The scope is enforced by search itself, not by asking the model to behave: the assistant is told what the scope is, and cannot widen it. Reading a specific atom, wiki article, or report finding by id is deliberately unscoped — the scope shapes what the agent can *find*, not what you can point it at.
 
 ## Conversations
 
@@ -42,8 +81,12 @@ The primary endpoints are:
 - `PUT /api/conversations/{id}`
 - `DELETE /api/conversations/{id}`
 - `PUT /api/conversations/{id}/scope`
+- `POST /api/conversations/{id}/scope/tags`
+- `DELETE /api/conversations/{id}/scope/tags/{tag_id}`
 - `POST /api/conversations/{id}/messages`
 - `POST /api/conversations/{id}/messages/cancel`
+
+Scope entries carry their mode. `PUT .../scope` takes `{"tag_ids": [{"tag_id": "...", "mode": "require"}, ...]}`, and a bare tag id in that array still means include, so clients written before modes existed keep working. `POST .../scope/tags` takes `{"tag_id": "...", "mode": "exclude"}` (mode optional, defaults to include) and re-posting a tag already in scope changes its mode rather than failing.
 
 Streaming event names exposed to the frontend include `chat-stream-delta`, `chat-tool-start`, `chat-tool-complete`, `chat-complete`, `chat-canvas-action`, `chat-conversation-updated` (an auto-generated title landed), and `chat-error`. Each `chat-stream-delta` carries one incremental chunk of assistant text — clients append them; `chat-complete` carries the authoritative full message.
 
@@ -57,4 +100,6 @@ Chat requires an LLM provider and model that can handle the conversation and too
 
 - [AI Providers](/getting-started/ai-providers/)
 - [Tags](/concepts/tags/)
+- [Wiki Synthesis](/concepts/wiki-synthesis/)
+- [Reports](/concepts/reports/)
 - [MCP Server](/guides/mcp-server/)

--- a/docs/manual/getting-started/ai-providers.md
+++ b/docs/manual/getting-started/ai-providers.md
@@ -73,10 +73,10 @@ Fresh databases seed these defaults:
 | Setting | Default |
 |---------|---------|
 | `provider` | `openrouter` |
-| `embedding_model` | `openai/text-embedding-3-small` |
-| `tagging_model` | `openai/gpt-4o-mini` |
-| `wiki_model` | `anthropic/claude-sonnet-4.6` |
-| `chat_model` | `anthropic/claude-sonnet-4.6` |
+| `embedding_model` | `qwen/qwen3-embedding-8b` |
+| `tagging_model` | `openai/gpt-5-nano` |
+| `wiki_model` | `anthropic/claude-sonnet-5` |
+| `chat_model` | `anthropic/claude-sonnet-5` |
 | `ollama_host` | `http://127.0.0.1:11434` |
 | `ollama_embedding_model` | `nomic-embed-text` |
 | `ollama_llm_model` | `llama3.2` |

--- a/plugins/obsidian-plugin/src/atomic-client.ts
+++ b/plugins/obsidian-plugin/src/atomic-client.ts
@@ -130,6 +130,11 @@ export interface ChatCitation {
   relevance_score: number | null;
   /** Source URL of the cited atom (populated by server for client linking). */
   source_url?: string | null;
+  /**
+   * What `atom_id` identifies: an atom, the tag behind a wiki article, or a
+   * finding's atom. Absent on citations stored before source types existed.
+   */
+  source_type?: "atom" | "wiki" | "finding";
 }
 
 export interface ChatMessageWithContext extends ChatMessage {

--- a/plugins/obsidian-plugin/src/chat-view.ts
+++ b/plugins/obsidian-plugin/src/chat-view.ts
@@ -623,6 +623,9 @@ export class ChatView extends ItemView {
       const index = parseInt(idxStr, 10);
       const cit = byIndex.get(index);
       if (!cit) return match;
+      // Wiki articles and findings have no vault note and no atom to fetch;
+      // their marker stays plain text rather than becoming a dead link.
+      if (cit.source_type && cit.source_type !== "atom") return match;
 
       const atom = this.atomCache.get(cit.atom_id);
       const url = atom?.source_url ?? null;

--- a/src/components/atoms/AtomReader.tsx
+++ b/src/components/atoms/AtomReader.tsx
@@ -11,6 +11,7 @@ import { useTagsStore } from '../../stores/tags';
 import { useUIStore } from '../../stores/ui';
 import { useInlineEditor } from '../../hooks';
 import { formatDate } from '../../lib/date';
+import { isTypingTarget } from '../../lib/keyboard';
 import { getTransport, isDemoInstance } from '../../lib/transport';
 import { readerEditorActions } from '../../lib/reader-editor-bridge';
 import { atomLinkExtension, type AtomLinkSuggestion, type AtomLinkSuggestionSource } from '../../editor/atom-links';
@@ -575,14 +576,6 @@ function AtomReaderContent({
       </Modal>
     </div>
   );
-}
-
-/// Whether a keystroke is destined for a real text input, so single-letter
-/// shortcuts (`i`) must not hijack it. The read-mode editor body is not
-/// contenteditable, so it never matches.
-function isTypingTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 }
 
 function searchResultsToAtomLinkSuggestions(

--- a/src/components/canvas/SigmaCanvas.tsx
+++ b/src/components/canvas/SigmaCanvas.tsx
@@ -847,8 +847,11 @@ export function SigmaCanvas({
     sigmaRef.current?.refresh();
   }, [selectedTagId]);
 
-  // Continuously refresh sigma during chat sidebar transition so the graph resizes smoothly
+  // Continuously refresh sigma during chat sidebar transition so the graph
+  // resizes smoothly. Expanding the pane collapses this column to zero width
+  // without unmounting it, so the same catch-up applies.
   const chatSidebarOpen = useUIStore(s => s.chatSidebarOpen);
+  const chatSidebarExpanded = useUIStore(s => s.chatSidebarExpanded);
   useEffect(() => {
     const start = performance.now();
     let raf: number;
@@ -860,7 +863,7 @@ export function SigmaCanvas({
     }
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [chatSidebarOpen]);
+  }, [chatSidebarOpen, chatSidebarExpanded]);
 
   // Subscribe to canvas action events from the chat agent.
   // Preview instances don't own the controller and shouldn't react to chat actions.

--- a/src/components/chat/ChatContextChip.tsx
+++ b/src/components/chat/ChatContextChip.tsx
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+import { Eye, EyeOff, X } from 'lucide-react';
+import { useChatStore } from '../../stores/chat';
+import { useUIStore } from '../../stores/ui';
+import { useAtomsStore } from '../../stores/atoms';
+import { useTagsStore, TagWithCount } from '../../stores/tags';
+import { isDemoInstance } from '../../lib/transport';
+
+function findTagName(nodes: TagWithCount[], tagId: string): string | null {
+  for (const node of nodes) {
+    if (node.id === tagId) return node.name;
+    const found = node.children?.length ? findTagName(node.children, tagId) : null;
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * What `buildPageContext()` in the chat store will attach to the next
+ * message, in the same precedence order it uses. `null` means the current
+ * view carries nothing worth announcing.
+ */
+function usePageContextLabel(): string | null {
+  const readerAtomId = useUIStore((s) => s.readerState.atomId);
+  const wikiTagName = useUIStore((s) => s.wikiReaderState.tagName);
+  const graphAtomId = useUIStore((s) => (s.localGraph.isOpen ? s.localGraph.centerAtomId : null));
+  const selectedTagId = useUIStore((s) => s.selectedTagId);
+  const atoms = useAtomsStore((s) => s.atoms);
+  const tags = useTagsStore((s) => s.tags);
+
+  const atomId = readerAtomId ?? (wikiTagName ? null : graphAtomId);
+
+  return useMemo(() => {
+    if (atomId) {
+      // The atom may not be in the loaded page (opened from a citation), so
+      // name it generically rather than guessing.
+      return atoms.find((a) => a.id === atomId)?.title || 'the open atom';
+    }
+    if (wikiTagName) return `the ${wikiTagName} wiki`;
+    if (selectedTagId) {
+      const name = findTagName(tags, selectedTagId);
+      return name ? `the ${name} filter` : null;
+    }
+    return null;
+  }, [atomId, atoms, wikiTagName, selectedTagId, tags]);
+}
+
+/**
+ * One quiet row above the composer naming what leaves with the next message.
+ * Dismissing it suppresses page context for this conversation (see the chat
+ * store's `pageContextOff`), and the row stays put so the choice is
+ * reversible.
+ */
+export function ChatContextChip({ conversationId }: { conversationId: string }) {
+  const label = usePageContextLabel();
+  const isOff = useChatStore((s) => Boolean(s.pageContextOff[conversationId]));
+  const setPageContextEnabled = useChatStore((s) => s.setPageContextEnabled);
+
+  if (isDemoInstance() || !label) return null;
+
+  return (
+    <div className="flex-shrink-0 px-3 pt-2 -mb-1">
+      <div className="inline-flex items-center gap-1.5 max-w-full px-2 py-0.5 rounded text-xs bg-[var(--color-bg-card)] border border-[var(--color-border)] text-[var(--color-text-secondary)]">
+        {isOff ? (
+          <EyeOff className="w-3 h-3 flex-shrink-0" strokeWidth={2} />
+        ) : (
+          <Eye className="w-3 h-3 flex-shrink-0 text-[var(--color-accent-light)]" strokeWidth={2} />
+        )}
+        <span className="truncate">
+          {isOff ? 'Not sharing' : 'Sharing'} {label}
+        </span>
+        {isOff ? (
+          <button
+            onClick={() => setPageContextEnabled(conversationId, true)}
+            className="flex-shrink-0 text-[var(--color-text-tertiary)] hover:text-[var(--color-accent-light)] transition-colors"
+            title="Share this page with the assistant again"
+          >
+            Share
+          </button>
+        ) : (
+          <button
+            onClick={() => setPageContextEnabled(conversationId, false)}
+            className="flex-shrink-0 text-[var(--color-text-tertiary)] hover:text-red-400 transition-colors"
+            aria-label="Stop sharing page context"
+            title="Stop sharing page context"
+          >
+            <X className="w-3 h-3" strokeWidth={2} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { ChevronLeft } from 'lucide-react';
+import { Archive, ArchiveRestore, ChevronLeft, MoreVertical } from 'lucide-react';
 import { ConversationWithTags, useChatStore } from '../../stores/chat';
+import { ContextMenu } from '../ui/ContextMenu';
 import { ScopeEditor } from './ScopeEditor';
 
 interface ChatHeaderProps {
@@ -11,7 +12,9 @@ interface ChatHeaderProps {
 export function ChatHeader({ conversation, onBack }: ChatHeaderProps) {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState(conversation.title || '');
+  const [menuPosition, setMenuPosition] = useState<{ x: number; y: number } | null>(null);
   const updateConversationTitle = useChatStore(s => s.updateConversationTitle);
+  const setConversationArchived = useChatStore(s => s.setConversationArchived);
 
   const handleTitleSave = async () => {
     if (editedTitle.trim() !== conversation.title) {
@@ -28,6 +31,27 @@ export function ChatHeader({ conversation, onBack }: ChatHeaderProps) {
       setIsEditingTitle(false);
     }
   };
+
+  const handleArchive = async () => {
+    await setConversationArchived(conversation.id, !conversation.is_archived);
+    // Archiving hides the conversation from the default list; staying in it
+    // would leave the user in a view they can't navigate back to.
+    if (!conversation.is_archived) {
+      onBack();
+    }
+  };
+
+  const menuItems = [
+    {
+      label: conversation.is_archived ? 'Unarchive' : 'Archive',
+      onClick: handleArchive,
+      icon: conversation.is_archived ? (
+        <ArchiveRestore className="w-4 h-4" strokeWidth={2} />
+      ) : (
+        <Archive className="w-4 h-4" strokeWidth={2} />
+      ),
+    },
+  ];
 
   return (
     <div className="flex-shrink-0 border-b border-[var(--color-border)]">
@@ -67,7 +91,25 @@ export function ChatHeader({ conversation, onBack }: ChatHeaderProps) {
             {conversation.title || 'New Conversation'}
           </h2>
         )}
+
+        <button
+          onClick={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setMenuPosition({ x: rect.right - 160, y: rect.bottom + 4 });
+          }}
+          className="p-1.5 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] rounded transition-colors"
+          aria-label="Conversation actions"
+        >
+          <MoreVertical className="w-4 h-4" strokeWidth={2} />
+        </button>
       </div>
+
+      <ContextMenu
+        items={menuItems}
+        position={menuPosition}
+        onClose={() => setMenuPosition(null)}
+        autoFocus
+      />
 
       {/* Scope editor row */}
       <div className="px-4 pb-3">

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,3 +1,4 @@
+import { ArrowUp, Square } from 'lucide-react';
 import { isDemoInstance, demoSignupUrl } from '../../lib/transport';
 
 interface ChatInputProps {
@@ -7,15 +8,23 @@ interface ChatInputProps {
   onKeyDown: (e: React.KeyboardEvent) => void;
   disabled?: boolean;
   placeholder?: string;
+  /** A response is streaming: the send button becomes a stop button. */
+  isStreaming?: boolean;
+  /** A stop has been requested and we're waiting for the turn to wind down. */
+  isCancelling?: boolean;
+  onStop?: () => void;
 }
 
 export function ChatInput({
   value,
   onChange,
-  onSend: _onSend,
+  onSend,
   onKeyDown,
   disabled = false,
   placeholder = 'Type a message...',
+  isStreaming = false,
+  isCancelling = false,
+  onStop,
 }: ChatInputProps) {
   // On the public demo, chat is the signup carrot: conversations are
   // account-scoped (anonymous chat would be a shared wall), so the input
@@ -33,31 +42,58 @@ export function ChatInput({
       </div>
     );
   }
+  const canSend = value.trim().length > 0 && !disabled;
+
   return (
     <div className="flex-shrink-0 p-3 border-t border-[var(--color-border)]">
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        onKeyDown={onKeyDown}
-        placeholder={placeholder}
-        disabled={disabled}
-        rows={1}
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        spellCheck={false}
-        className="w-full resize-none overflow-hidden bg-[var(--color-bg-main)] border border-[var(--color-border)] rounded-lg px-4 py-3 text-[var(--color-text-primary)] placeholder-[var(--color-text-tertiary)] focus:outline-none focus:border-[var(--color-accent)] disabled:opacity-50 disabled:cursor-not-allowed"
-        style={{
-          minHeight: '44px',
-          maxHeight: '200px',
-        }}
-        onInput={(e) => {
-          // Auto-resize textarea
-          const target = e.target as HTMLTextAreaElement;
-          target.style.height = 'auto';
-          target.style.height = `${Math.min(target.scrollHeight, 200)}px`;
-        }}
-      />
+      <div className="relative">
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={1}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className="w-full resize-none overflow-hidden bg-[var(--color-bg-main)] border border-[var(--color-border)] rounded-lg pl-4 pr-14 py-3 text-[var(--color-text-primary)] placeholder-[var(--color-text-tertiary)] focus:outline-none focus:border-[var(--color-accent)] disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{
+            minHeight: '44px',
+            maxHeight: '200px',
+          }}
+          onInput={(e) => {
+            // Auto-resize textarea
+            const target = e.target as HTMLTextAreaElement;
+            target.style.height = 'auto';
+            target.style.height = `${Math.min(target.scrollHeight, 200)}px`;
+          }}
+        />
+        {isStreaming ? (
+          <button
+            type="button"
+            onClick={onStop}
+            disabled={isCancelling || !onStop}
+            title={isCancelling ? 'Stopping…' : 'Stop response'}
+            aria-label={isCancelling ? 'Stopping response' : 'Stop response'}
+            className="absolute right-2 bottom-2 w-8 h-8 flex items-center justify-center rounded-md bg-[var(--color-bg-card)] border border-[var(--color-border)] text-[var(--color-text-primary)] hover:border-[var(--color-accent)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <Square className="w-3.5 h-3.5 fill-current" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onSend}
+            disabled={!canSend}
+            title="Send message"
+            aria-label="Send message"
+            className="absolute right-2 bottom-2 w-8 h-8 flex items-center justify-center rounded-md bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <ArrowUp className="w-4 h-4" strokeWidth={2.5} />
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,9 +1,9 @@
 import { useState, useCallback, Fragment, ReactNode, useEffect, useMemo } from 'react';
-import { BookOpen, CheckCircle2, Loader2, Telescope, Wrench, XCircle } from 'lucide-react';
-import { ChatMessageWithContext, ChatCitation, ChatToolCall } from '../../stores/chat';
+import { BookOpen, Check, CheckCircle2, FilePlus, Loader2, Telescope, Wrench, XCircle } from 'lucide-react';
+import { ChatMessageWithContext, ChatCitation, ChatToolCall, useChatStore } from '../../stores/chat';
 import { useAtomsStore, type AtomSummary, type AtomWithTags } from '../../stores/atoms';
 import { useUIStore } from '../../stores/ui';
-import { getTransport } from '../../lib/transport';
+import { getTransport, isDemoInstance } from '../../lib/transport';
 import { CitationLink, CitationPopover } from '../wiki';
 import { MarkdownImage } from '../ui/MarkdownImage';
 import ReactMarkdown from 'react-markdown';
@@ -267,7 +267,7 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
     <>
       <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
         <div
-          className={`max-w-[85%] rounded-lg px-4 py-3 ${
+          className={`group max-w-[85%] rounded-lg px-4 py-3 ${
             isUser
               ? 'bg-[var(--color-accent)] text-white'
               : 'bg-[var(--color-bg-card)] text-[var(--color-text-primary)]'
@@ -335,6 +335,14 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
             </div>
           )}
 
+          {/* Keep the answer. Hidden until the turn is finished — there is no
+              answer to save mid-stream — and on the demo, where atoms aren't
+              the visitor's to create. */}
+          {isAssistant && !isStreaming && message.content && !isDemoInstance() && (
+            <div className="mt-2 flex justify-end opacity-0 max-md:opacity-100 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+              <SaveAnswerAction messageId={message.id} />
+            </div>
+          )}
         </div>
       </div>
 
@@ -350,6 +358,50 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
         />
       )}
     </>
+  );
+}
+
+const ANSWER_ACTION_CLASS =
+  'inline-flex items-center gap-1.5 px-2 py-1 text-xs rounded text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)] transition-colors disabled:cursor-default disabled:hover:bg-transparent';
+
+// Turns an answer into an atom, then becomes the way back to it. The saved id
+// only lives for this session (see `savedAtomIdByMessageId`), so after a
+// reload the action reads as unsaved again.
+function SaveAnswerAction({ messageId }: { messageId: string }) {
+  const savedAtomId = useChatStore((s) => s.savedAtomIdByMessageId[messageId]);
+  const isSaving = useChatStore((s) => s.savingAnswerMessageIds[messageId] === true);
+  const saveAnswer = useChatStore((s) => s.saveAnswer);
+  const openReader = useUIStore((s) => s.openReader);
+
+  if (savedAtomId) {
+    return (
+      <button
+        type="button"
+        onClick={() => openReader(savedAtomId)}
+        className={ANSWER_ACTION_CLASS}
+        title="Open the atom this answer was saved as"
+      >
+        <Check className="w-3.5 h-3.5" strokeWidth={2} />
+        Saved — open
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void saveAnswer(messageId)}
+      disabled={isSaving}
+      className={ANSWER_ACTION_CLASS}
+      title="Save this answer as an atom, tagged Chat Answers"
+    >
+      {isSaving ? (
+        <Loader2 className="w-3.5 h-3.5 animate-spin" strokeWidth={2} />
+      ) : (
+        <FilePlus className="w-3.5 h-3.5" strokeWidth={2} />
+      )}
+      {isSaving ? 'Saving…' : 'Save as atom'}
+    </button>
   );
 }
 

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, Fragment, ReactNode, useEffect, useMemo } from 'react';
-import { CheckCircle2, Loader2, Wrench, XCircle } from 'lucide-react';
+import { BookOpen, CheckCircle2, Loader2, Telescope, Wrench, XCircle } from 'lucide-react';
 import { ChatMessageWithContext, ChatCitation, ChatToolCall } from '../../stores/chat';
 import { useAtomsStore, type AtomSummary, type AtomWithTags } from '../../stores/atoms';
+import { useUIStore } from '../../stores/ui';
 import { getTransport } from '../../lib/transport';
 import { CitationLink, CitationPopover } from '../wiki';
 import { MarkdownImage } from '../ui/MarkdownImage';
@@ -20,6 +21,8 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
   const isUser = message.role === 'user';
   const isAssistant = message.role === 'assistant';
   const atoms = useAtomsStore(s => s.atoms);
+  const openWikiReader = useUIStore(s => s.openWikiReader);
+  const openFindingReader = useUIStore(s => s.openFindingReader);
 
   const [activeCitation, setActiveCitation] = useState<ChatCitation | null>(null);
   const [anchorRect, setAnchorRect] = useState<{ top: number; left: number; bottom: number; width: number } | null>(null);
@@ -94,6 +97,25 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
       onViewAtom(atomId, highlightText);
     }
     handleClosePopover();
+  };
+
+  // Open whatever a citation points at. The excerpt doubles as the passage
+  // to scroll to, which is what turns a citation into a deep link — except
+  // for findings, whose reader has no highlight support (accepted; the
+  // finding still opens, just at the top).
+  const handleOpenCitation = (citation: ChatCitation) => {
+    switch (citation.source_type) {
+      case 'wiki':
+        openWikiReader(citation.atom_id, citation.source_title ?? 'Wiki', citation.excerpt);
+        handleClosePopover();
+        return;
+      case 'finding':
+        openFindingReader(citation.atom_id);
+        handleClosePopover();
+        return;
+      default:
+        handleViewAtom(citation.atom_id, citation.excerpt);
+    }
   };
 
   // Process text to replace [N] citations and [[atom-id]] references with
@@ -302,9 +324,10 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
                   <button
                     key={citation.id}
                     onClick={(e) => handleCitationClick(citation, e.currentTarget)}
-                    className="px-2 py-0.5 text-xs rounded bg-[var(--color-bg-hover)] hover:bg-[var(--color-border-hover)] text-[var(--color-accent-light)] transition-colors cursor-pointer"
-                    title={citation.excerpt}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded bg-[var(--color-bg-hover)] hover:bg-[var(--color-border-hover)] text-[var(--color-accent-light)] transition-colors cursor-pointer"
+                    title={citation.source_title ? `${citation.source_title} — ${citation.excerpt}` : citation.excerpt}
                   >
+                    <SourceIcon sourceType={citation.source_type} />
                     [{citation.citation_index}]
                   </button>
                 ))}
@@ -315,17 +338,27 @@ export function ChatMessage({ message, isStreaming = false, onViewAtom, searchQu
         </div>
       </div>
 
-      {/* Citation popover */}
+      {/* Citation popover. Where "view source" goes depends on what the
+          citation cites, so the popover's callback defers to the citation
+          rather than assuming an atom. */}
       {activeCitation && anchorRect && (
         <CitationPopover
           citation={activeCitation}
           anchorRect={anchorRect}
           onClose={handleClosePopover}
-          onViewAtom={handleViewAtom}
+          onViewAtom={() => handleOpenCitation(activeCitation)}
         />
       )}
     </>
   );
+}
+
+// Quietly marks the sources that aren't atoms — same icons the wiki and
+// reports views use in the nav.
+function SourceIcon({ sourceType }: { sourceType?: ChatCitation['source_type'] }) {
+  if (sourceType === 'wiki') return <BookOpen className="w-3 h-3" strokeWidth={2} />;
+  if (sourceType === 'finding') return <Telescope className="w-3 h-3" strokeWidth={2} />;
+  return null;
 }
 
 function displayTitleForAtom(atom: Pick<AtomSummary, 'id' | 'title' | 'snippet'>): string {

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -7,6 +7,7 @@ import { useContentSearch } from '../../hooks';
 import { ChatHeader } from './ChatHeader';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
+import { ChatContextChip } from './ChatContextChip';
 import { SearchBar } from '../ui/SearchBar';
 
 export function ChatView() {
@@ -14,10 +15,12 @@ export function ChatView() {
   const messages = useChatStore(s => s.messages);
   const isLoading = useChatStore(s => s.isLoading);
   const isStreaming = useChatStore(s => s.isStreaming);
+  const isCancelling = useChatStore(s => s.isCancelling);
   const streamingContent = useChatStore(s => s.streamingContent);
   const streamingToolCalls = useChatStore(s => s.streamingToolCalls);
   const error = useChatStore(s => s.error);
   const sendMessage = useChatStore(s => s.sendMessage);
+  const cancelResponse = useChatStore(s => s.cancelResponse);
   const goBack = useChatStore(s => s.goBack);
 
   const openReader = useUIStore(s => s.openReader);
@@ -201,6 +204,9 @@ export function ChatView() {
         <div ref={messagesEndRef} />
       </div>
 
+      {/* What the next message carries from the current page */}
+      <ChatContextChip conversationId={currentConversation.id} />
+
       {/* Input area */}
       <ChatInput
         value={inputValue}
@@ -208,6 +214,9 @@ export function ChatView() {
         onSend={handleSend}
         onKeyDown={handleKeyDown}
         disabled={isStreaming}
+        isStreaming={isStreaming}
+        isCancelling={isCancelling}
+        onStop={cancelResponse}
         placeholder={
           currentConversation.tags.length > 0
             ? `Ask about ${currentConversation.tags.map(t => t.name).join(', ')}...`

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -1,8 +1,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { MessageSquare } from 'lucide-react';
-import { useChatStore } from '../../stores/chat';
+import { useChatStore, scopeModeOf } from '../../stores/chat';
 import { useUIStore } from '../../stores/ui';
-import { useChatEvents } from '../../hooks/useChatEvents';
 import { useContentSearch } from '../../hooks';
 import { ChatHeader } from './ChatHeader';
 import { ChatMessage } from './ChatMessage';
@@ -14,6 +13,7 @@ export function ChatView() {
   const currentConversation = useChatStore(s => s.currentConversation);
   const messages = useChatStore(s => s.messages);
   const isLoading = useChatStore(s => s.isLoading);
+  const streamingConversationId = useChatStore(s => s.streamingConversationId);
   const isStreaming = useChatStore(s => s.isStreaming);
   const isCancelling = useChatStore(s => s.isCancelling);
   const streamingContent = useChatStore(s => s.streamingContent);
@@ -22,6 +22,13 @@ export function ChatView() {
   const sendMessage = useChatStore(s => s.sendMessage);
   const cancelResponse = useChatStore(s => s.cancelResponse);
   const goBack = useChatStore(s => s.goBack);
+
+  // The streaming fields describe one conversation's turn. Rendering them here
+  // is only correct when that conversation is the one on screen — otherwise a
+  // turn left running elsewhere would show up as this conversation thinking.
+  const isStreamingHere =
+    isStreaming && streamingConversationId !== null &&
+    streamingConversationId === currentConversation?.id;
 
   const openReader = useUIStore(s => s.openReader);
 
@@ -62,9 +69,6 @@ export function ChatView() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [openSearch]);
 
-  // Subscribe to chat events for streaming
-  useChatEvents(currentConversation?.id ?? null);
-
   // Check if user is near the bottom of the scroll container
   const checkIfNearBottom = useCallback(() => {
     const container = messagesContainerRef.current;
@@ -94,7 +98,7 @@ export function ChatView() {
   }, []);
 
   const handleSend = async () => {
-    if (!inputValue.trim() || isStreaming) return;
+    if (!inputValue.trim() || isStreamingHere) return;
 
     const content = inputValue.trim();
     setInputValue('');
@@ -123,7 +127,7 @@ export function ChatView() {
   }
 
   const scopeSubjects = currentConversation.tags
-    .filter((t) => t.mode !== 'exclude')
+    .filter((t) => scopeModeOf(t) !== 'exclude')
     .map((t) => t.name);
 
   return (
@@ -151,7 +155,7 @@ export function ChatView() {
             onClose={closeSearch}
           />
         )}
-        {messages.length === 0 && !isStreaming && (
+        {messages.length === 0 && !isStreamingHere && (
           <div className="flex flex-col items-center justify-center h-full gap-4 text-center">
             <div className="w-16 h-16 rounded-full bg-[var(--color-bg-card)] flex items-center justify-center">
               <MessageSquare className="w-8 h-8 text-[var(--color-accent)]" strokeWidth={2} />
@@ -179,7 +183,7 @@ export function ChatView() {
             calls show up while the model is still thinking and persist as
             streaming content flows in. ChatMessage handles the empty-content
             "Thinking…" fallback. */}
-        {isStreaming && (
+        {isStreamingHere && (
           <ChatMessage
             message={{
               id: 'streaming',
@@ -217,9 +221,9 @@ export function ChatView() {
         onChange={setInputValue}
         onSend={handleSend}
         onKeyDown={handleKeyDown}
-        disabled={isStreaming}
-        isStreaming={isStreaming}
-        isCancelling={isCancelling}
+        disabled={isStreamingHere}
+        isStreaming={isStreamingHere}
+        isCancelling={isStreamingHere && isCancelling}
         onStop={cancelResponse}
         placeholder={
           // Excluded tags say what the conversation isn't about — naming them

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -122,6 +122,10 @@ export function ChatView() {
     );
   }
 
+  const scopeSubjects = currentConversation.tags
+    .filter((t) => t.mode !== 'exclude')
+    .map((t) => t.name);
+
   return (
     <div className="h-full flex flex-col">
       {/* Header with back button and scope */}
@@ -218,8 +222,10 @@ export function ChatView() {
         isCancelling={isCancelling}
         onStop={cancelResponse}
         placeholder={
-          currentConversation.tags.length > 0
-            ? `Ask about ${currentConversation.tags.map(t => t.name).join(', ')}...`
+          // Excluded tags say what the conversation isn't about — naming them
+          // here would read as the opposite of the scope.
+          scopeSubjects.length > 0
+            ? `Ask about ${scopeSubjects.join(', ')}...`
             : 'Ask anything about your knowledge base...'
         }
       />

--- a/src/components/chat/ChatViewer.tsx
+++ b/src/components/chat/ChatViewer.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useRef } from 'react';
-import { X } from 'lucide-react';
+import { Maximize2, Minimize2, PanelLeft, X } from 'lucide-react';
 import { useChatStore } from '../../stores/chat';
 import { useUIStore } from '../../stores/ui';
 import { useDatabasesStore } from '../../stores/databases';
+import { isTypingTarget } from '../../lib/keyboard';
+import { isTauri } from '../../lib/platform';
+import { useIsMobile } from '../../hooks';
+import { useChatEvents } from '../../hooks/useChatEvents';
 import { ConversationsList } from './ConversationsList';
 import { ChatView } from './ChatView';
 
@@ -12,11 +16,26 @@ export function ChatViewer() {
   const openConversation = useChatStore(s => s.openConversation);
   const openOrCreateForTag = useChatStore(s => s.openOrCreateForTag);
   const setChatSidebarOpen = useUIStore(s => s.setChatSidebarOpen);
+  const isExpanded = useUIStore(s => s.chatSidebarExpanded);
+  const setChatSidebarExpanded = useUIStore(s => s.setChatSidebarExpanded);
+  const toggleChatSidebarExpanded = useUIStore(s => s.toggleChatSidebarExpanded);
   const initialTagId = useUIStore(s => s.chatSidebarInitialTagId);
   const initialConversationId = useUIStore(s => s.chatSidebarInitialConversationId);
   const lastConversationId = useUIStore(s => s.chatSidebarConversationId);
+  const leftPanelOpen = useUIStore(s => s.leftPanelOpen);
+  const toggleLeftPanel = useUIStore(s => s.toggleLeftPanel);
   const activeDbId = useDatabasesStore(s => s.activeId);
+  const isMobile = useIsMobile();
   const initializedRef = useRef(false);
+
+  // Fullscreen is a desktop-only mode — on mobile the pane already fills the
+  // screen, and the main view behind it is never collapsed.
+  const isFullscreen = isExpanded && !isMobile;
+
+  // Subscribed here, not in ChatView: a turn survives the user leaving the
+  // conversation it was started from, and its completion event has to be
+  // heard from wherever they end up or the streaming state never clears.
+  useChatEvents();
 
   // Re-initialize when database changes
   useEffect(() => {
@@ -43,20 +62,79 @@ export function ChatViewer() {
     initializedRef.current = true;
   }, [initialTagId, initialConversationId, lastConversationId, showList, openConversation, openOrCreateForTag]);
 
+  // Escape leaves fullscreen. Listening in the capture phase and stopping the
+  // event there is what keeps it from also reaching the reader mounted behind
+  // the expanded pane, whose own Escape handler would dismiss the very tab the
+  // user is about to come back to. Typing targets are handed the key untouched
+  // so the composer and the in-chat search bar keep their own Escape, and an
+  // open modal owns it outright — the convention `useKeyboard` follows.
+  useEffect(() => {
+    if (!isExpanded) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (document.querySelector('[data-modal="true"]')) return;
+      if (isTypingTarget(e.target)) return;
+      e.stopPropagation();
+      setChatSidebarExpanded(false);
+    };
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [isExpanded, setChatSidebarExpanded]);
+
   return (
     <div className="h-full flex flex-col bg-[var(--color-bg-panel)]">
-      {/* Header */}
-      <div className="flex-shrink-0 flex items-center justify-between px-4 py-3 border-b border-[var(--color-border)]">
-        <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">
-          {view === 'list' ? 'Conversations' : 'Chat'}
-        </h2>
-        <button
-          onClick={() => setChatSidebarOpen(false)}
-          className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
-          aria-label="Close"
-        >
-          <X className="w-5 h-5" strokeWidth={2} />
-        </button>
+      {/* Header. At fullscreen this row stands in for the main view's titlebar,
+          which is collapsed away with the rest of that column, so it picks up
+          the two jobs that bar was doing: toggling the left panel — now showing
+          this chat's conversations — and, under Tauri, holding the traffic
+          lights clear. That clearance must be carried by exactly one *visible*
+          surface: the left panel's own titlebar owns it whenever the panel is
+          open, and MainView's bar only ever competes for it when not expanded. */}
+      <div
+        data-tauri-drag-region={isFullscreen || undefined}
+        className={`flex-shrink-0 flex items-center justify-between px-4 py-3 border-b border-[var(--color-border)] ${
+          isFullscreen ? 'drag-region' : ''
+        } ${isFullscreen && isTauri() && !leftPanelOpen ? 'pl-[78px]' : ''}`}
+      >
+        <div className="flex items-center gap-2">
+          {isFullscreen && (
+            <button
+              onClick={toggleLeftPanel}
+              className={`p-1.5 rounded-md transition-colors ${
+                leftPanelOpen
+                  ? 'text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
+                  : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-hover)]'
+              }`}
+              title={leftPanelOpen ? 'Hide sidebar' : 'Show sidebar'}
+              aria-label={leftPanelOpen ? 'Hide sidebar' : 'Show sidebar'}
+            >
+              <PanelLeft className="w-4 h-4" strokeWidth={2} />
+            </button>
+          )}
+          <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">
+            {view === 'list' ? 'Conversations' : 'Chat'}
+          </h2>
+        </div>
+        <div className="flex items-center gap-1">
+          {/* Desktop only: on mobile the pane is already full-screen. */}
+          <button
+            onClick={toggleChatSidebarExpanded}
+            className="hidden md:block p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+            aria-label={isExpanded ? 'Minimize chat' : 'Expand chat'}
+            title={isExpanded ? 'Minimize chat (Esc)' : 'Expand chat'}
+          >
+            {isExpanded
+              ? <Minimize2 className="w-4 h-4" strokeWidth={2} />
+              : <Maximize2 className="w-4 h-4" strokeWidth={2} />}
+          </button>
+          <button
+            onClick={() => setChatSidebarOpen(false)}
+            className="p-1 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" strokeWidth={2} />
+          </button>
+        </div>
       </div>
 
       {/* Content */}

--- a/src/components/chat/ConversationCard.tsx
+++ b/src/components/chat/ConversationCard.tsx
@@ -105,7 +105,11 @@ export function ConversationCard({
               {conversation.tags.slice(0, 3).map((tag) => (
                 <span
                   key={tag.id}
-                  className="px-2 py-0.5 text-xs rounded bg-[var(--color-accent)]/20 text-[var(--color-accent-light)]"
+                  className={`px-2 py-0.5 text-xs rounded ${
+                    tag.mode === 'exclude'
+                      ? 'bg-red-500/10 text-red-300 line-through decoration-red-400/60'
+                      : 'bg-[var(--color-accent)]/20 text-[var(--color-accent-light)]'
+                  }`}
                 >
                   {tag.name}
                 </span>

--- a/src/components/chat/ConversationCard.tsx
+++ b/src/components/chat/ConversationCard.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
 import { Archive, ArchiveRestore, Pencil, Trash2 } from 'lucide-react';
-import { ConversationWithTags } from '../../stores/chat';
+import { ConversationWithTags, scopeModeOf } from '../../stores/chat';
 import { formatRelativeDate } from '../../lib/date';
 
 interface ConversationCardProps {
   conversation: ConversationWithTags;
+  /// Marks the conversation the chat pane is currently showing. Only the
+  /// sidebar list renders alongside an open conversation, so this is a no-op
+  /// in the pane's own list.
+  isActive?: boolean;
   onClick: () => void;
   onDelete: (e: React.MouseEvent) => void;
   onRename: (title: string) => void;
@@ -13,6 +17,7 @@ interface ConversationCardProps {
 
 export function ConversationCard({
   conversation,
+  isActive = false,
   onClick,
   onDelete,
   onRename,
@@ -56,7 +61,9 @@ export function ConversationCard({
   return (
     <div
       onClick={isEditingTitle ? undefined : onClick}
-      className="group px-4 py-3 hover:bg-[var(--color-bg-card)] cursor-pointer transition-colors"
+      className={`group px-4 py-3 cursor-pointer transition-colors ${
+        isActive ? 'bg-[var(--color-accent)]/20' : 'hover:bg-[var(--color-bg-card)]'
+      }`}
     >
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
@@ -106,7 +113,7 @@ export function ConversationCard({
                 <span
                   key={tag.id}
                   className={`px-2 py-0.5 text-xs rounded ${
-                    tag.mode === 'exclude'
+                    scopeModeOf(tag) === 'exclude'
                       ? 'bg-red-500/10 text-red-300 line-through decoration-red-400/60'
                       : 'bg-[var(--color-accent)]/20 text-[var(--color-accent-light)]'
                   }`}

--- a/src/components/chat/ConversationCard.tsx
+++ b/src/components/chat/ConversationCard.tsx
@@ -1,4 +1,5 @@
-import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { Archive, ArchiveRestore, Pencil, Trash2 } from 'lucide-react';
 import { ConversationWithTags } from '../../stores/chat';
 import { formatRelativeDate } from '../../lib/date';
 
@@ -6,25 +7,85 @@ interface ConversationCardProps {
   conversation: ConversationWithTags;
   onClick: () => void;
   onDelete: (e: React.MouseEvent) => void;
+  onRename: (title: string) => void;
+  onArchive: (isArchived: boolean) => void;
 }
 
-export function ConversationCard({ conversation, onClick, onDelete }: ConversationCardProps) {
+export function ConversationCard({
+  conversation,
+  onClick,
+  onDelete,
+  onRename,
+  onArchive,
+}: ConversationCardProps) {
   const title = conversation.title || 'New Conversation';
   const preview = conversation.last_message_preview || 'No messages yet';
   const messageCount = conversation.message_count;
   const updatedAt = formatRelativeDate(conversation.updated_at);
 
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [editedTitle, setEditedTitle] = useState(conversation.title || '');
+
+  // Enter and blur both commit; Escape restores. Same contract as the
+  // header's title field, including the empty → 'Untitled' fallback.
+  const handleTitleSave = () => {
+    if (!isEditingTitle) return;
+    setIsEditingTitle(false);
+    const next = editedTitle.trim() || 'Untitled';
+    if (next !== conversation.title) {
+      onRename(next);
+    }
+  };
+
+  const handleTitleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleTitleSave();
+    } else if (e.key === 'Escape') {
+      setEditedTitle(conversation.title || '');
+      setIsEditingTitle(false);
+    }
+  };
+
+  const startEditing = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditedTitle(conversation.title || '');
+    setIsEditingTitle(true);
+  };
+
   return (
     <div
-      onClick={onClick}
+      onClick={isEditingTitle ? undefined : onClick}
       className="group px-4 py-3 hover:bg-[var(--color-bg-card)] cursor-pointer transition-colors"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
           {/* Title */}
-          <h3 className="text-[var(--color-text-primary)] font-medium truncate mb-1">
-            {title}
-          </h3>
+          {isEditingTitle ? (
+            <input
+              type="text"
+              value={editedTitle}
+              onChange={(e) => setEditedTitle(e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+              onBlur={handleTitleSave}
+              onKeyDown={handleTitleKeyDown}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              className="w-full mb-1 bg-[var(--color-bg-main)] border border-[var(--color-border)] rounded px-2 py-0.5 text-[var(--color-text-primary)] font-medium focus:outline-none focus:border-[var(--color-accent)]"
+              autoFocus
+            />
+          ) : (
+            <h3 className="flex items-center gap-2 text-[var(--color-text-primary)] font-medium truncate mb-1">
+              <span className="truncate">{title}</span>
+              {conversation.is_archived && (
+                <span className="flex-shrink-0 px-1.5 py-0.5 text-[10px] uppercase tracking-wide rounded bg-[var(--color-bg-hover)] text-[var(--color-text-tertiary)]">
+                  Archived
+                </span>
+              )}
+            </h3>
+          )}
 
           {/* Preview */}
           <p className="text-[var(--color-text-secondary)] text-sm line-clamp-2 mb-2">
@@ -58,14 +119,40 @@ export function ConversationCard({ conversation, onClick, onDelete }: Conversati
           )}
         </div>
 
-        {/* Delete button */}
-        <button
-          onClick={onDelete}
-          className="p-1.5 text-[var(--color-text-tertiary)] hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
-          aria-label="Delete conversation"
-        >
-          <Trash2 className="w-4 h-4" strokeWidth={2} />
-        </button>
+        {/* Hover actions */}
+        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-all">
+          <button
+            onClick={startEditing}
+            className="p-1.5 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]"
+            aria-label="Rename conversation"
+            title="Rename"
+          >
+            <Pencil className="w-4 h-4" strokeWidth={2} />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onArchive(!conversation.is_archived);
+            }}
+            className="p-1.5 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]"
+            aria-label={conversation.is_archived ? 'Unarchive conversation' : 'Archive conversation'}
+            title={conversation.is_archived ? 'Unarchive' : 'Archive'}
+          >
+            {conversation.is_archived ? (
+              <ArchiveRestore className="w-4 h-4" strokeWidth={2} />
+            ) : (
+              <Archive className="w-4 h-4" strokeWidth={2} />
+            )}
+          </button>
+          <button
+            onClick={onDelete}
+            className="p-1.5 text-[var(--color-text-tertiary)] hover:text-red-400"
+            aria-label="Delete conversation"
+            title="Delete"
+          >
+            <Trash2 className="w-4 h-4" strokeWidth={2} />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/chat/ConversationsList.tsx
+++ b/src/components/chat/ConversationsList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Plus, MessageCircle } from 'lucide-react';
 import { useChatStore, ConversationWithTags } from '../../stores/chat';
+import { useUIStore } from '../../stores/ui';
 import { ConversationCard } from './ConversationCard';
 import { Modal } from '../ui/Modal';
 
@@ -9,18 +10,26 @@ export function ConversationsList() {
   const isLoading = useChatStore(s => s.isLoading);
   const error = useChatStore(s => s.error);
   const listFilterTagId = useChatStore(s => s.listFilterTagId);
+  const showArchived = useChatStore(s => s.showArchived);
+  const setShowArchived = useChatStore(s => s.setShowArchived);
   const createConversation = useChatStore(s => s.createConversation);
   const openConversation = useChatStore(s => s.openConversation);
   const deleteConversation = useChatStore(s => s.deleteConversation);
+  const updateConversationTitle = useChatStore(s => s.updateConversationTitle);
+  const setConversationArchived = useChatStore(s => s.setConversationArchived);
+  const selectedTagId = useUIStore(s => s.selectedTagId);
 
   const [deleteTarget, setDeleteTarget] = useState<ConversationWithTags | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
   const handleNewChat = async () => {
     try {
-      // Create conversation with current filter tag if any
-      const tagIds = listFilterTagId ? [listFilterTagId] : [];
-      await createConversation(tagIds);
+      // Scope the new conversation to whatever the user is already looking
+      // at: the list's own tag filter, or the tag selected in the sidebar.
+      // The chip is removable in the header's ScopeEditor, so this is a
+      // suggestion, not a commitment.
+      const scopeTagId = listFilterTagId ?? selectedTagId;
+      await createConversation(scopeTagId ? [scopeTagId] : []);
     } catch (e) {
       console.error('Failed to create conversation:', e);
     }
@@ -86,9 +95,13 @@ export function ConversationsList() {
               <MessageCircle className="w-8 h-8 text-[var(--color-text-secondary)]" strokeWidth={2} />
             </div>
             <div>
-              <p className="text-[var(--color-text-primary)] font-medium mb-1">No conversations yet</p>
+              <p className="text-[var(--color-text-primary)] font-medium mb-1">
+                {showArchived ? 'Nothing here' : 'No conversations yet'}
+              </p>
               <p className="text-[var(--color-text-secondary)] text-sm">
-                Start a new conversation to chat with your knowledge base
+                {showArchived
+                  ? 'No conversations, archived or otherwise'
+                  : 'Start a new conversation to chat with your knowledge base'}
               </p>
             </div>
           </div>
@@ -100,10 +113,22 @@ export function ConversationsList() {
                 conversation={conversation}
                 onClick={() => handleOpenConversation(conversation)}
                 onDelete={(e) => handleDeleteClick(conversation, e)}
+                onRename={(title) => updateConversationTitle(conversation.id, title)}
+                onArchive={(isArchived) => setConversationArchived(conversation.id, isArchived)}
               />
             ))}
           </div>
         )}
+      </div>
+
+      {/* Archive visibility */}
+      <div className="flex-shrink-0 px-4 py-2 border-t border-[var(--color-border)]">
+        <button
+          onClick={() => setShowArchived(!showArchived)}
+          className="text-xs text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] transition-colors"
+        >
+          {showArchived ? 'Hide archived' : 'Show archived'}
+        </button>
       </div>
 
       {/* Delete Confirmation Modal */}

--- a/src/components/chat/ConversationsSidebar.tsx
+++ b/src/components/chat/ConversationsSidebar.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useChatStore, type ConversationWithTags } from '../../stores/chat';
+import { useDatabasesStore } from '../../stores/databases';
+import { useUIStore } from '../../stores/ui';
+import { ConversationCard } from './ConversationCard';
+import { Modal } from '../ui/Modal';
+
+/// The left panel while chat is expanded to fullscreen: every conversation,
+/// one click from the one on screen. The chat pane keeps its own list view —
+/// this is an additional way in, not a replacement for it.
+export function ConversationsSidebar() {
+  const conversations = useChatStore(s => s.conversations);
+  const currentConversationId = useChatStore(s => s.currentConversation?.id ?? null);
+  const listFilterTagId = useChatStore(s => s.listFilterTagId);
+  const fetchConversations = useChatStore(s => s.fetchConversations);
+  const openConversation = useChatStore(s => s.openConversation);
+  const createConversation = useChatStore(s => s.createConversation);
+  const deleteConversation = useChatStore(s => s.deleteConversation);
+  const updateConversationTitle = useChatStore(s => s.updateConversationTitle);
+  const setConversationArchived = useChatStore(s => s.setConversationArchived);
+  const selectedTagId = useUIStore(s => s.selectedTagId);
+  const activeDatabaseId = useDatabasesStore(s => s.activeId);
+
+  const [deleteTarget, setDeleteTarget] = useState<ConversationWithTags | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // The panel mounts when chat goes fullscreen, which can be long after the
+  // pane last fetched the list — and a database switch invalidates it outright.
+  useEffect(() => {
+    void fetchConversations(listFilterTagId ?? undefined);
+  }, [fetchConversations, listFilterTagId, activeDatabaseId]);
+
+  const handleNewChat = async () => {
+    try {
+      // Same scoping suggestion the pane's list makes: whatever the user is
+      // already looking at.
+      const scopeTagId = listFilterTagId ?? selectedTagId;
+      await createConversation(scopeTagId ? [scopeTagId] : []);
+    } catch (e) {
+      console.error('Failed to create conversation:', e);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await deleteConversation(deleteTarget.id);
+    } catch (e) {
+      console.error('Failed to delete conversation:', e);
+    } finally {
+      setIsDeleting(false);
+      setDeleteTarget(null);
+    }
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex-shrink-0 px-3 py-2">
+        <button
+          onClick={handleNewChat}
+          className="w-full flex items-center justify-center gap-2 px-3 py-1.5 text-sm bg-[var(--color-bg-hover)] hover:bg-[var(--color-border)] text-[var(--color-text-primary)] rounded-md transition-colors"
+        >
+          <Plus className="w-4 h-4" strokeWidth={2} />
+          New Conversation
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto scrollbar-hidden">
+        {conversations.length === 0 ? (
+          <p className="px-3 py-4 text-xs text-[var(--color-text-secondary)] leading-relaxed">
+            No conversations yet. Ask a question in the chat pane and it shows up here.
+          </p>
+        ) : (
+          <div className="divide-y divide-[var(--color-border)]">
+            {conversations.map((conversation) => (
+              <ConversationCard
+                key={conversation.id}
+                conversation={conversation}
+                isActive={conversation.id === currentConversationId}
+                onClick={() => openConversation(conversation.id)}
+                onDelete={(e) => {
+                  e.stopPropagation();
+                  setDeleteTarget(conversation);
+                }}
+                onRename={(title) => updateConversationTitle(conversation.id, title)}
+                onArchive={(isArchived) => setConversationArchived(conversation.id, isArchived)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Modal
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        title="Delete Conversation"
+        confirmLabel={isDeleting ? 'Deleting...' : 'Delete'}
+        confirmVariant="danger"
+        onConfirm={handleConfirmDelete}
+      >
+        <p>
+          Are you sure you want to delete "{deleteTarget?.title || 'New Conversation'}"?
+          This will remove all messages and cannot be undone.
+        </p>
+      </Modal>
+    </div>
+  );
+}

--- a/src/components/chat/ScopeEditor.tsx
+++ b/src/components/chat/ScopeEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { X, Plus } from 'lucide-react';
-import { ConversationWithTags, ScopeMode, useChatStore } from '../../stores/chat';
+import { ConversationWithTags, ScopeMode, scopeModeOf, useChatStore } from '../../stores/chat';
 import { useTagsStore } from '../../stores/tags';
 
 interface ScopeEditorProps {
@@ -209,12 +209,13 @@ export function ScopeEditor({ conversation }: ScopeEditorProps) {
 
       {/* Without an included tag the base set is everything, and the
           remaining chips narrow it — say so instead of leaving it implied. */}
-      {!conversation.tags.some((tag) => tag.mode === 'include') && (
+      {!conversation.tags.some((tag) => scopeModeOf(tag) === 'include') && (
         <span className="text-sm text-[var(--color-text-secondary)] italic">All atoms</span>
       )}
 
       {conversation.tags.map((tag) => {
-        const style = MODE_STYLE[tag.mode] ?? MODE_STYLE.include;
+        const mode = scopeModeOf(tag);
+        const style = MODE_STYLE[mode];
         return (
           <span
             key={tag.id}
@@ -224,10 +225,10 @@ export function ScopeEditor({ conversation }: ScopeEditorProps) {
               <span className="text-[9px] uppercase tracking-wide opacity-70">{style.label}</span>
             )}
             <button
-              onClick={() => handleCycleMode(tag.id, tag.mode)}
+              onClick={() => handleCycleMode(tag.id, mode)}
               title={style.hint}
               className={style.name}
-              aria-label={`${tag.name}: ${tag.mode}. Change how this tag scopes the conversation`}
+              aria-label={`${tag.name}: ${mode}. Change how this tag scopes the conversation`}
             >
               {tag.name}
             </button>

--- a/src/components/chat/ScopeEditor.tsx
+++ b/src/components/chat/ScopeEditor.tsx
@@ -1,10 +1,38 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { X, Plus } from 'lucide-react';
-import { ConversationWithTags, useChatStore } from '../../stores/chat';
+import { ConversationWithTags, ScopeMode, useChatStore } from '../../stores/chat';
 import { useTagsStore } from '../../stores/tags';
 
 interface ScopeEditorProps {
   conversation: ConversationWithTags;
+}
+
+// Clicking a chip walks this cycle; "Add tag" enters at the front.
+const MODE_CYCLE: ScopeMode[] = ['include', 'require', 'exclude'];
+
+const MODE_STYLE: Record<ScopeMode, { chip: string; name: string; label: string; hint: string }> = {
+  include: {
+    chip: 'bg-[var(--color-accent)]/20 text-[var(--color-accent-light)]',
+    name: '',
+    label: '',
+    hint: 'Included — a result may carry any included tag. Click to require it.',
+  },
+  require: {
+    chip: 'bg-[var(--color-accent)]/10 text-[var(--color-accent-light)] border border-[var(--color-accent)]',
+    name: '',
+    label: 'and',
+    hint: 'Required — every result must carry this tag. Click to exclude it.',
+  },
+  exclude: {
+    chip: 'bg-red-500/10 text-red-300 border border-red-500/30',
+    name: 'line-through decoration-red-400/60',
+    label: '',
+    hint: 'Excluded — no result may carry this tag. Click to include it again.',
+  },
+};
+
+function nextMode(mode: ScopeMode): ScopeMode {
+  return MODE_CYCLE[(MODE_CYCLE.indexOf(mode) + 1) % MODE_CYCLE.length];
 }
 
 // Fuzzy matching algorithm
@@ -151,13 +179,18 @@ export function ScopeEditor({ conversation }: ScopeEditorProps) {
   }, [allFlatTags, scopeTagIds, searchQuery]);
 
   const handleAddTag = async (tagId: string) => {
-    await addTagToScope(tagId);
+    await addTagToScope(tagId, 'include');
     setIsAdding(false);
     setSearchQuery('');
   };
 
   const handleRemoveTag = async (tagId: string) => {
     await removeTagFromScope(tagId);
+  };
+
+  // Same call as adding: the tag is already in scope, so this rewrites its mode.
+  const handleCycleMode = async (tagId: string, mode: ScopeMode) => {
+    await addTagToScope(tagId, nextMode(mode));
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -174,15 +207,30 @@ export function ScopeEditor({ conversation }: ScopeEditorProps) {
     <div className="flex flex-wrap items-center gap-2">
       <span className="text-xs text-[var(--color-text-tertiary)] uppercase tracking-wide">Scope:</span>
 
-      {conversation.tags.length === 0 ? (
+      {/* Without an included tag the base set is everything, and the
+          remaining chips narrow it — say so instead of leaving it implied. */}
+      {!conversation.tags.some((tag) => tag.mode === 'include') && (
         <span className="text-sm text-[var(--color-text-secondary)] italic">All atoms</span>
-      ) : (
-        conversation.tags.map((tag) => (
+      )}
+
+      {conversation.tags.map((tag) => {
+        const style = MODE_STYLE[tag.mode] ?? MODE_STYLE.include;
+        return (
           <span
             key={tag.id}
-            className="group inline-flex items-center gap-1 px-2 py-0.5 text-sm rounded bg-[var(--color-accent)]/20 text-[var(--color-accent-light)]"
+            className={`group inline-flex items-center gap-1 px-2 py-0.5 text-sm rounded ${style.chip}`}
           >
-            {tag.name}
+            {style.label && (
+              <span className="text-[9px] uppercase tracking-wide opacity-70">{style.label}</span>
+            )}
+            <button
+              onClick={() => handleCycleMode(tag.id, tag.mode)}
+              title={style.hint}
+              className={style.name}
+              aria-label={`${tag.name}: ${tag.mode}. Change how this tag scopes the conversation`}
+            >
+              {tag.name}
+            </button>
             <button
               onClick={() => handleRemoveTag(tag.id)}
               className="opacity-0 group-hover:opacity-100 hover:text-red-400 transition-all"
@@ -191,8 +239,8 @@ export function ScopeEditor({ conversation }: ScopeEditorProps) {
               <X className="w-3 h-3" strokeWidth={2} />
             </button>
           </span>
-        ))
-      )}
+        );
+      })}
 
       {/* Add tag button/dropdown */}
       {isAdding ? (

--- a/src/components/chat/index.ts
+++ b/src/components/chat/index.ts
@@ -5,4 +5,5 @@ export { ChatView } from './ChatView';
 export { ChatHeader } from './ChatHeader';
 export { ChatMessage } from './ChatMessage';
 export { ChatInput } from './ChatInput';
+export { ChatContextChip } from './ChatContextChip';
 export { ScopeEditor } from './ScopeEditor';

--- a/src/components/chat/saveAnswerAsAtom.test.ts
+++ b/src/components/chat/saveAnswerAsAtom.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import { buildAnswerAtomContent } from './saveAnswerAsAtom';
+import type { ChatCitation } from '../../stores/chat';
+
+const ATOM_A = '11111111-1111-4111-8111-111111111111';
+const ATOM_B = '22222222-2222-4222-8222-222222222222';
+
+function citation(overrides: Partial<ChatCitation> & { citation_index: number }): ChatCitation {
+  return {
+    id: `citation-${overrides.citation_index}`,
+    message_id: 'm1',
+    atom_id: ATOM_A,
+    chunk_index: null,
+    excerpt: 'an excerpt',
+    relevance_score: null,
+    ...overrides,
+  };
+}
+
+describe('buildAnswerAtomContent', () => {
+  it('converts atom markers to atom links and lists them as sources', () => {
+    const content = buildAnswerAtomContent({
+      answer: 'Rust owns memory [1].',
+      citations: [citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A })],
+      question: 'How does Rust manage memory?',
+    });
+
+    expect(content).toBe(
+      [
+        '# How does Rust manage memory?',
+        '',
+        `Rust owns memory [[${ATOM_A}]].`,
+        '',
+        '## Sources',
+        `- [[${ATOM_A}]]`,
+      ].join('\n'),
+    );
+  });
+
+  it('treats a citation with no source type as an atom', () => {
+    const content = buildAnswerAtomContent({
+      answer: 'Legacy citation [1].',
+      citations: [citation({ citation_index: 1, atom_id: ATOM_B })],
+      question: 'q',
+    });
+
+    expect(content).toContain(`Legacy citation [[${ATOM_B}]].`);
+    expect(content).toContain(`- [[${ATOM_B}]]`);
+  });
+
+  it('strips wiki and finding markers inline but keeps them in Sources', () => {
+    const content = buildAnswerAtomContent({
+      answer: 'The article says so [1], and the report agrees [2].',
+      citations: [
+        citation({ citation_index: 1, source_type: 'wiki', source_title: 'Rust' }),
+        citation({
+          citation_index: 2,
+          source_type: 'finding',
+          source_title: null,
+          excerpt: 'Weekly digest\nsecond line',
+        }),
+      ],
+      question: 'q',
+    });
+
+    expect(content).toContain('The article says so, and the report agrees.');
+    expect(content).toContain('- Wiki: Rust');
+    expect(content).toContain('- Report finding: Weekly digest');
+  });
+
+  it('handles a mix of source types in one answer', () => {
+    const content = buildAnswerAtomContent({
+      answer: 'Both the note [1] and the article [2] say so, and so does [3].',
+      citations: [
+        citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A }),
+        citation({ citation_index: 2, source_type: 'wiki', source_title: 'Ownership' }),
+        citation({ citation_index: 3, source_type: 'atom', atom_id: ATOM_B }),
+      ],
+      question: 'q',
+    });
+
+    expect(content).toContain(
+      `Both the note [[${ATOM_A}]] and the article say so, and so does [[${ATOM_B}]].`,
+    );
+    expect(content.split('\n').slice(-3)).toEqual([
+      `- [[${ATOM_A}]]`,
+      '- Wiki: Ownership',
+      `- [[${ATOM_B}]]`,
+    ]);
+  });
+
+  it('lists each cited source once, in citation order', () => {
+    const content = buildAnswerAtomContent({
+      answer: 'Twice [2] over [1] and again [2].',
+      citations: [
+        citation({ citation_index: 2, source_type: 'atom', atom_id: ATOM_B }),
+        citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A }),
+        citation({ citation_index: 2, source_type: 'atom', atom_id: ATOM_B }),
+      ],
+      question: 'q',
+    });
+
+    expect(content.split('\n').slice(-2)).toEqual([`- [[${ATOM_A}]]`, `- [[${ATOM_B}]]`]);
+  });
+
+  it('leaves a bracketed number alone when no citation backs it', () => {
+    const content = buildAnswerAtomContent({
+      answer: 'Item [7] of the list.',
+      citations: [],
+      question: 'q',
+    });
+
+    expect(content).toBe('# q\n\nItem [7] of the list.');
+  });
+
+  it('omits the Sources section when there are no citations', () => {
+    const content = buildAnswerAtomContent({
+      answer: 'No sources here.',
+      citations: [],
+      question: 'What is this?',
+    });
+
+    expect(content).toBe('# What is this?\n\nNo sources here.');
+    expect(content).not.toContain('## Sources');
+  });
+
+  it('leaves bracketed numbers inside a fenced code block alone', () => {
+    const content = buildAnswerAtomContent({
+      answer: [
+        'Index it like this [1]:',
+        '',
+        '```ts',
+        'const first = items[1];',
+        'const second = items[2];',
+        '```',
+        '',
+        'That is the pattern [2].',
+      ].join('\n'),
+      citations: [
+        citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A }),
+        citation({ citation_index: 2, source_type: 'wiki', source_title: 'Arrays' }),
+      ],
+      question: 'q',
+    });
+
+    expect(content).toContain('const first = items[1];');
+    expect(content).toContain('const second = items[2];');
+    expect(content).toContain(`Index it like this [[${ATOM_A}]]:`);
+    expect(content).toContain('That is the pattern.');
+  });
+
+  it('handles tilde fences, info strings, and an unclosed fence', () => {
+    const fenced = buildAnswerAtomContent({
+      answer: ['~~~python', 'print(items[1])', '~~~', '', 'Done [1].'].join('\n'),
+      citations: [citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A })],
+      question: 'q',
+    });
+    expect(fenced).toContain('print(items[1])');
+    expect(fenced).toContain(`Done [[${ATOM_A}]].`);
+
+    // A fence the answer never closed runs to the end, the way a renderer
+    // reads it — so nothing after it is prose to rewrite. (The Sources list
+    // still names the citation; only the inline marker is left alone.)
+    const unclosed = buildAnswerAtomContent({
+      answer: ['```', 'items[1]', 'still code [1]'].join('\n'),
+      citations: [citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A })],
+      question: 'q',
+    });
+    expect(unclosed).toBe(
+      ['# q', '', '```', 'items[1]', 'still code [1]', '', '## Sources', `- [[${ATOM_A}]]`].join(
+        '\n',
+      ),
+    );
+  });
+
+  it('leaves bracketed numbers inside inline code spans alone', () => {
+    const content = buildAnswerAtomContent({
+      answer: 'Use `items[1]` and ``a ` items[2]`` — then cite [1] and [2].',
+      citations: [
+        citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A }),
+        citation({ citation_index: 2, source_type: 'wiki', source_title: 'Arrays' }),
+      ],
+      question: 'q',
+    });
+
+    expect(content).toContain('`items[1]`');
+    expect(content).toContain('``a ` items[2]``');
+    expect(content).toContain(`then cite [[${ATOM_A}]] and.`);
+  });
+
+  it('treats a line that closes its own backtick run as a span, not a fence', () => {
+    // Without this, ```x``` opening a sentence reads as an unclosed fence and
+    // swallows the rest of the answer — nothing after it would be rewritten.
+    const content = buildAnswerAtomContent({
+      answer: ['```items[1]``` is the syntax [1].', '', 'More prose [1].'].join('\n'),
+      citations: [citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A })],
+      question: 'q',
+    });
+
+    expect(content).toContain('```items[1]```');
+    expect(content).toContain(`is the syntax [[${ATOM_A}]].`);
+    expect(content).toContain(`More prose [[${ATOM_A}]].`);
+  });
+
+  it('protects code inside a fence nested in a longer fence', () => {
+    const content = buildAnswerAtomContent({
+      answer: ['````md', '```', 'items[1]', '```', '````', '', 'cite [1]'].join('\n'),
+      citations: [citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A })],
+      question: 'q',
+    });
+
+    expect(content).toContain('```\nitems[1]\n```');
+    expect(content).toContain(`cite [[${ATOM_A}]]`);
+  });
+
+  it('leaves reference-style links intact', () => {
+    const content = buildAnswerAtomContent({
+      answer: [
+        'See [the docs][1] and [2](https://example.com), cited as [1].',
+        '',
+        '[1]: https://example.com/docs',
+      ].join('\n'),
+      citations: [
+        citation({ citation_index: 1, source_type: 'atom', atom_id: ATOM_A }),
+        citation({ citation_index: 2, source_type: 'atom', atom_id: ATOM_B }),
+      ],
+      question: 'q',
+    });
+
+    expect(content).toContain('See [the docs][1] and [2](https://example.com)');
+    expect(content).toContain(`cited as [[${ATOM_A}]].`);
+    expect(content).toContain('[1]: https://example.com/docs');
+  });
+
+  it('titles the atom from the question, then the conversation, then a constant', () => {
+    const base = { answer: 'Answer.', citations: [] };
+
+    expect(
+      buildAnswerAtomContent({ ...base, question: 'First line\nsecond line', conversationTitle: 'Conv' }),
+    ).toContain('# First line');
+    expect(buildAnswerAtomContent({ ...base, question: '   ', conversationTitle: 'Conv' })).toContain(
+      '# Conv',
+    );
+    expect(buildAnswerAtomContent({ ...base, question: null, conversationTitle: null })).toContain(
+      '# Chat answer',
+    );
+  });
+
+  it('truncates a long question to a title-sized first line', () => {
+    const question = `${'word '.repeat(40)}end`;
+    const title = buildAnswerAtomContent({ answer: 'a', citations: [], question }).split('\n')[0];
+
+    expect(title.startsWith('# word word')).toBe(true);
+    expect(title.endsWith('...')).toBe(true);
+    // "# " + 80 chars of question (trailing space trimmed) + the ellipsis.
+    expect(title.length).toBeLessThanOrEqual(2 + 80 + 3);
+  });
+});

--- a/src/components/chat/saveAnswerAsAtom.ts
+++ b/src/components/chat/saveAnswerAsAtom.ts
@@ -1,0 +1,244 @@
+import type { ChatCitation, CitationSourceType } from '../../stores/chat';
+import { useAtomsStore, type AtomWithTags } from '../../stores/atoms';
+import { useTagsStore, type TagWithCount } from '../../stores/tags';
+
+/// Every saved answer carries this tag: the visible, filterable marker that a
+/// note was written by the assistant rather than by hand.
+export const CHAT_ANSWERS_TAG_NAME = 'Chat Answers';
+
+const MAX_TITLE_LENGTH = 80;
+const FALLBACK_TITLE = 'Chat answer';
+
+export interface AnswerAtomContentInput {
+  /// Raw assistant markdown. Never the rendered DOM: a `[N]` marker only means
+  /// something alongside the citations array it was emitted with.
+  answer: string;
+  citations: ChatCitation[];
+  /// The question that produced the answer; its first line becomes the title.
+  question?: string | null;
+  conversationTitle?: string | null;
+}
+
+/// Assemble the markdown for an atom made from a chat answer.
+///
+/// Citation markers are resolved rather than carried over: an answer that
+/// keeps saying `[3]` in the knowledge base points at nothing. Atom citations
+/// become `[[atom-id]]` links — the server extracts those into real atom links,
+/// which is what wires the saved answer into the graph — and citations of
+/// wikis and report findings, which have no atom to link to, lose their inline
+/// marker and survive only in the Sources list.
+export function buildAnswerAtomContent({
+  answer,
+  citations,
+  question,
+  conversationTitle,
+}: AnswerAtomContentInput): string {
+  const byIndex = new Map(citations.map((citation) => [citation.citation_index, citation]));
+  const sections = [
+    `# ${answerTitle(question, conversationTitle)}`,
+    convertCitationMarkers(answer.trim(), byIndex),
+    buildSourcesSection(citations),
+  ];
+  return sections.filter((section) => section.length > 0).join('\n\n');
+}
+
+/// Turn an assistant answer into an atom. The ordinary create pipeline takes
+/// it from there: chunking, embedding, auto-tagging, and link extraction all
+/// follow from the write, so nothing here is special-cased.
+export async function saveAnswerAsAtom(input: AnswerAtomContentInput): Promise<AtomWithTags> {
+  const content = buildAnswerAtomContent(input);
+  const tagId = await findOrCreateChatAnswersTag();
+  return useAtomsStore.getState().createAtom(content, undefined, [tagId]);
+}
+
+function sourceTypeOf(citation: ChatCitation): CitationSourceType {
+  return citation.source_type ?? 'atom';
+}
+
+/// A fence line: up to three spaces of indent, then three or more backticks
+/// or tildes.
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+/// A closing fence: the same run of the same character, nothing after it.
+const FENCE_CLOSE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/;
+/// A run of backticks delimiting an inline span, closed by a run of the same
+/// length — `` `a ` b` `` is one span, not two.
+const INLINE_CODE = /(`+)[^]*?\1(?!`)/g;
+
+/// Half-open `[start, end)` ranges of `markdown` that are code: fenced blocks
+/// first, then inline spans in the prose between them.
+///
+/// Citation markers are the assistant's, written into its own prose. The same
+/// characters inside a code block are the *user's content* — `items[1]` in a
+/// snippet, a `[2]` in a config sample — and rewriting them silently corrupts
+/// the atom the answer was saved as.
+function codeRanges(markdown: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+
+  let position = 0;
+  let open: { marker: string; start: number } | null = null;
+  for (const line of markdown.split('\n')) {
+    const lineStart = position;
+    position += line.length + 1; // the '\n' split consumed
+    const match = FENCE_OPEN.exec(line);
+    if (!match) continue;
+
+    if (!open) {
+      const [, marker, info] = match;
+      // A line that closes its own run — ```items[1]``` at the start of a
+      // sentence — is a code span, not a fence. Treating it as one would
+      // swallow the rest of the answer; the inline-span pass below picks it
+      // up instead.
+      if (info.includes(marker)) continue;
+      open = { marker, start: lineStart };
+    } else if (
+      FENCE_CLOSE.test(line) &&
+      match[1][0] === open.marker[0] &&
+      match[1].length >= open.marker.length
+    ) {
+      ranges.push([open.start, Math.min(position, markdown.length)]);
+      open = null;
+    }
+  }
+  // An unclosed fence runs to the end of the document, the way a renderer
+  // treats it.
+  if (open) ranges.push([open.start, markdown.length]);
+
+  const spans: Array<[number, number]> = [];
+  const gaps: Array<[number, number]> = [
+    ...ranges,
+    [markdown.length, markdown.length] as [number, number],
+  ];
+  let cursor = 0;
+  for (const [start, end] of gaps) {
+    const gap = markdown.slice(cursor, start);
+    for (const span of gap.matchAll(INLINE_CODE)) {
+      const at = cursor + (span.index ?? 0);
+      spans.push([at, at + span[0].length]);
+    }
+    cursor = end;
+  }
+
+  return [...ranges, ...spans].sort((a, b) => a[0] - b[0]);
+}
+
+/// Whether the bracketed number at `[start, end)` is part of a link rather
+/// than a citation marker: the reference half of `[text][1]`, an inline link
+/// `[1](url)`, or a definition `[1]: url`. Rewriting any of those breaks the
+/// link.
+function isLinkSyntax(markdown: string, start: number, end: number): boolean {
+  const previous = markdown[start - 1];
+  if (previous === ']' || previous === '[') return true;
+  const next = markdown[end];
+  if (next === '(' || next === '[') return true;
+  if (next !== ':') return false;
+  // A definition only counts at the start of a line — "cited as [1]: here"
+  // is prose, and the marker in it is ours.
+  const lineStart = markdown.lastIndexOf('\n', start - 1) + 1;
+  return /^ {0,3}$/.test(markdown.slice(lineStart, start));
+}
+
+function convertCitationMarkers(markdown: string, byIndex: Map<number, ChatCitation>): string {
+  // The space before a marker is part of the match so dropping a non-atom
+  // marker doesn't leave "the answer ." behind.
+  const rewrite = (prose: string, base: number): string =>
+    prose.replace(/([ \t]?)\[(\d+)\]/g, (marker, space: string, index: string, at: number) => {
+      const bracket = base + at + space.length;
+      if (isLinkSyntax(markdown, bracket, bracket + marker.length - space.length)) return marker;
+      const citation = byIndex.get(Number(index));
+      // A marker with no citation behind it isn't ours to rewrite — the answer
+      // may simply have written a bracketed number.
+      if (!citation) return marker;
+      if (sourceTypeOf(citation) !== 'atom') return '';
+      return `${space}[[${citation.atom_id}]]`;
+    });
+
+  let out = '';
+  let cursor = 0;
+  for (const [start, end] of codeRanges(markdown)) {
+    // Ranges are sorted but a fence can contain nothing else; guard anyway so
+    // an overlapping pair can never duplicate text.
+    if (start < cursor) continue;
+    out += rewrite(markdown.slice(cursor, start), cursor);
+    out += markdown.slice(start, end);
+    cursor = end;
+  }
+  return out + rewrite(markdown.slice(cursor), cursor);
+}
+
+function buildSourcesSection(citations: ChatCitation[]): string {
+  const seen = new Set<string>();
+  const lines: string[] = [];
+
+  for (const citation of [...citations].sort((a, b) => a.citation_index - b.citation_index)) {
+    const key = `${sourceTypeOf(citation)}:${citation.atom_id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    lines.push(`- ${sourceLine(citation)}`);
+  }
+
+  if (lines.length === 0) return '';
+  return ['## Sources', ...lines].join('\n');
+}
+
+function sourceLine(citation: ChatCitation): string {
+  switch (sourceTypeOf(citation)) {
+    case 'wiki':
+      return `Wiki: ${firstLine(citation.source_title) || 'Untitled article'}`;
+    case 'finding':
+      return `Report finding: ${firstLine(citation.source_title) || firstLine(citation.excerpt) || 'Untitled finding'}`;
+    default:
+      return `[[${citation.atom_id}]]`;
+  }
+}
+
+function answerTitle(question?: string | null, conversationTitle?: string | null): string {
+  return firstLine(question) || firstLine(conversationTitle) || FALLBACK_TITLE;
+}
+
+function firstLine(text?: string | null, max = MAX_TITLE_LENGTH): string {
+  const line = (text ?? '').trim().split('\n')[0].trim();
+  if (line.length <= max) return line;
+  return `${line.slice(0, max).trimEnd()}...`;
+}
+
+/// Resolve the provenance tag, creating it the first time an answer is saved.
+async function findOrCreateChatAnswersTag(): Promise<string> {
+  const cached = matchChatAnswersTag(useTagsStore.getState().tags);
+  if (cached) return cached.id;
+
+  // A miss can just mean the tree hasn't loaded yet — confirm against a fresh
+  // tree before creating, or every cold start would mint another
+  // "Chat Answers".
+  await useTagsStore.getState().fetchTags();
+  const fresh = matchChatAnswersTag(useTagsStore.getState().tags);
+  if (fresh) return fresh.id;
+
+  try {
+    const created = await useTagsStore.getState().createTag(CHAT_ANSWERS_TAG_NAME);
+    return created.id;
+  } catch (error) {
+    // Creation is the racy step: SQLite makes tag names globally unique
+    // (case-insensitively), so another client — or this one, a moment ago —
+    // may have taken the name since the fetch above. The name is the identity
+    // here, so re-resolving is the right answer to "already exists".
+    await useTagsStore.getState().fetchTags();
+    const existing = matchChatAnswersTag(useTagsStore.getState().tags);
+    if (existing) return existing.id;
+    throw error;
+  }
+}
+
+/// Find the provenance tag wherever the user has since filed it. Matching on
+/// name alone is deliberate: the tag is created at the root, but a user who
+/// nests it under, say, "Meta" has renamed nothing — and on SQLite the name is
+/// unique across the whole tree, so a parent-anchored lookup would miss it
+/// forever and every save would fail on the duplicate name.
+function matchChatAnswersTag(tags: TagWithCount[]): TagWithCount | undefined {
+  const wanted = CHAT_ANSWERS_TAG_NAME.toLowerCase();
+  for (const tag of tags) {
+    if (tag.name.trim().toLowerCase() === wanted) return tag;
+    const nested = matchChatAnswersTag(tag.children);
+    if (nested) return nested;
+  }
+  return undefined;
+}

--- a/src/components/layout/LeftPanel.tsx
+++ b/src/components/layout/LeftPanel.tsx
@@ -4,6 +4,7 @@ import { TocPanel } from '../toc/TocPanel';
 import { WikiArticlesList } from '../wiki/WikiArticlesList';
 import { RecentAtomsPanel } from '../dashboard/RecentAtomsPanel';
 import { LatestFindingsPanel } from '../reports/LatestFindingsPanel';
+import { ConversationsSidebar } from '../chat/ConversationsSidebar';
 import { useUIStore } from '../../stores/ui';
 import { useTocStore, type TocSource } from '../../stores/toc';
 import { isTauri } from '../../lib/platform';
@@ -59,6 +60,8 @@ function SidebarBody({ context }: { context: SidebarContext }) {
       return <RecentAtomsPanel />;
     case 'findings':
       return <LatestFindingsPanel reportId={context.reportId} />;
+    case 'conversations':
+      return <ConversationsSidebar />;
   }
 }
 
@@ -123,7 +126,12 @@ export function LeftPanel() {
         <div
           className="h-full w-[250px] bg-[var(--color-bg-panel)]/80 border-r border-[var(--color-border)] backdrop-blur-xl flex flex-col overflow-hidden md:absolute md:inset-y-0 md:left-0 md:translate-x-0 md:pointer-events-auto"
         >
-          {/* Titlebar row — names whatever the body is currently showing */}
+          {/* Titlebar row — names whatever the body is currently showing.
+              While the panel is open this is the leftmost visible surface, so
+              it, and only it, holds the Tauri traffic lights clear; the panel
+              collapses to zero width when closed, at which point the clearance
+              passes to MainView's titlebar (or, with chat expanded to
+              fullscreen and that bar collapsed too, ChatViewer's header). */}
           <div className={`h-[52px] flex items-center px-3 flex-shrink-0 gap-1 ${isTauri() ? 'pl-[78px]' : ''}`} data-tauri-drag-region>
             <span className="text-xs font-semibold text-[var(--color-text-tertiary)] uppercase tracking-wider truncate select-none">
               {SIDEBAR_CONTEXT_TITLES[context.kind]}

--- a/src/components/layout/MainView.tsx
+++ b/src/components/layout/MainView.tsx
@@ -79,9 +79,15 @@ export function MainView() {
 
   const chatSidebarOpen = useUIStore(s => s.chatSidebarOpen);
   const chatSidebarWidth = useUIStore(s => s.chatSidebarWidth);
+  const chatSidebarExpanded = useUIStore(s => s.chatSidebarExpanded);
   const setChatSidebarWidth = useUIStore(s => s.setChatSidebarWidth);
   const toggleChatSidebar = useUIStore(s => s.toggleChatSidebar);
   const [isResizingChat, setIsResizingChat] = useState(false);
+
+  // Desktop fullscreen chat: the whole main column, titlebar included, gives way
+  // to the chat pane. Width is untouched by expanding, so minimizing restores
+  // whatever the user had dragged the pane to.
+  const isChatFullscreen = chatSidebarOpen && chatSidebarExpanded;
 
   const [filterBarOpen, setFilterBarOpen] = useState(false);
   const isMobile = useIsMobile();
@@ -241,7 +247,15 @@ export function MainView() {
 
   return (
     <>
-    <main className="relative flex-1 flex flex-col h-full bg-[var(--color-bg-main)] overflow-hidden">
+    {/* Expanding chat collapses this column — titlebar and all — to nothing
+        rather than unmounting it: SigmaCanvas would take a fresh WebGL context
+        on every remount, and browsers hand out a limited number of them
+        (v1.39). */}
+    <main
+      className={`relative flex-1 flex flex-col h-full bg-[var(--color-bg-main)] overflow-hidden ${
+        isChatFullscreen ? 'md:flex-none md:w-0' : ''
+      }`}
+    >
       {/* Titlebar row — the row itself is a Tauri drag region; interactive
           elements inside it (buttons, tabs) receive their own events normally. */}
       <div
@@ -516,7 +530,8 @@ export function MainView() {
     />
 
     {/* Chat sidebar — available in all views.
-        Desktop: flex sibling that animates width.
+        Desktop: flex sibling that animates width, or claims the whole row when
+        expanded to fullscreen.
         Mobile: fixed overlay that slides in from the right. */}
     <div
       className={`
@@ -527,15 +542,20 @@ export function MainView() {
         ${isResizingChat ? '' : 'transition-[width,transform] duration-300 ease-in-out'}
         ${chatSidebarOpen ? 'max-md:translate-x-0' : 'max-md:translate-x-full'}
         ${chatSidebarOpen ? '' : 'md:!w-0 md:border-l-0'}
+        ${isChatFullscreen ? 'md:flex-1' : ''}
       `}
       style={{ '--chat-w': `${chatSidebarWidth}px` } as React.CSSProperties}
     >
-      {/* Resize handle — desktop only */}
-      <div
-        className="hidden md:block absolute left-0 top-0 h-full w-1.5 cursor-col-resize z-10 hover:bg-[var(--color-accent)]/20 active:bg-[var(--color-accent)]/30"
-        onMouseDown={handleChatResizeStart}
-      />
-      <div className="w-full md:min-w-[var(--chat-w)] h-full">
+      {/* Resize handle — desktop only, and meaningless at fullscreen */}
+      {!isChatFullscreen && (
+        <div
+          className="hidden md:block absolute left-0 top-0 h-full w-1.5 cursor-col-resize z-10 hover:bg-[var(--color-accent)]/20 active:bg-[var(--color-accent)]/30"
+          onMouseDown={handleChatResizeStart}
+        />
+      )}
+      {/* The min-width keeps the pane's contents from reflowing as it animates
+          shut; at fullscreen there is no such floor to hold. */}
+      <div className={`w-full h-full ${isChatFullscreen ? '' : 'md:min-w-[var(--chat-w)]'}`}>
         <ChatViewer />
       </div>
     </div>

--- a/src/components/layout/sidebar-context.test.ts
+++ b/src/components/layout/sidebar-context.test.ts
@@ -4,6 +4,8 @@ import type { ViewMode } from '../../stores/ui';
 
 function input(overrides: Partial<SidebarContextInput> = {}): SidebarContextInput {
   return {
+    chatSidebarOpen: false,
+    chatSidebarExpanded: false,
     localGraph: { isOpen: false },
     readerState: { atomId: null },
     wikiReaderState: { tagId: null },
@@ -49,6 +51,27 @@ describe('deriveSidebarContext', () => {
       kind: 'findings',
       reportId: 'r1',
     });
+  });
+
+  it('shows conversations while the chat pane is expanded, whatever else is open', () => {
+    const fullscreen: SidebarContextInput = input({
+      chatSidebarOpen: true,
+      chatSidebarExpanded: true,
+      localGraph: { isOpen: true },
+      readerState: { atomId: 'a1' },
+      reportsDetailState: { reportId: 'r1' },
+      viewMode: 'wiki',
+    });
+    expect(deriveSidebarContext(fullscreen)).toEqual({ kind: 'conversations' });
+  });
+
+  it('ignores an expanded flag while the chat pane is closed', () => {
+    expect(
+      deriveSidebarContext(input({ chatSidebarExpanded: true, chatSidebarOpen: false, viewMode: 'wiki' })),
+    ).toEqual({ kind: 'wiki-list' });
+    expect(
+      deriveSidebarContext(input({ chatSidebarExpanded: false, chatSidebarOpen: true, viewMode: 'wiki' })),
+    ).toEqual({ kind: 'wiki-list' });
   });
 
   it('keeps the tag tree while the local graph is open', () => {

--- a/src/components/layout/sidebar-context.ts
+++ b/src/components/layout/sidebar-context.ts
@@ -8,11 +8,14 @@ export type SidebarContext =
   | { kind: 'toc'; source: 'atom' | 'wiki' | 'finding' }
   | { kind: 'wiki-list' }
   | { kind: 'recent' }
-  | { kind: 'findings'; reportId: string | null };
+  | { kind: 'findings'; reportId: string | null }
+  | { kind: 'conversations' };
 
 /// The slices `deriveSidebarContext` reads. Structurally a subset of the UI
 /// store, so the store's state can be passed straight in.
 export interface SidebarContextInput {
+  chatSidebarOpen: boolean;
+  chatSidebarExpanded: boolean;
   localGraph: { isOpen: boolean };
   readerState: { atomId: string | null };
   wikiReaderState: { tagId: string | null };
@@ -27,6 +30,7 @@ export const SIDEBAR_CONTEXT_TITLES: Record<SidebarContext['kind'], string> = {
   'wiki-list': 'Articles',
   recent: 'Recent',
   findings: 'Findings',
+  conversations: 'Conversations',
 };
 
 /// Decide the sidebar's content from the projected reader slices.
@@ -40,6 +44,11 @@ export const SIDEBAR_CONTEXT_TITLES: Record<SidebarContext['kind'], string> = {
 /// `wikiReaderState.tagName`; those are written atomically with the ids they
 /// accompany by `projectActiveEntry`, so testing the ids alone is equivalent.
 export function deriveSidebarContext(s: SidebarContextInput): SidebarContext {
+  // Fullscreen chat outranks the mirror below rather than sitting inside it:
+  // the readers and views those branches describe are all hidden behind the
+  // expanded pane, so the only navigation that means anything is the chat's
+  // own list of conversations.
+  if (s.chatSidebarExpanded && s.chatSidebarOpen) return { kind: 'conversations' };
   if (s.localGraph.isOpen) return { kind: 'tags' };
   if (s.readerState.atomId) return { kind: 'toc', source: 'atom' };
   if (s.wikiReaderState.tagId) return { kind: 'toc', source: 'wiki' };

--- a/src/components/onboarding/useOnboardingState.ts
+++ b/src/components/onboarding/useOnboardingState.ts
@@ -147,8 +147,8 @@ const initialState: OnboardingState = {
   apiKey: '',
   embeddingModel: 'openai/text-embedding-3-small',
   taggingModel: 'openai/gpt-4o-mini',
-  wikiModel: 'anthropic/claude-sonnet-4.6',
-  chatModel: 'anthropic/claude-sonnet-4.6',
+  wikiModel: 'anthropic/claude-sonnet-5',
+  chatModel: 'anthropic/claude-sonnet-5',
   autoTaggingEnabled: true,
   isTesting: false,
   testResult: null,
@@ -211,8 +211,8 @@ function reducer(state: OnboardingState, action: OnboardingAction): OnboardingSt
       } else if (action.value === 'openrouter') {
         base.embeddingModel = 'openai/text-embedding-3-small';
         base.taggingModel = 'openai/gpt-4o-mini';
-        base.wikiModel = 'anthropic/claude-sonnet-4.6';
-        base.chatModel = 'anthropic/claude-sonnet-4.6';
+        base.wikiModel = 'anthropic/claude-sonnet-5';
+        base.chatModel = 'anthropic/claude-sonnet-5';
       }
       return base;
     }

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -956,13 +956,13 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
   const [autoTaggingEnabled, setAutoTaggingEnabled] = useState(true);
   const [embeddingModel, setEmbeddingModel] = useState('openai/text-embedding-3-small');
   const [taggingModel, setTaggingModel] = useState('openai/gpt-4o-mini');
-  const [wikiModel, setWikiModel] = useState('anthropic/claude-sonnet-4.6');
+  const [wikiModel, setWikiModel] = useState('anthropic/claude-sonnet-5');
   const [wikiStrategy, setWikiStrategy] = useState('centroid');
   const [wikiGenerationPrompt, setWikiGenerationPrompt] = useState('');
   const [wikiUpdatePrompt, setWikiUpdatePrompt] = useState('');
   const [chatPrompt, setChatPrompt] = useState('');
   const [taggingPrompt, setTaggingPrompt] = useState('');
-  const [chatModel, setChatModel] = useState('anthropic/claude-sonnet-4.6');
+  const [chatModel, setChatModel] = useState('anthropic/claude-sonnet-5');
   const [saveError, setSaveError] = useState<string | null>(null);
 
   // Re-embedding confirmation
@@ -1422,13 +1422,13 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
     setAutoTaggingEnabled(settings.auto_tagging_enabled !== 'false');
     setEmbeddingModel(settings.embedding_model || 'openai/text-embedding-3-small');
     setTaggingModel(settings.tagging_model || 'openai/gpt-4o-mini');
-    setWikiModel(settings.wiki_model || 'anthropic/claude-sonnet-4.6');
+    setWikiModel(settings.wiki_model || 'anthropic/claude-sonnet-5');
     setWikiStrategy(settings.wiki_strategy || 'centroid');
     setWikiGenerationPrompt(settings.wiki_generation_prompt || '');
     setWikiUpdatePrompt(settings.wiki_update_prompt || '');
     setChatPrompt(settings.chat_prompt || '');
     setTaggingPrompt(settings.tagging_prompt || '');
-    setChatModel(settings.chat_model || 'anthropic/claude-sonnet-4.6');
+    setChatModel(settings.chat_model || 'anthropic/claude-sonnet-5');
     setOllamaHost(settings.ollama_host || 'http://127.0.0.1:11434');
     setOllamaEmbeddingModel(settings.ollama_embedding_model || 'nomic-embed-text');
     setOllamaLlmModel(settings.ollama_llm_model || 'llama3.2');

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -149,6 +149,12 @@ export function ContextMenu({ items, position, onClose, autoFocus = false }: Con
     <div
       ref={menuRef}
       role="menu"
+      /* An open menu owns Escape and the click that closes it — the same
+         claim Modal and the palettes make. Without the marker, a capture-phase
+         Escape handler further out (fullscreen chat's, which stops the event
+         there) closes itself and leaves this menu floating over a view it no
+         longer belongs to. */
+      data-modal="true"
       onKeyDown={onMenuKeyDown}
       className="fixed z-50 min-w-[160px] bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-lg shadow-xl py-1 animate-in fade-in zoom-in-95 duration-100"
       style={{

--- a/src/components/wiki/CitationPopover.tsx
+++ b/src/components/wiki/CitationPopover.tsx
@@ -2,7 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, BookOpen, Telescope } from 'lucide-react';
 import { useKeyboard } from '../../hooks/useKeyboard';
 
 // Generic citation interface that works with both WikiCitation and ChatCitation
@@ -10,7 +10,19 @@ export interface CitationForPopover {
   citation_index: number;
   atom_id: string;
   excerpt: string;
+  // Chat citations can point at a wiki article or a report finding instead
+  // of an atom. Everything else cites atoms only and omits this.
+  source_type?: 'atom' | 'wiki' | 'finding';
+  source_title?: string | null;
 }
+
+// How each kind of source names itself. Atoms keep the original wording so
+// the wiki, dashboard and finding readers are untouched by chat's sources.
+const SOURCE_LABELS = {
+  atom: { kind: 'Source excerpt', open: 'View full atom', Icon: null },
+  wiki: { kind: 'Wiki excerpt', open: 'View wiki article', Icon: BookOpen },
+  finding: { kind: 'Finding excerpt', open: 'View finding', Icon: Telescope },
+} as const;
 
 interface CitationPopoverProps {
   citation: CitationForPopover;
@@ -89,6 +101,8 @@ export function CitationPopover({ citation, anchorRect, onClose, onViewAtom }: C
     onClose();
   };
 
+  const source = SOURCE_LABELS[citation.source_type ?? 'atom'];
+
   // Truncate excerpt if needed
   const displayExcerpt = citation.excerpt.length > 300
     ? citation.excerpt.slice(0, 297) + '...'
@@ -114,7 +128,12 @@ export function CitationPopover({ citation, anchorRect, onClose, onViewAtom }: C
         <span className="inline-flex items-center justify-center w-6 h-6 rounded bg-[var(--color-accent)]/20 text-[var(--color-accent-light)] text-xs font-medium">
           {citation.citation_index}
         </span>
-        <span className="text-xs text-[var(--color-text-secondary)]">Source excerpt</span>
+        {source.Icon && (
+          <source.Icon className="w-3.5 h-3.5 text-[var(--color-text-tertiary)]" strokeWidth={2} />
+        )}
+        <span className="text-xs text-[var(--color-text-secondary)]">
+          {citation.source_title ? `${source.kind} — ${citation.source_title}` : source.kind}
+        </span>
       </div>
 
       {/* Excerpt content */}
@@ -130,7 +149,7 @@ export function CitationPopover({ citation, anchorRect, onClose, onViewAtom }: C
           onClick={handleViewAtom}
           className="flex items-center gap-1 text-sm text-[var(--color-accent)] hover:text-[var(--color-accent-light)] transition-colors"
         >
-          View full atom
+          {source.open}
           <ArrowRight className="w-4 h-4" strokeWidth={2} />
         </button>
       </div>

--- a/src/hooks/useChatEvents.ts
+++ b/src/hooks/useChatEvents.ts
@@ -18,6 +18,7 @@ interface ChatToolComplete {
   conversation_id: string;
   tool_call_id: string;
   results_count: number;
+  failed: boolean;
 }
 
 interface ChatComplete {
@@ -30,12 +31,18 @@ interface ChatError {
   error: string;
 }
 
+interface ChatConversationUpdated {
+  conversation_id: string;
+  title: string;
+}
+
 export function useChatEvents(conversationId: string | null) {
   const appendStreamContent = useChatStore(s => s.appendStreamContent);
   const startStreamingToolCall = useChatStore(s => s.startStreamingToolCall);
   const completeStreamingToolCall = useChatStore(s => s.completeStreamingToolCall);
   const completeMessage = useChatStore(s => s.completeMessage);
   const setStreamingError = useChatStore(s => s.setStreamingError);
+  const applyConversationTitle = useChatStore(s => s.applyConversationTitle);
 
   useEffect(() => {
     if (!conversationId) return;
@@ -64,6 +71,7 @@ export function useChatEvents(conversationId: string | null) {
         completeStreamingToolCall({
           tool_call_id: payload.tool_call_id,
           results_count: payload.results_count,
+          failed: payload.failed ?? false,
         });
       }
     }));
@@ -80,8 +88,16 @@ export function useChatEvents(conversationId: string | null) {
       }
     }));
 
+    // The auto-generated title lands after the turn completes; applying it
+    // here updates the header and the list entry without a refetch.
+    unsubs.push(transport.subscribe<ChatConversationUpdated>('chat-conversation-updated', (payload) => {
+      if (payload.conversation_id === conversationId) {
+        applyConversationTitle(payload.conversation_id, payload.title);
+      }
+    }));
+
     return () => {
       unsubs.forEach((unsub) => unsub());
     };
-  }, [conversationId, appendStreamContent, startStreamingToolCall, completeStreamingToolCall, completeMessage, setStreamingError]);
+  }, [conversationId, appendStreamContent, startStreamingToolCall, completeStreamingToolCall, completeMessage, setStreamingError, applyConversationTitle]);
 }

--- a/src/hooks/useChatEvents.ts
+++ b/src/hooks/useChatEvents.ts
@@ -36,7 +36,20 @@ interface ChatConversationUpdated {
   title: string;
 }
 
-export function useChatEvents(conversationId: string | null) {
+/**
+ * Subscribe to the chat event stream for the whole pane.
+ *
+ * Mounted once, at the always-present ChatViewer, and deliberately *not*
+ * scoped to a conversation id. A turn outlives the view it was started from:
+ * the user hits back, opens another conversation, archives this one — and the
+ * completion event still has to land, or the streaming state it was going to
+ * clear stays raised forever and every conversation renders a phantom
+ * "Thinking…" with a dead input. Each payload carries the conversation it is
+ * about and the store decides what applies to what (see
+ * `streamingConversationId`), which is also why this hook has nothing to
+ * filter.
+ */
+export function useChatEvents() {
   const appendStreamContent = useChatStore(s => s.appendStreamContent);
   const startStreamingToolCall = useChatStore(s => s.startStreamingToolCall);
   const completeStreamingToolCall = useChatStore(s => s.completeStreamingToolCall);
@@ -45,59 +58,47 @@ export function useChatEvents(conversationId: string | null) {
   const applyConversationTitle = useChatStore(s => s.applyConversationTitle);
 
   useEffect(() => {
-    if (!conversationId) return;
-
     const transport = getTransport();
     const unsubs: Array<() => void> = [];
 
     unsubs.push(transport.subscribe<ChatStreamDelta>('chat-stream-delta', (payload) => {
-      if (payload.conversation_id === conversationId) {
-        appendStreamContent(payload.content);
-      }
+      appendStreamContent(payload.conversation_id, payload.content);
     }));
 
     unsubs.push(transport.subscribe<ChatToolStart>('chat-tool-start', (payload) => {
-      if (payload.conversation_id === conversationId) {
-        startStreamingToolCall({
-          tool_call_id: payload.tool_call_id,
-          tool_name: payload.tool_name,
-          tool_input: payload.tool_input,
-        });
-      }
+      startStreamingToolCall({
+        conversation_id: payload.conversation_id,
+        tool_call_id: payload.tool_call_id,
+        tool_name: payload.tool_name,
+        tool_input: payload.tool_input,
+      });
     }));
 
     unsubs.push(transport.subscribe<ChatToolComplete>('chat-tool-complete', (payload) => {
-      if (payload.conversation_id === conversationId) {
-        completeStreamingToolCall({
-          tool_call_id: payload.tool_call_id,
-          results_count: payload.results_count,
-          failed: payload.failed ?? false,
-        });
-      }
+      completeStreamingToolCall({
+        conversation_id: payload.conversation_id,
+        tool_call_id: payload.tool_call_id,
+        results_count: payload.results_count,
+        failed: payload.failed ?? false,
+      });
     }));
 
     unsubs.push(transport.subscribe<ChatComplete>('chat-complete', (payload) => {
-      if (payload.conversation_id === conversationId) {
-        completeMessage(payload.message);
-      }
+      completeMessage(payload.conversation_id, payload.message);
     }));
 
     unsubs.push(transport.subscribe<ChatError>('chat-error', (payload) => {
-      if (payload.conversation_id === conversationId) {
-        setStreamingError(payload.error);
-      }
+      setStreamingError(payload.conversation_id, payload.error);
     }));
 
     // The auto-generated title lands after the turn completes; applying it
     // here updates the header and the list entry without a refetch.
     unsubs.push(transport.subscribe<ChatConversationUpdated>('chat-conversation-updated', (payload) => {
-      if (payload.conversation_id === conversationId) {
-        applyConversationTitle(payload.conversation_id, payload.title);
-      }
+      applyConversationTitle(payload.conversation_id, payload.title);
     }));
 
     return () => {
       unsubs.forEach((unsub) => unsub());
     };
-  }, [conversationId, appendStreamContent, startStreamingToolCall, completeStreamingToolCall, completeMessage, setStreamingError, applyConversationTitle]);
+  }, [appendStreamContent, startStreamingToolCall, completeStreamingToolCall, completeMessage, setStreamingError, applyConversationTitle]);
 }

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -1,0 +1,7 @@
+/// Whether a keystroke is destined for a real text input, so bare shortcuts
+/// (`i`, Escape) must not hijack it. Read-only editor bodies are not
+/// contenteditable, so they never match.
+export function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+}

--- a/src/lib/transport/command-map.ts
+++ b/src/lib/transport/command-map.ts
@@ -536,13 +536,13 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
     method: 'PUT',
     path: (a) => `/api/conversations/${encodeURIComponent(a.conversationId as string)}/scope`,
     argsMode: 'body',
-    transformArgs: (a) => ({ tag_ids: a.tagIds }),
+    transformArgs: (a) => ({ tag_ids: a.entries }),
   },
   add_tag_to_scope: {
     method: 'POST',
     path: (a) => `/api/conversations/${encodeURIComponent(a.conversationId as string)}/scope/tags`,
     argsMode: 'body',
-    transformArgs: (a) => ({ tag_id: a.tagId }),
+    transformArgs: (a) => ({ tag_id: a.tagId, mode: a.mode ?? 'include' }),
   },
   remove_tag_from_scope: {
     method: 'DELETE',

--- a/src/lib/transport/command-map.ts
+++ b/src/lib/transport/command-map.ts
@@ -513,6 +513,7 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
       if (a.filterTagId) params.set('filter_tag_id', a.filterTagId as string);
       if (a.limit != null) params.set('limit', String(a.limit));
       if (a.offset != null) params.set('offset', String(a.offset));
+      if (a.includeArchived) params.set('include_archived', 'true');
       const qs = params.toString();
       return `/api/conversations${qs ? `?${qs}` : ''}`;
     },
@@ -556,6 +557,11 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
       ...(a.canvasContext ? { canvas_context: a.canvasContext } : {}),
       ...(a.pageContext ? { page_context: a.pageContext } : {}),
     }),
+  },
+  cancel_chat_message: {
+    method: 'POST',
+    path: (a) =>
+      `/api/conversations/${encodeURIComponent(a.conversationId as string)}/messages/cancel`,
   },
 
   // ==================== Ollama ====================

--- a/src/lib/transport/event-normalizer.ts
+++ b/src/lib/transport/event-normalizer.ts
@@ -30,6 +30,8 @@ export function normalizeServerEvent(data: Record<string, unknown>): NormalizedE
       return { event: 'chat-canvas-action', payload: data };
     case 'ChatError':
       return { event: 'chat-error', payload: data };
+    case 'ChatConversationUpdated':
+      return { event: 'chat-conversation-updated', payload: data };
     case 'AtomCreated':
       return { event: 'atom-created', payload: data.atom };
     case 'AtomUpdated':

--- a/src/router/RouterBridge.tsx
+++ b/src/router/RouterBridge.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useUIStore, type Tab, type TabEntry } from '../stores/ui';
+import { LEAVE_FULLSCREEN_CHAT, useUIStore, type Tab, type TabEntry } from '../stores/ui';
 import { parseLocation, type ParsedRoute } from './routes';
 import { setNavigateFn, type NavigateState } from './navigate-ref';
 
@@ -14,7 +14,9 @@ import { setNavigateFn, type NavigateState } from './navigate-ref';
 ///      tabs array is the source of truth for what tabs exist and where in
 ///      their stacks the user has been. Bridge keeps the two consistent:
 ///      activate/create tabs to match URL, navigate to the current tab's
-///      entry on tab switches.
+///      entry on tab switches. Every reconcile also leaves fullscreen chat —
+///      the store's navigating actions do, and browser Back/Forward reaches
+///      here instead of through them, so the promise has to be kept twice.
 ///
 /// The seq counter in `history.state` is still used to disambiguate forward
 /// vs back popstate. Without it, browser-back to a tab whose stackIndex was
@@ -240,6 +242,7 @@ export function RouterBridge() {
       const projected = projectActiveEntry(null);
       const needsUpdate =
         store.activeTabId !== null ||
+        store.chatSidebarExpanded ||
         store.viewMode !== parsed.viewMode ||
         store.selectedTagId !== parsed.tagId ||
         store.readerState.atomId !== null ||
@@ -252,6 +255,7 @@ export function RouterBridge() {
         viewMode: parsed.viewMode,
         selectedTagId: parsed.tagId,
         activeTabId: null,
+        ...LEAVE_FULLSCREEN_CHAT,
         ...projected,
         localGraph: { ...s.localGraph, ...projected.localGraphPatch },
       }));
@@ -266,6 +270,7 @@ export function RouterBridge() {
       useUIStore.setState((s) => ({
         tabs: reconciled.tabs,
         activeTabId: reconciled.activeTabId,
+        ...LEAVE_FULLSCREEN_CHAT,
         selectedTagId:
           parsed.kind === 'wiki-reader' ||
           parsed.kind === 'reports-detail' ||
@@ -295,6 +300,7 @@ export function RouterBridge() {
       tabs: [...s.tabs, newTab],
       activeTabId: tabId,
       nextTabOrdinal: s.nextTabOrdinal + 1,
+      ...LEAVE_FULLSCREEN_CHAT,
       selectedTagId:
         parsed.kind === 'wiki-reader' ||
         parsed.kind === 'reports-detail' ||

--- a/src/stores/chat-streaming.test.ts
+++ b/src/stores/chat-streaming.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useChatStore, type ChatMessageWithContext, type ConversationWithTags } from './chat';
+
+const invoke = vi.fn();
+vi.mock('../lib/transport', () => ({
+  getTransport: () => ({ invoke, subscribe: () => () => {} }),
+  isDemoInstance: () => false,
+}));
+
+/// The streaming state machine, exercised through the actions the event
+/// subscription calls. The regression these cover: before the turn carried a
+/// conversation id, leaving a conversation mid-stream dropped the completion
+/// event on the floor, and `isStreaming` stayed raised forever — every
+/// conversation then rendered a phantom "Thinking…" over a dead composer,
+/// recoverable only by reloading the app.
+
+const A = 'conversation-a';
+const B = 'conversation-b';
+
+function conversation(id: string): ConversationWithTags {
+  return {
+    id,
+    title: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    is_archived: false,
+    tags: [],
+    message_count: 0,
+    last_message_preview: null,
+  };
+}
+
+function answer(id: string, conversationId: string): ChatMessageWithContext {
+  return {
+    id,
+    conversation_id: conversationId,
+    role: 'assistant',
+    content: 'the answer',
+    created_at: '2026-01-01T00:00:00Z',
+    message_index: 1,
+    tool_calls: [],
+    citations: [],
+  };
+}
+
+/// The store as it looks one message into a turn on `A`.
+function streamingOn(conversationId: string, open = conversationId) {
+  useChatStore.setState({
+    view: 'conversation',
+    currentConversation: conversation(open),
+    messages: [],
+    streamingConversationId: conversationId,
+    isStreaming: true,
+    isCancelling: false,
+    streamingContent: '',
+    streamingToolCalls: [],
+    error: null,
+  });
+}
+
+describe('chat streaming state', () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+  });
+
+  it('completes a turn the user left, and leaves nothing streaming behind', () => {
+    streamingOn(A);
+    // The user goes back to the list mid-stream.
+    useChatStore.setState({ view: 'list', currentConversation: null, messages: [] });
+    expect(useChatStore.getState().isStreaming).toBe(true);
+
+    useChatStore.getState().completeMessage(A, answer('m1', A));
+
+    const state = useChatStore.getState();
+    expect(state.isStreaming).toBe(false);
+    expect(state.isCancelling).toBe(false);
+    expect(state.streamingConversationId).toBeNull();
+    expect(state.streamingContent).toBe('');
+    expect(state.streamingToolCalls).toEqual([]);
+    // The answer belongs to a conversation that isn't on screen, so it is not
+    // spliced into whatever transcript happens to be.
+    expect(state.messages).toEqual([]);
+  });
+
+  it('adds the completed answer when its conversation is the one on screen', () => {
+    streamingOn(A);
+    useChatStore.getState().completeMessage(A, answer('m1', A));
+    expect(useChatStore.getState().messages.map((m) => m.id)).toEqual(['m1']);
+
+    // The refetch that follows delivers the same message; it must not double.
+    useChatStore.getState().completeMessage(A, answer('m1', A));
+    expect(useChatStore.getState().messages.map((m) => m.id)).toEqual(['m1']);
+  });
+
+  it('ignores events from a conversation that is not the streaming one', () => {
+    streamingOn(A);
+    useChatStore.getState().appendStreamContent(B, 'not mine');
+    useChatStore.getState().startStreamingToolCall({
+      conversation_id: B,
+      tool_call_id: 't1',
+      tool_name: 'search_atoms',
+      tool_input: {},
+    });
+    useChatStore.getState().completeMessage(B, answer('m9', B));
+
+    const state = useChatStore.getState();
+    expect(state.streamingContent).toBe('');
+    expect(state.streamingToolCalls).toEqual([]);
+    // B's completion must not release A's turn.
+    expect(state.isStreaming).toBe(true);
+    expect(state.streamingConversationId).toBe(A);
+  });
+
+  it('accumulates deltas and tool calls for the streaming conversation', () => {
+    streamingOn(A);
+    useChatStore.getState().appendStreamContent(A, 'Hello ');
+    useChatStore.getState().appendStreamContent(A, 'world');
+    useChatStore.getState().startStreamingToolCall({
+      conversation_id: A,
+      tool_call_id: 't1',
+      tool_name: 'search_atoms',
+      tool_input: { query: 'x' },
+    });
+    useChatStore
+      .getState()
+      .completeStreamingToolCall({ conversation_id: A, tool_call_id: 't1', results_count: 3, failed: false });
+
+    const state = useChatStore.getState();
+    expect(state.streamingContent).toBe('Hello world');
+    expect(state.streamingToolCalls).toHaveLength(1);
+    expect(state.streamingToolCalls[0].status).toBe('complete');
+    expect(state.streamingToolCalls[0].tool_output).toEqual({ results_count: 3 });
+  });
+
+  it('clears the turn on an error, wherever the user is', () => {
+    streamingOn(A, B);
+    useChatStore.getState().setStreamingError(A, 'provider exploded');
+
+    const state = useChatStore.getState();
+    expect(state.isStreaming).toBe(false);
+    expect(state.streamingConversationId).toBeNull();
+    expect(state.error).toBe('provider exploded');
+  });
+
+  it('reset() puts the streaming slot back to empty', () => {
+    streamingOn(A);
+    useChatStore.getState().appendStreamContent(A, 'partial');
+    useChatStore.getState().reset();
+
+    const state = useChatStore.getState();
+    expect(state.streamingConversationId).toBeNull();
+    expect(state.isStreaming).toBe(false);
+    expect(state.streamingContent).toBe('');
+    expect(state.savingAnswerMessageIds).toEqual({});
+  });
+});
+
+describe('cancelResponse', () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+    invoke.mockReset();
+  });
+
+  it('un-latches Stop when the server had no turn to cancel', async () => {
+    streamingOn(A);
+    // The cancel beat its own turn's registration (or the turn already
+    // finished): nothing will arrive to clear the pending look.
+    invoke.mockResolvedValue({ cancelled: false });
+
+    await useChatStore.getState().cancelResponse();
+
+    const state = useChatStore.getState();
+    expect(state.isCancelling).toBe(false);
+    expect(state.isStreaming).toBe(true);
+    expect(invoke).toHaveBeenCalledWith('cancel_chat_message', { conversationId: A });
+  });
+
+  it('keeps Stop pending while a signalled turn finishes its partial answer', async () => {
+    streamingOn(A);
+    invoke.mockResolvedValue({ cancelled: true });
+
+    await useChatStore.getState().cancelResponse();
+
+    expect(useChatStore.getState().isCancelling).toBe(true);
+    expect(useChatStore.getState().isStreaming).toBe(true);
+
+    // The turn still finalizes, and that is what ends the streaming state.
+    useChatStore.getState().completeMessage(A, answer('m1', A));
+    expect(useChatStore.getState().isStreaming).toBe(false);
+    expect(useChatStore.getState().isCancelling).toBe(false);
+  });
+
+  it('drops the streaming state when the cancel request itself fails', async () => {
+    streamingOn(A);
+    invoke.mockRejectedValue(new Error('offline'));
+
+    await useChatStore.getState().cancelResponse();
+
+    const state = useChatStore.getState();
+    expect(state.isStreaming).toBe(false);
+    expect(state.streamingConversationId).toBeNull();
+    expect(state.error).toContain('offline');
+  });
+
+  it('cancels the streaming conversation even after the user navigated away', async () => {
+    streamingOn(A, B);
+    invoke.mockResolvedValue({ cancelled: true });
+
+    await useChatStore.getState().cancelResponse();
+
+    expect(invoke).toHaveBeenCalledWith('cancel_chat_message', { conversationId: A });
+  });
+});

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -12,6 +12,21 @@ export interface Tag {
   created_at: string;
 }
 
+// The role a tag plays in a conversation's scope. An atom is in scope when it
+// carries at least one `include` tag (skipped when nothing is included),
+// every `require` tag, and no `exclude` tag — child tags count as their
+// parent. `include` is what every tag meant before modes existed.
+export type ScopeMode = 'include' | 'require' | 'exclude';
+
+export interface ScopeTag extends Tag {
+  mode: ScopeMode;
+}
+
+export interface ScopeEntry {
+  tag_id: string;
+  mode: ScopeMode;
+}
+
 export interface Conversation {
   id: string;
   title: string | null;
@@ -21,7 +36,7 @@ export interface Conversation {
 }
 
 export interface ConversationWithTags extends Conversation {
-  tags: Tag[];
+  tags: ScopeTag[];
   message_count: number;
   last_message_preview: string | null;
 }
@@ -46,6 +61,12 @@ export interface ChatToolCall {
   completed_at: string | null;
 }
 
+// What a citation points at. `atom_id` is read according to it: an atom id,
+// the tag id of a wiki article, or a finding's atom id. Citations stored
+// before source types existed arrive without the field, so it is optional
+// and absent means 'atom'.
+export type CitationSourceType = 'atom' | 'wiki' | 'finding';
+
 export interface ChatCitation {
   id: string;
   message_id: string;
@@ -54,6 +75,9 @@ export interface ChatCitation {
   chunk_index: number | null;
   excerpt: string;
   relevance_score: number | null;
+  source_type?: CitationSourceType;
+  // Display name for a source an id can't name — the tag behind a wiki citation.
+  source_title?: string | null;
 }
 
 export interface ChatMessageWithContext extends ChatMessage {
@@ -62,7 +86,7 @@ export interface ChatMessageWithContext extends ChatMessage {
 }
 
 export interface ConversationWithMessages extends Conversation {
-  tags: Tag[];
+  tags: ScopeTag[];
   messages: ChatMessageWithContext[];
 }
 
@@ -177,8 +201,9 @@ interface ChatStore {
   setPageContextEnabled: (conversationId: string, enabled: boolean) => void;
 
   // Actions - Scope Management
-  setScope: (tagIds: string[]) => Promise<void>;
-  addTagToScope: (tagId: string) => Promise<void>;
+  setScope: (entries: ScopeEntry[]) => Promise<void>;
+  // Doubles as "set this tag's mode": a tag already in scope changes mode.
+  addTagToScope: (tagId: string, mode?: ScopeMode) => Promise<void>;
   removeTagFromScope: (tagId: string) => Promise<void>;
 
   // Actions - Messaging
@@ -402,14 +427,14 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 
   // Scope Management
-  setScope: async (tagIds: string[]) => {
+  setScope: async (entries: ScopeEntry[]) => {
     const { currentConversation } = get();
     if (!currentConversation) return;
 
     try {
       const updated = await getTransport().invoke<ConversationWithTags>('set_conversation_scope', {
         conversationId: currentConversation.id,
-        tagIds,
+        entries,
       });
       set({ currentConversation: updated });
     } catch (e) {
@@ -417,7 +442,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }
   },
 
-  addTagToScope: async (tagId: string) => {
+  addTagToScope: async (tagId: string, mode: ScopeMode = 'include') => {
     const { currentConversation } = get();
     if (!currentConversation) return;
 
@@ -425,6 +450,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       const updated = await getTransport().invoke<ConversationWithTags>('add_tag_to_scope', {
         conversationId: currentConversation.id,
         tagId,
+        mode,
       });
       set({ currentConversation: updated });
     } catch (e) {

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { getTransport, isDemoInstance } from '../lib/transport';
+import { saveAnswerAsAtom } from '../components/chat/saveAnswerAsAtom';
 import { useUIStore } from './ui';
 import { useCanvasStore } from './canvas';
 
@@ -19,7 +20,15 @@ export interface Tag {
 export type ScopeMode = 'include' | 'require' | 'exclude';
 
 export interface ScopeTag extends Tag {
-  mode: ScopeMode;
+  // Optional because a server older than boolean scope answers without it.
+  // Read it through `scopeModeOf` rather than defaulting at each use site.
+  mode?: ScopeMode;
+}
+
+/// A scope tag's mode, defaulting to `include` — which is what every tag meant
+/// before modes existed, and what a server that predates them still means.
+export function scopeModeOf(tag: Pick<ScopeTag, 'mode'>): ScopeMode {
+  return tag.mode ?? 'include';
 }
 
 export interface ScopeEntry {
@@ -160,8 +169,31 @@ interface ChatStore {
    */
   pageContextOff: Record<string, boolean>;
 
+  /**
+   * Answers already saved as atoms, keyed by message id. Client-session-local
+   * by design: nothing records the association server-side, so a reload
+   * forgets it and the action offers to save again — which writes a second
+   * atom rather than touching the first.
+   */
+  savedAtomIdByMessageId: Record<string, string>;
+  /**
+   * Answers whose save is in flight, keyed by message id. Per-message rather
+   * than a single slot: saving one answer must not disable the action on
+   * every other answer in the conversation.
+   */
+  savingAnswerMessageIds: Record<string, boolean>;
+
   // Streaming state
   isLoading: boolean;
+  /**
+   * The conversation whose turn is currently streaming, or null when nothing
+   * is in flight. Every other streaming field belongs to *this* conversation,
+   * which is what lets the user leave a streaming turn and come back: the
+   * events keep landing, the completion still clears the slot, and a
+   * conversation that isn't the one streaming never renders a phantom
+   * "Thinking…".
+   */
+  streamingConversationId: string | null;
   isStreaming: boolean;
   /**
    * A stop has been requested for the current turn. The backend finishes the
@@ -200,6 +232,9 @@ interface ChatStore {
   // Actions - Page context
   setPageContextEnabled: (conversationId: string, enabled: boolean) => void;
 
+  // Actions - Saving answers
+  saveAnswer: (messageId: string) => Promise<void>;
+
   // Actions - Scope Management
   setScope: (entries: ScopeEntry[]) => Promise<void>;
   // Doubles as "set this tag's mode": a tag already in scope changes mode.
@@ -210,17 +245,41 @@ interface ChatStore {
   sendMessage: (content: string) => Promise<void>;
   cancelResponse: () => Promise<void>;
 
-  // Actions - Streaming updates (called from event handlers)
-  appendStreamContent: (delta: string) => void;
-  startStreamingToolCall: (call: { tool_call_id: string; tool_name: string; tool_input: unknown }) => void;
-  completeStreamingToolCall: (update: { tool_call_id: string; results_count: number; failed: boolean }) => void;
-  completeMessage: (message: ChatMessageWithContext) => void;
-  setStreamingError: (error: string) => void;
+  // Actions - Streaming updates (called from event handlers).
+  //
+  // Every one of these takes the conversation the event was about and decides
+  // for itself whether it applies: the subscription is global (see
+  // `useChatEvents`), so routing lives here rather than in a component that
+  // may have unmounted.
+  appendStreamContent: (conversationId: string, delta: string) => void;
+  startStreamingToolCall: (call: { conversation_id: string; tool_call_id: string; tool_name: string; tool_input: unknown }) => void;
+  completeStreamingToolCall: (update: { conversation_id: string; tool_call_id: string; results_count: number; failed: boolean }) => void;
+  completeMessage: (conversationId: string, message: ChatMessageWithContext) => void;
+  setStreamingError: (conversationId: string, error: string) => void;
   applyConversationTitle: (id: string, title: string) => void;
 
   // Actions - Utilities
   clearError: () => void;
   reset: () => void;
+}
+
+/// Nothing in flight. The single description of "no turn is streaming", so
+/// every path that ends a turn ends it the same way.
+const NO_STREAM = {
+  streamingConversationId: null,
+  isStreaming: false,
+  isCancelling: false,
+  streamingContent: '',
+  streamingMessageId: null,
+  streamingToolCalls: [] as ChatToolCall[],
+};
+
+/// Release the streaming slot, but only if `conversationId` is the turn
+/// holding it. A stale completion — a turn that was superseded, an event that
+/// arrived after the request already returned — must not clear a turn that is
+/// still running.
+function releaseStream(state: ChatStore, conversationId: string): Partial<ChatStore> {
+  return state.streamingConversationId === conversationId ? NO_STREAM : {};
 }
 
 export const useChatStore = create<ChatStore>((set, get) => ({
@@ -232,12 +291,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   listFilterTagId: null,
   showArchived: false,
   pageContextOff: {},
+  savedAtomIdByMessageId: {},
+  savingAnswerMessageIds: {},
   isLoading: false,
-  isStreaming: false,
-  isCancelling: false,
-  streamingContent: '',
-  streamingMessageId: null,
-  streamingToolCalls: [],
+  ...NO_STREAM,
   error: null,
 
   // Navigation
@@ -312,15 +369,13 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }
   },
 
+  // Leaving a conversation does not end its turn: the streaming state stays
+  // keyed to `streamingConversationId`, so the turn keeps arriving, still
+  // clears itself when it completes, and is waiting where the user left it if
+  // they come back.
   goBack: () => {
     const { listFilterTagId } = get();
-    set({
-      view: 'list',
-      currentConversation: null,
-      messages: [],
-      streamingContent: '',
-      streamingToolCalls: [],
-    });
+    set({ view: 'list', currentConversation: null, messages: [] });
     useUIStore.getState().setChatSidebarConversationId(null);
     get().fetchConversations(listFilterTagId ?? undefined);
   },
@@ -381,6 +436,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       await getTransport().invoke('delete_conversation', { id });
       set((state) => ({
         conversations: state.conversations.filter((c) => c.id !== id),
+        // A deleted conversation has nowhere to stream to, so its turn's
+        // state goes with it.
+        ...releaseStream(state, id),
         // If we deleted the current conversation, go back to list
         ...(state.currentConversation?.id === id
           ? { view: 'list' as const, currentConversation: null, messages: [] }
@@ -424,6 +482,49 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set((state) => ({
       pageContextOff: { ...state.pageContextOff, [conversationId]: !enabled },
     }));
+  },
+
+  // Saving answers
+  saveAnswer: async (messageId: string) => {
+    const { messages, currentConversation, savedAtomIdByMessageId, savingAnswerMessageIds } = get();
+    // Guards this answer only: two answers can be saved at once, and a slow
+    // save of one must not look like a disabled action on the rest.
+    if (savedAtomIdByMessageId[messageId] || savingAnswerMessageIds[messageId]) return;
+
+    const index = messages.findIndex((m) => m.id === messageId);
+    if (index === -1) return;
+
+    // The question that prompted the answer titles the atom. Walk back rather
+    // than assuming the previous message is the user's — tool turns land in
+    // the same list.
+    const question = messages
+      .slice(0, index)
+      .reverse()
+      .find((m) => m.role === 'user')?.content;
+
+    const clearInFlight = (state: ChatStore) => {
+      const { [messageId]: _saving, ...rest } = state.savingAnswerMessageIds;
+      return rest;
+    };
+
+    set((state) => ({
+      savingAnswerMessageIds: { ...state.savingAnswerMessageIds, [messageId]: true },
+      error: null,
+    }));
+    try {
+      const atom = await saveAnswerAsAtom({
+        answer: messages[index].content,
+        citations: messages[index].citations ?? [],
+        question,
+        conversationTitle: currentConversation?.title,
+      });
+      set((state) => ({
+        savedAtomIdByMessageId: { ...state.savedAtomIdByMessageId, [messageId]: atom.id },
+        savingAnswerMessageIds: clearInFlight(state),
+      }));
+    } catch (e) {
+      set((state) => ({ error: String(e), savingAnswerMessageIds: clearInFlight(state) }));
+    }
   },
 
   // Scope Management
@@ -480,11 +581,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       set({ error: 'No conversation selected' });
       return;
     }
+    const conversationId = currentConversation.id;
 
     // Add user message optimistically
     const userMessage: ChatMessageWithContext = {
       id: `temp-user-${Date.now()}`,
-      conversation_id: currentConversation.id,
+      conversation_id: conversationId,
       role: 'user',
       content,
       created_at: new Date().toISOString(),
@@ -495,10 +597,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
     set({
       messages: [...messages, userMessage],
+      ...NO_STREAM,
+      streamingConversationId: conversationId,
       isStreaming: true,
-      isCancelling: false,
-      streamingContent: '',
-      streamingToolCalls: [],
       error: null,
     });
 
@@ -522,116 +623,135 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       const sharesPageContext = !get().pageContextOff[currentConversation.id];
 
       await getTransport().invoke<ChatMessageWithContext>('send_chat_message', {
-        conversationId: currentConversation.id,
+        conversationId,
         content,
         canvasContext,
         pageContext: sharesPageContext ? buildPageContext() : undefined,
       });
 
-      // Refetch the conversation to get the properly saved messages
-      // This ensures correct IDs and ordering from the database
-      await openConversation(currentConversation.id);
+      // The request returning means the turn is over, whether or not its
+      // completion event arrived — release the slot before anything else so a
+      // dropped event can't strand the UI.
+      set((state) => releaseStream(state, conversationId));
+
+      // Refetch the conversation to get the properly saved messages. This
+      // ensures correct IDs and ordering from the database — but only if the
+      // user is still looking at it; a refetch would otherwise drag them back
+      // from wherever they navigated while the turn ran.
+      if (get().currentConversation?.id === conversationId) {
+        await openConversation(conversationId);
+      }
     } catch (e) {
-      // Remove the temp user message on error
       set((state) => ({
-        messages: state.messages.filter((m) => !m.id.startsWith('temp-')),
+        ...releaseStream(state, conversationId),
+        // Remove the temp user message on error — but only from the
+        // conversation it belongs to.
+        ...(state.currentConversation?.id === conversationId
+          ? { messages: state.messages.filter((m) => !m.id.startsWith('temp-')) }
+          : {}),
         error: String(e),
-        isStreaming: false,
-        isCancelling: false,
-        streamingContent: '',
       }));
     }
   },
 
   cancelResponse: async () => {
-    const { currentConversation, isStreaming, isCancelling } = get();
-    if (!currentConversation || !isStreaming || isCancelling) return;
+    const { streamingConversationId, isStreaming, isCancelling } = get();
+    if (!streamingConversationId || !isStreaming || isCancelling) return;
 
     set({ isCancelling: true });
     try {
-      await getTransport().invoke('cancel_chat_message', {
-        conversationId: currentConversation.id,
+      const result = await getTransport().invoke<{ cancelled?: boolean }>('cancel_chat_message', {
+        conversationId: streamingConversationId,
       });
-      // The turn keeps streaming until the backend finalizes the partial
-      // answer; completeMessage clears the streaming state from the event.
+      // `cancelled: false` means the server found no turn to signal — the
+      // request beat its own turn's registration, or the turn already
+      // finished. Either way nothing is coming to clear the latch, so the
+      // Stop button must not stay stuck in its pending look.
+      if (result?.cancelled === false) {
+        set((state) =>
+          state.streamingConversationId === streamingConversationId
+            ? { isCancelling: false }
+            : {},
+        );
+      }
+      // Otherwise the turn keeps streaming until the backend finalizes the
+      // partial answer; completeMessage clears the streaming state from the
+      // event.
     } catch (e) {
       // The request never landed — nothing is coming back to clear the UI,
       // so drop the streaming state here.
-      set({ isStreaming: false, isCancelling: false, streamingContent: '', error: String(e) });
+      set((state) => ({ ...releaseStream(state, streamingConversationId), error: String(e) }));
     }
   },
 
   // Streaming updates - deltas arrive one provider chunk at a time
-  appendStreamContent: (delta: string) => {
-    set((state) => ({ streamingContent: state.streamingContent + delta }));
+  appendStreamContent: (conversationId: string, delta: string) => {
+    set((state) =>
+      state.streamingConversationId === conversationId
+        ? { streamingContent: state.streamingContent + delta }
+        : {},
+    );
   },
 
-  startStreamingToolCall: ({ tool_call_id, tool_name, tool_input }) => {
+  startStreamingToolCall: ({ conversation_id, tool_call_id, tool_name, tool_input }) => {
     const now = new Date().toISOString();
-    set((state) => ({
-      streamingToolCalls: [
-        ...state.streamingToolCalls,
-        {
-          id: tool_call_id,
-          message_id: '',
-          tool_name,
-          tool_input,
-          tool_output: null,
-          status: 'running',
-          created_at: now,
-          completed_at: null,
-        },
-      ],
-    }));
+    set((state) =>
+      state.streamingConversationId === conversation_id
+        ? {
+            streamingToolCalls: [
+              ...state.streamingToolCalls,
+              {
+                id: tool_call_id,
+                message_id: '',
+                tool_name,
+                tool_input,
+                tool_output: null,
+                status: 'running' as const,
+                created_at: now,
+                completed_at: null,
+              },
+            ],
+          }
+        : {},
+    );
   },
 
-  completeStreamingToolCall: ({ tool_call_id, results_count, failed }) => {
+  completeStreamingToolCall: ({ conversation_id, tool_call_id, results_count, failed }) => {
     const now = new Date().toISOString();
-    set((state) => ({
-      streamingToolCalls: state.streamingToolCalls.map((call) =>
-        call.id === tool_call_id
-          ? {
-              ...call,
-              status: failed ? ('failed' as const) : ('complete' as const),
-              tool_output: { results_count },
-              completed_at: now,
-            }
-          : call
-      ),
-    }));
+    set((state) =>
+      state.streamingConversationId === conversation_id
+        ? {
+            streamingToolCalls: state.streamingToolCalls.map((call) =>
+              call.id === tool_call_id
+                ? {
+                    ...call,
+                    status: failed ? ('failed' as const) : ('complete' as const),
+                    tool_output: { results_count },
+                    completed_at: now,
+                  }
+                : call,
+            ),
+          }
+        : {},
+    );
   },
 
-  completeMessage: (message: ChatMessageWithContext) => {
+  completeMessage: (conversationId: string, message: ChatMessageWithContext) => {
     set((state) => {
-      // Don't add if message already exists (prevents duplicates from event + refetch)
-      const messageExists = state.messages.some((m) => m.id === message.id);
-      if (messageExists) {
-        return {
-          isStreaming: false,
-          isCancelling: false,
-          streamingContent: '',
-          streamingMessageId: null,
-          streamingToolCalls: [],
-        };
-      }
-      return {
-        messages: [...state.messages, message],
-        isStreaming: false,
-        isCancelling: false,
-        streamingContent: '',
-        streamingMessageId: null,
-        streamingToolCalls: [],
-      };
+      // The turn is over for the conversation it belonged to, wherever the
+      // user happens to be now.
+      const released = releaseStream(state, conversationId);
+      // The message only joins the transcript on screen if that transcript is
+      // the one it belongs to. Skip if it's already there (event + refetch).
+      const belongsHere =
+        state.currentConversation?.id === conversationId &&
+        !state.messages.some((m) => m.id === message.id);
+      return belongsHere ? { ...released, messages: [...state.messages, message] } : released;
     });
   },
 
-  setStreamingError: (error: string) => {
-    set({
-      error,
-      isStreaming: false,
-      isCancelling: false,
-      streamingContent: '',
-    });
+  setStreamingError: (conversationId: string, error: string) => {
+    set((state) => ({ ...releaseStream(state, conversationId), error }));
   },
 
   applyConversationTitle: (id: string, title: string) => {
@@ -656,12 +776,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       listFilterTagId: null,
       showArchived: false,
       pageContextOff: {},
+      savedAtomIdByMessageId: {},
+      savingAnswerMessageIds: {},
       isLoading: false,
-      isStreaming: false,
-      isCancelling: false,
-      streamingContent: '',
-      streamingMessageId: null,
-      streamingToolCalls: [],
+      ...NO_STREAM,
       error: null,
     }),
 }));

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -125,10 +125,27 @@ interface ChatStore {
   // Conversations list
   conversations: ConversationWithTags[];
   listFilterTagId: string | null;
+  /** Archived conversations are hidden until the list asks for them. */
+  showArchived: boolean;
+
+  /**
+   * Conversations where the user dismissed the page-context chip. Client-side
+   * and per-session by design: what the current page is has no meaning to the
+   * server between requests, so persisting the choice would outlive the
+   * context it was made about.
+   */
+  pageContextOff: Record<string, boolean>;
 
   // Streaming state
   isLoading: boolean;
   isStreaming: boolean;
+  /**
+   * A stop has been requested for the current turn. The backend finishes the
+   * turn by persisting the partial answer, so streaming state stays up until
+   * the completion event arrives — this only drives the button's pending look
+   * and keeps repeat clicks from piling up requests.
+   */
+  isCancelling: boolean;
   streamingContent: string;
   streamingMessageId: string | null;
   /**
@@ -150,25 +167,31 @@ interface ChatStore {
 
   // Actions - CRUD
   fetchConversations: (tagId?: string) => Promise<void>;
+  setShowArchived: (show: boolean) => Promise<void>;
   createConversation: (tagIds?: string[]) => Promise<ConversationWithTags>;
   deleteConversation: (id: string) => Promise<void>;
   updateConversationTitle: (id: string, title: string) => Promise<void>;
+  setConversationArchived: (id: string, isArchived: boolean) => Promise<void>;
+
+  // Actions - Page context
+  setPageContextEnabled: (conversationId: string, enabled: boolean) => void;
 
   // Actions - Scope Management
   setScope: (tagIds: string[]) => Promise<void>;
   addTagToScope: (tagId: string) => Promise<void>;
   removeTagFromScope: (tagId: string) => Promise<void>;
 
-  // Actions - Messaging (placeholder for now)
+  // Actions - Messaging
   sendMessage: (content: string) => Promise<void>;
-  cancelResponse: () => void;
+  cancelResponse: () => Promise<void>;
 
   // Actions - Streaming updates (called from event handlers)
   appendStreamContent: (delta: string) => void;
   startStreamingToolCall: (call: { tool_call_id: string; tool_name: string; tool_input: unknown }) => void;
-  completeStreamingToolCall: (update: { tool_call_id: string; results_count: number }) => void;
+  completeStreamingToolCall: (update: { tool_call_id: string; results_count: number; failed: boolean }) => void;
   completeMessage: (message: ChatMessageWithContext) => void;
   setStreamingError: (error: string) => void;
+  applyConversationTitle: (id: string, title: string) => void;
 
   // Actions - Utilities
   clearError: () => void;
@@ -182,8 +205,11 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   messages: [],
   conversations: [],
   listFilterTagId: null,
+  showArchived: false,
+  pageContextOff: {},
   isLoading: false,
   isStreaming: false,
+  isCancelling: false,
   streamingContent: '',
   streamingMessageId: null,
   streamingToolCalls: [],
@@ -288,11 +314,17 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         filterTagId: tagId ?? null,
         limit: 50,
         offset: 0,
+        includeArchived: get().showArchived,
       });
       set({ conversations, isLoading: false, listFilterTagId: tagId ?? null });
     } catch (e) {
       set({ error: String(e), isLoading: false });
     }
+  },
+
+  setShowArchived: async (show: boolean) => {
+    set({ showArchived: show });
+    await get().fetchConversations(get().listFilterTagId ?? undefined);
   },
 
   createConversation: async (tagIds?: string[]) => {
@@ -337,18 +369,36 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   updateConversationTitle: async (id: string, title: string) => {
     try {
       await getTransport().invoke('update_conversation', { id, title, isArchived: null });
+      get().applyConversationTitle(id, title);
+    } catch (e) {
+      set({ error: String(e) });
+    }
+  },
+
+  setConversationArchived: async (id: string, isArchived: boolean) => {
+    try {
+      await getTransport().invoke('update_conversation', { id, title: null, isArchived });
       set((state) => ({
-        conversations: state.conversations.map((c) =>
-          c.id === id ? { ...c, title } : c
-        ),
+        // The list only holds archived conversations while it is showing
+        // them; otherwise archiving removes the card outright.
+        conversations: state.showArchived
+          ? state.conversations.map((c) => (c.id === id ? { ...c, is_archived: isArchived } : c))
+          : state.conversations.filter((c) => c.id !== id),
         currentConversation:
           state.currentConversation?.id === id
-            ? { ...state.currentConversation, title }
+            ? { ...state.currentConversation, is_archived: isArchived }
             : state.currentConversation,
       }));
     } catch (e) {
       set({ error: String(e) });
     }
+  },
+
+  // Page context
+  setPageContextEnabled: (conversationId: string, enabled: boolean) => {
+    set((state) => ({
+      pageContextOff: { ...state.pageContextOff, [conversationId]: !enabled },
+    }));
   },
 
   // Scope Management
@@ -420,6 +470,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set({
       messages: [...messages, userMessage],
       isStreaming: true,
+      isCancelling: false,
       streamingContent: '',
       streamingToolCalls: [],
       error: null,
@@ -440,11 +491,15 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         }
       }
 
+      // Dismissing the context chip is a promise that nothing about the
+      // current page leaves with the message.
+      const sharesPageContext = !get().pageContextOff[currentConversation.id];
+
       await getTransport().invoke<ChatMessageWithContext>('send_chat_message', {
         conversationId: currentConversation.id,
         content,
         canvasContext,
-        pageContext: buildPageContext(),
+        pageContext: sharesPageContext ? buildPageContext() : undefined,
       });
 
       // Refetch the conversation to get the properly saved messages
@@ -456,19 +511,33 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         messages: state.messages.filter((m) => !m.id.startsWith('temp-')),
         error: String(e),
         isStreaming: false,
+        isCancelling: false,
         streamingContent: '',
       }));
     }
   },
 
-  cancelResponse: () => {
-    // TODO: Implement cancellation
-    set({ isStreaming: false, streamingContent: '' });
+  cancelResponse: async () => {
+    const { currentConversation, isStreaming, isCancelling } = get();
+    if (!currentConversation || !isStreaming || isCancelling) return;
+
+    set({ isCancelling: true });
+    try {
+      await getTransport().invoke('cancel_chat_message', {
+        conversationId: currentConversation.id,
+      });
+      // The turn keeps streaming until the backend finalizes the partial
+      // answer; completeMessage clears the streaming state from the event.
+    } catch (e) {
+      // The request never landed — nothing is coming back to clear the UI,
+      // so drop the streaming state here.
+      set({ isStreaming: false, isCancelling: false, streamingContent: '', error: String(e) });
+    }
   },
 
-  // Streaming updates - receives full accumulated content from backend
-  appendStreamContent: (content: string) => {
-    set({ streamingContent: content });
+  // Streaming updates - deltas arrive one provider chunk at a time
+  appendStreamContent: (delta: string) => {
+    set((state) => ({ streamingContent: state.streamingContent + delta }));
   },
 
   startStreamingToolCall: ({ tool_call_id, tool_name, tool_input }) => {
@@ -490,14 +559,14 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }));
   },
 
-  completeStreamingToolCall: ({ tool_call_id, results_count }) => {
+  completeStreamingToolCall: ({ tool_call_id, results_count, failed }) => {
     const now = new Date().toISOString();
     set((state) => ({
       streamingToolCalls: state.streamingToolCalls.map((call) =>
         call.id === tool_call_id
           ? {
               ...call,
-              status: 'complete' as const,
+              status: failed ? ('failed' as const) : ('complete' as const),
               tool_output: { results_count },
               completed_at: now,
             }
@@ -513,6 +582,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       if (messageExists) {
         return {
           isStreaming: false,
+          isCancelling: false,
           streamingContent: '',
           streamingMessageId: null,
           streamingToolCalls: [],
@@ -521,6 +591,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       return {
         messages: [...state.messages, message],
         isStreaming: false,
+        isCancelling: false,
         streamingContent: '',
         streamingMessageId: null,
         streamingToolCalls: [],
@@ -532,8 +603,19 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set({
       error,
       isStreaming: false,
+      isCancelling: false,
       streamingContent: '',
     });
+  },
+
+  applyConversationTitle: (id: string, title: string) => {
+    set((state) => ({
+      conversations: state.conversations.map((c) => (c.id === id ? { ...c, title } : c)),
+      currentConversation:
+        state.currentConversation?.id === id
+          ? { ...state.currentConversation, title }
+          : state.currentConversation,
+    }));
   },
 
   // Utilities
@@ -546,8 +628,11 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       messages: [],
       conversations: [],
       listFilterTagId: null,
+      showArchived: false,
+      pageContextOff: {},
       isLoading: false,
       isStreaming: false,
+      isCancelling: false,
       streamingContent: '',
       streamingMessageId: null,
       streamingToolCalls: [],

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -105,6 +105,9 @@ interface UIStore {
   leftPanelOpen: boolean;
   // Chat sidebar state
   chatSidebarOpen: boolean;
+  /// Desktop only: the chat pane takes the whole main view. Independent of
+  /// `chatSidebarWidth`, which keeps the width to restore on minimize.
+  chatSidebarExpanded: boolean;
   chatSidebarWidth: number;
   chatSidebarConversationId: string | null;
   chatSidebarInitialTagId: string | null;
@@ -171,6 +174,8 @@ interface UIStore {
   // Chat sidebar actions
   toggleChatSidebar: () => void;
   setChatSidebarOpen: (open: boolean) => void;
+  setChatSidebarExpanded: (expanded: boolean) => void;
+  toggleChatSidebarExpanded: () => void;
   setChatSidebarWidth: (width: number) => void;
   setChatSidebarConversationId: (id: string | null) => void;
   openChatSidebar: (tagId?: string, conversationId?: string) => void;
@@ -197,6 +202,15 @@ interface UIStore {
   setReaderTheme: (theme: 'light' | 'dark') => void;
   toggleReaderTheme: () => void;
 }
+
+/// Fullscreen chat is a mode, not a destination: whenever the user navigates
+/// the main view they mean to look at it, so every navigating action folds
+/// this into its `set` rather than each call site remembering to.
+///
+/// Exported because the store's actions aren't the only way the main view
+/// changes — browser Back/Forward reconciles the store from the URL in
+/// `RouterBridge`, which has to make the same promise.
+export const LEAVE_FULLSCREEN_CHAT = { chatSidebarExpanded: false } as const;
 
 /// Generate a tab id. Falls back to a monotonic counter for environments
 /// without crypto.randomUUID (older mobile webviews).
@@ -342,6 +356,7 @@ export const useUIStore = create<UIStore>()(
       highlightedAtomId: null,
       leftPanelOpen: true,
       chatSidebarOpen: false,
+      chatSidebarExpanded: false,
       chatSidebarWidth: 480,
       chatSidebarConversationId: null,
       chatSidebarInitialTagId: null,
@@ -358,7 +373,7 @@ export const useUIStore = create<UIStore>()(
       setServerConnected: (connected: boolean) => set({ serverConnected: connected }),
 
       setSelectedTag: (tagId: string | null) => {
-        set({ selectedTagId: tagId });
+        set({ selectedTagId: tagId, ...LEAVE_FULLSCREEN_CHAT });
         const state = get();
         const activeTab = state.activeTabId ? state.tabs.find((t) => t.id === state.activeTabId) : null;
         const activeEntry = activeTab?.stack[activeTab.stackIndex] ?? null;
@@ -413,6 +428,7 @@ export const useUIStore = create<UIStore>()(
               tabs: [...s.tabs, tab],
               activeTabId: id,
               nextTabOrdinal: s.nextTabOrdinal + 1,
+              ...LEAVE_FULLSCREEN_CHAT,
               ...projected,
               localGraph: { ...s.localGraph, ...projected.localGraphPatch },
             };
@@ -433,6 +449,7 @@ export const useUIStore = create<UIStore>()(
             const projected = projectActiveEntry(entry);
             return {
               tabs,
+              ...LEAVE_FULLSCREEN_CHAT,
               ...projected,
               localGraph: { ...s.localGraph, ...projected.localGraphPatch },
             };
@@ -480,6 +497,7 @@ export const useUIStore = create<UIStore>()(
             return {
               tabs,
               activeTabId: existingId,
+              ...LEAVE_FULLSCREEN_CHAT,
               ...projected,
               localGraph: { ...s.localGraph, ...projected.localGraphPatch },
             };
@@ -497,6 +515,7 @@ export const useUIStore = create<UIStore>()(
             tabs: [...s.tabs, tab],
             activeTabId: id,
             nextTabOrdinal: s.nextTabOrdinal + 1,
+            ...LEAVE_FULLSCREEN_CHAT,
             ...projected,
             localGraph: { ...s.localGraph, ...projected.localGraphPatch },
           };
@@ -514,6 +533,7 @@ export const useUIStore = create<UIStore>()(
         const projected = projectActiveEntry(entry);
         set((s) => ({
           activeTabId: tabId,
+          ...LEAVE_FULLSCREEN_CHAT,
           ...projected,
           localGraph: { ...s.localGraph, ...projected.localGraphPatch },
         }));
@@ -580,6 +600,7 @@ export const useUIStore = create<UIStore>()(
         const projected = projectActiveEntry(entry);
         set((s) => ({
           tabs: s.tabs.map((t) => (t.id === tab.id ? { ...t, stackIndex: newIndex } : t)),
+          ...LEAVE_FULLSCREEN_CHAT,
           ...projected,
           localGraph: { ...s.localGraph, ...projected.localGraphPatch },
         }));
@@ -596,6 +617,7 @@ export const useUIStore = create<UIStore>()(
         const projected = projectActiveEntry(entry);
         set((s) => ({
           tabs: s.tabs.map((t) => (t.id === tab.id ? { ...t, stackIndex: newIndex } : t)),
+          ...LEAVE_FULLSCREEN_CHAT,
           ...projected,
           localGraph: { ...s.localGraph, ...projected.localGraphPatch },
         }));
@@ -847,8 +869,19 @@ export const useUIStore = create<UIStore>()(
 
       // -- Chat sidebar --------------------------------------------------
 
-      toggleChatSidebar: () => set((state) => ({ chatSidebarOpen: !state.chatSidebarOpen })),
-      setChatSidebarOpen: (open: boolean) => set({ chatSidebarOpen: open }),
+      // Closing the pane also leaves fullscreen: reopening it should give the
+      // user the sidebar they closed, not an unexpected takeover.
+      toggleChatSidebar: () =>
+        set((state) =>
+          state.chatSidebarOpen
+            ? { chatSidebarOpen: false, ...LEAVE_FULLSCREEN_CHAT }
+            : { chatSidebarOpen: true },
+        ),
+      setChatSidebarOpen: (open: boolean) =>
+        set(open ? { chatSidebarOpen: true } : { chatSidebarOpen: false, ...LEAVE_FULLSCREEN_CHAT }),
+      setChatSidebarExpanded: (expanded: boolean) => set({ chatSidebarExpanded: expanded }),
+      toggleChatSidebarExpanded: () =>
+        set((state) => ({ chatSidebarExpanded: !state.chatSidebarExpanded })),
       setChatSidebarWidth: (width: number) => set({ chatSidebarWidth: Math.min(Math.max(width, 320), 800) }),
       setChatSidebarConversationId: (id: string | null) => set({ chatSidebarConversationId: id }),
       openChatSidebar: (tagId?: string, conversationId?: string) =>
@@ -869,6 +902,7 @@ export const useUIStore = create<UIStore>()(
         const projected = wasInTab ? projectActiveEntry(null) : null;
         set((s) => ({
           viewMode: mode,
+          ...LEAVE_FULLSCREEN_CHAT,
           ...(wasInTab
             ? {
                 activeTabId: null,
@@ -1015,6 +1049,7 @@ export const useUIStore = create<UIStore>()(
         atomsLayout: state.atomsLayout,
         readerTheme: state.readerTheme,
         chatSidebarOpen: state.chatSidebarOpen,
+        chatSidebarExpanded: state.chatSidebarExpanded,
         chatSidebarWidth: state.chatSidebarWidth,
         chatSidebarConversationId: state.chatSidebarConversationId,
         leftPanelOpen: state.leftPanelOpen,


### PR DESCRIPTION
The chat era's first three phases in two commits: make the existing chat honest and alive (Phase 0), cover the table stakes (Phase 1), then rebuild agent capability on a unified runtime (Phase 2). Loop unification happened here deliberately so future tools (web search, etc.) land once, not twice.

## Commit 1 — Phases 0+1: foundations and table stakes

- **True token streaming** — `StreamDelta` per provider chunk; answers render token-by-token.
- **Working stop/cancel** — per-`(scope, conversation)` registry, `POST .../messages/cancel`, checked between iterations/tools and mid-stream (`tokio::select!` drops the in-flight provider stream). Partial answers persist with `*(stopped)*`.
- **Errors reach the UI**; tool failures record `status: "failed"` and show red mid-stream.
- **Postgres scope bug** — scoped search honored only the first tag; fixed at the `SearchStore` trait boundary.
- **Iteration-cap salvage** — the accumulated answer survives the tool-call cap instead of being discarded.
- **Auto-titled conversations** — tagging model, fire-and-forget, live-updating, never overwrites a manual rename.
- **Visible context** — "Sharing: …" chip with a toggle; New Conversation pre-scopes to the selected tag.
- **Archive UI, rename from list, send button**, model-default drift fixed.

## Commit 2 — Phase 2: agent capability

- **Unified agent runtime** (`crates/atomic-core/src/agent_runtime/`) — one loop for chat and reports: `AgentTool` registry, streaming/cancel/salvage, and the reports `Citable` citation machinery generalized (numbered ledger, `[N]`-marker extraction, admission policies). `agent.rs` 1859→670 lines; the reports loop is deleted, its behavior locked by tests written against the old code and passing unchanged after.
- **Knowledge-base tools** — chat can now see the tag tree (`list_tags`), read wiki articles (`get_wiki`), and read report findings (`list_reports`/`get_finding`), with wiki/finding reads registering first-class citables.
- **Real citations** — Sources are cited-only (markers decide, not tool access); `chat_citations.source_type` (`atom`|`wiki`|`finding`); clicking deep-links to the stored excerpt via the existing reveal mechanics. Also fixes a live PG citation-numbering bug (`citation_index` now persisted there).
- **Boolean scope (closes #156)** — scope tags carry include (OR) / require (AND) / exclude (NOT), enforced in retrieval with descendant expansion on both backends; ScopeEditor chips cycle modes. Existing scopes are unchanged (include-only).
- **Docs** — chat manual gains Tools/Citations/rewritten Scope sections; WS events reference updated.

## Migrations

SQLite V23 (`chat_citations` rebuild with `source_type`; drops the atoms FK deliberately — non-atom sources) + V24 (`conversation_tags.mode`). Postgres `024` + `025`.

## Behavior changes to note

- Sources lists are now bibliographies (cited-only), not access logs.
- The legacy SQLite search path now expands scope tags to descendants, matching Postgres and the documented intent (the backends previously disagreed silently).
- Hallucinated tool names get an `Error:` prefix in the tool result (runtime-owned path).

## Testing

Chat agent wiremock suite 7→15; new report agent suite (4, written pre-migration as a behavior lock); runtime units; storage-level scope predicate tests. **838 passing** across `atomic-core` + `atomic-server`; vitest 55; `tsc` clean; `--features postgres` compile-checked.

**Before merge:** run the `ATOMIC_TEST_DATABASE_URL`-gated Postgres suites — the two new PG migrations and the recursive-CTE scope query are compile-checked only in local runs. Manual pass checklist: scoped conversation with require/exclude chips, wiki citation deep-link, `list_tags`-informed answer, stop mid-answer, auto-title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)