### PR TITLE
fix: two provider failures that arrive looking like successes

### DIFF
--- a/crates/atomic-bench/src/mock_ai.rs
+++ b/crates/atomic-bench/src/mock_ai.rs
@@ -136,11 +136,21 @@ impl Respond for ChatResponder {
             Err(_) => return ResponseTemplate::new(400),
         };
 
+        let request_text = body.to_string().to_lowercase();
+        // Generative callers keep the schema off the wire (see
+        // `GENERATIVE_CALL_ENFORCEMENT`) and state it in the prompt instead, so
+        // fall back to sniffing it — otherwise extraction silently benchmarks
+        // an empty `{}` response.
         let schema_name = body
             .pointer("/response_format/json_schema/name")
             .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let request_text = body.to_string().to_lowercase();
+            .unwrap_or_else(|| {
+                if request_text.contains("parent_name") {
+                    "extraction_result"
+                } else {
+                    ""
+                }
+            });
 
         let content = match schema_name {
             "extraction_result" => json!({

--- a/crates/atomic-core/src/compaction.rs
+++ b/crates/atomic-core/src/compaction.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles LLM-assisted tag merging and categorization.
 
-use crate::providers::structured::{call_structured, StructuredCall};
+use crate::providers::structured::{call_structured, StructuredCall, GENERATIVE_CALL_ENFORCEMENT};
 use crate::providers::types::{GenerationParams, Message};
 use crate::providers::ProviderConfig;
 use rusqlite::Connection;
@@ -202,6 +202,9 @@ async fn get_merge_suggestions(
         merge_schema(),
     )
     .with_params(params)
+    // `{"merges": []}` is a legal answer, so a constrained decoder can return
+    // it and compaction silently does nothing.
+    .with_schema_enforcement(GENERATIVE_CALL_ENFORCEMENT)
     .with_max_retries(3);
 
     match call_structured::<MergeResult>(call).await {

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -4,7 +4,7 @@
 
 use crate::providers::structured::{call_structured, SchemaEnforcement, StructuredCall};
 use crate::providers::types::{GenerationParams, Message};
-use crate::providers::{ProviderConfig, ProviderType};
+use crate::providers::ProviderConfig;
 use rusqlite::Connection;
 use serde::Deserialize;
 use std::sync::{LazyLock, Mutex};
@@ -247,46 +247,30 @@ pub(crate) fn consolidation_schema() -> serde_json::Value {
     })
 }
 
-/// How the tagging schema reaches the model — a property of the **provider**,
-/// not of the task alone.
+/// How the tagging schema reaches the model.
 ///
 /// Tag extraction is *generative*: the model decides how many tags to emit, so
 /// a decoder that shortens the output silently changes the answer rather than
-/// just its shape. Measured 2026-08-09, same content and task:
+/// just its shape. Wire-level `response_format` does exactly that on
+/// OpenRouter — measured 2026-08-09 on `google/gemma-4-26b-a4b-it` pinned to
+/// DeepInfra, it returned `{"tags": []}` on 3 calls of 6, with counts swinging
+/// 5–13 on identical input. That failure is **silent**: an empty-but-valid
+/// result parses, so no fallback fires, and the atom is recorded tagged with
+/// nothing. Schema in the prompt returned 4–8 tags on 8 of 8.
 ///
-/// **OpenRouter** (`gemma-4-26b-a4b-it` pinned to DeepInfra) — schema on the
-/// wire returned `{"tags": []}` on 3 calls of 6, and tag counts swung 5–13 on
-/// identical input. Schema in the prompt: 4–8 tags, 8 of 8. This is the failure
-/// that matters, because it is **silent**: an empty-but-valid result parses, so
-/// no fallback fires, and the atom is recorded tagged with nothing.
+/// This started out provider-dependent, on a measurement that said prompt mode
+/// emptied half of `llama3.2`'s extractions. That was wrong twice over: the
+/// model was echoing the *schema* back rather than returning nothing, and it
+/// was doing so because the instruction handed it a JSON Schema document and
+/// asked it to "match this schema" — genuinely ambiguous input for a 3B model.
+/// Once [`crate::providers::structured`] began leading with a concrete example
+/// of the shape, `llama3.2` produced valid output on 8 of 8 first attempts, and
+/// the provider distinction had nothing left to stand on.
 ///
-/// **Ollama** (`llama3.2`, 3B, local) — both transports end up at the same 2
-/// tags. Prompt mode does provoke a recognizable small-model failure roughly
-/// half the time (the model echoes the *schema* back, nesting the data under
-/// `properties`), but that shape deserializes as neither variant of
-/// `ExtractionResult`, so it fails **loudly**: `parse_tolerant` rejects it, the
-/// prompt-based fallback re-asks, and the retry succeeds — 6 of 6 through the
-/// real pipeline. The llama.cpp grammar is not rescuing accuracy here; it is
-/// saving the round-trip.
-///
-/// So the split is not "one transport works and the other doesn't". Both work
-/// on Ollama, and only one works on OpenRouter:
-///
-/// - **OpenRouter → prompt-only.** The constrained-decoding implementation
-///   belongs to whichever endpoint routing picked; we cannot see it, test it,
-///   or be told when it changes. Its failure mode is silent, and no retry
-///   budget helps with an answer that looks correct.
-/// - **Ollama → wire-level.** One local implementation we can characterize, and
-///   it avoids a fallback round-trip on about half of calls at no measured cost
-///   to quality. Prompt-only would also be correct here, just slower.
-/// - **OpenAI-compatible → wire-level**, unmeasured: keep the status quo rather
-///   than guess.
-fn tagging_schema_enforcement(provider: &ProviderType) -> SchemaEnforcement {
-    match provider {
-        ProviderType::OpenRouter => SchemaEnforcement::PromptOnly,
-        ProviderType::Ollama | ProviderType::OpenAICompat => SchemaEnforcement::Strict,
-    }
-}
+/// So: one transport everywhere. It is required on OpenRouter, free on Ollama,
+/// and its failure mode — a reply the tolerant parser rejects, which re-asks
+/// and retries — is the one we can actually see.
+const TAGGING_SCHEMA_ENFORCEMENT: SchemaEnforcement = SchemaEnforcement::PromptOnly;
 
 /// Output ceiling for tag extraction.
 ///
@@ -383,7 +367,7 @@ pub async fn extract_tags_from_content(
         extraction_schema(),
     )
     .with_params(extraction_params(supported_params))
-    .with_schema_enforcement(tagging_schema_enforcement(&provider_config.provider_type))
+    .with_schema_enforcement(TAGGING_SCHEMA_ENFORCEMENT)
     .with_max_retries(3);
 
     match call_structured::<ExtractionResult>(call).await {
@@ -421,7 +405,7 @@ pub async fn extract_tags_from_chunk(
         extraction_schema(),
     )
     .with_params(extraction_params(supported_params))
-    .with_schema_enforcement(tagging_schema_enforcement(&provider_config.provider_type))
+    .with_schema_enforcement(TAGGING_SCHEMA_ENFORCEMENT)
     .with_max_retries(3);
 
     match call_structured::<ExtractionResult>(call).await {
@@ -770,29 +754,17 @@ mod tests {
         (db, temp_file)
     }
 
-    /// The transport choice is provider-dependent, so pin it. Only the
-    /// OpenRouter arm is load-bearing for correctness — the others are a
-    /// round-trip optimisation and an untouched default, and a future refactor
-    /// that collapses all three into one constant would take the silent
-    /// failure back on.
+    /// Tagging must not put the schema on the wire, on any provider.
+    ///
+    /// The value is what stops the silent failure: a constrained decoder that
+    /// returns `{"tags": []}` produces a result that parses, fires no fallback,
+    /// and marks the atom tagged with nothing. The prompt-level contract fails
+    /// visibly instead, into a parser that re-asks. Reintroducing a
+    /// provider-specific exception here needs a measurement, not an intuition —
+    /// the last one cost three reversals.
     #[test]
-    fn tagging_transport_follows_the_provider() {
-        assert_eq!(
-            tagging_schema_enforcement(&ProviderType::OpenRouter),
-            SchemaEnforcement::PromptOnly,
-            "heterogeneous gateway: the decoder is unknowable and fails silently"
-        );
-        assert_eq!(
-            tagging_schema_enforcement(&ProviderType::Ollama),
-            SchemaEnforcement::Strict,
-            "prompt-only is also correct here; the grammar just avoids a \
-             fallback round-trip on ~half of calls"
-        );
-        assert_eq!(
-            tagging_schema_enforcement(&ProviderType::OpenAICompat),
-            SchemaEnforcement::Strict,
-            "unmeasured: keep the status quo rather than guessing"
-        );
+    fn tagging_never_puts_the_schema_on_the_wire() {
+        assert_eq!(TAGGING_SCHEMA_ENFORCEMENT, SchemaEnforcement::PromptOnly);
     }
 
     // ==================== Schema lint regression tests ====================

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -251,9 +251,23 @@ pub(crate) fn consolidation_schema() -> serde_json::Value {
 /// (tag-picking is nearly deterministic), reasoning minimized, optional
 /// `supported_params` threaded through so we don't send fields the router's
 /// downstream provider doesn't accept.
+/// Output ceiling for tag extraction.
+///
+/// A tag list is a few hundred tokens, but reasoning models spend completion
+/// tokens thinking before emitting the JSON — a field failure was observed at
+/// 3091 completion tokens for 300 characters of tags — so the cap has to clear
+/// that comfortably. It is deliberately far below
+/// [`DEFAULT_MAX_OUTPUT_TOKENS`]: OpenRouter routes only to endpoints whose
+/// `max_completion_tokens` covers the request, and 32k prunes real endpoints
+/// from the pool (`google/gemma-4-26b-a4b-it` on DeepInfra caps at 16384 and
+/// drops out entirely, taking the request to a 404 when pinned). 8192 keeps
+/// the pool intact with ~2.6x headroom over the worst generation seen.
+const TAGGING_MAX_OUTPUT_TOKENS: u32 = 8192;
+
 fn extraction_params(supported_params: Option<Vec<String>>) -> GenerationParams {
     let mut params = GenerationParams::new()
         .with_temperature(0.1)
+        .with_max_tokens(TAGGING_MAX_OUTPUT_TOKENS)
         .with_minimize_reasoning(true);
     if let Some(supported) = supported_params {
         params = params.with_supported_parameters(supported);

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -252,26 +252,35 @@ pub(crate) fn consolidation_schema() -> serde_json::Value {
 ///
 /// Tag extraction is *generative*: the model decides how many tags to emit, so
 /// a decoder that shortens the output silently changes the answer rather than
-/// just its shape. Whether that risk outweighs the schema guarantee depends
-/// entirely on whose decoder is in the path, and the two deployments we support
-/// sit at opposite ends. Measured 2026-08-09, same content, same task:
+/// just its shape. Measured 2026-08-09, same content and task:
 ///
-/// | provider | schema on the wire | schema in the prompt |
-/// |---|---|---|
-/// | OpenRouter (`gemma-4-26b-a4b-it` → DeepInfra) | `{"tags": []}` on ~1 call in 3; counts swing 5–13 | 7–8 tags, 8 of 8 |
-/// | Ollama (`llama3.2`, 3B, local) | 2 tags, 6 of 6 | **empty on 3 of 6** |
+/// **OpenRouter** (`gemma-4-26b-a4b-it` pinned to DeepInfra) — schema on the
+/// wire returned `{"tags": []}` on 3 calls of 6, and tag counts swung 5–13 on
+/// identical input. Schema in the prompt: 4–8 tags, 8 of 8. This is the failure
+/// that matters, because it is **silent**: an empty-but-valid result parses, so
+/// no fallback fires, and the atom is recorded tagged with nothing.
 ///
-/// The inversion is the point. OpenRouter is a *heterogeneous gateway*: the
-/// constrained-decoding implementation belongs to whichever endpoint we happen
-/// to route to, we cannot see or test it, and it changes without notice — so
-/// the schema guarantee is really a dependency on the worst decoder in the
-/// pool. Ollama is one local implementation (llama.cpp grammars) paired with
-/// models small enough that instruction-following is the weaker link; there the
-/// grammar is doing real work and removing it costs half the extractions.
+/// **Ollama** (`llama3.2`, 3B, local) — both transports end up at the same 2
+/// tags. Prompt mode does provoke a recognizable small-model failure roughly
+/// half the time (the model echoes the *schema* back, nesting the data under
+/// `properties`), but that shape deserializes as neither variant of
+/// `ExtractionResult`, so it fails **loudly**: `parse_tolerant` rejects it, the
+/// prompt-based fallback re-asks, and the retry succeeds — 6 of 6 through the
+/// real pipeline. The llama.cpp grammar is not rescuing accuracy here; it is
+/// saving the round-trip.
 ///
-/// So: prompt-only where the decoder is unknowable, wire-level where it is
-/// known and the model needs the help. OpenAI-compatible servers keep the
-/// wire-level default because they are unmeasured, and that is the status quo.
+/// So the split is not "one transport works and the other doesn't". Both work
+/// on Ollama, and only one works on OpenRouter:
+///
+/// - **OpenRouter → prompt-only.** The constrained-decoding implementation
+///   belongs to whichever endpoint routing picked; we cannot see it, test it,
+///   or be told when it changes. Its failure mode is silent, and no retry
+///   budget helps with an answer that looks correct.
+/// - **Ollama → wire-level.** One local implementation we can characterize, and
+///   it avoids a fallback round-trip on about half of calls at no measured cost
+///   to quality. Prompt-only would also be correct here, just slower.
+/// - **OpenAI-compatible → wire-level**, unmeasured: keep the status quo rather
+///   than guess.
 fn tagging_schema_enforcement(provider: &ProviderType) -> SchemaEnforcement {
     match provider {
         ProviderType::OpenRouter => SchemaEnforcement::PromptOnly,
@@ -761,24 +770,23 @@ mod tests {
         (db, temp_file)
     }
 
-    /// The transport choice is provider-dependent, and the dependence runs in
-    /// *opposite* directions — that is the whole finding, so pin it. Dropping
-    /// the schema costs nothing behind a gateway whose decoder we can't see,
-    /// and costs half the extractions on a 3B local model leaning on the
-    /// grammar. A future refactor that collapses this to one constant would
-    /// silently regress one deployment or the other.
+    /// The transport choice is provider-dependent, so pin it. Only the
+    /// OpenRouter arm is load-bearing for correctness — the others are a
+    /// round-trip optimisation and an untouched default, and a future refactor
+    /// that collapses all three into one constant would take the silent
+    /// failure back on.
     #[test]
     fn tagging_transport_follows_the_provider() {
         assert_eq!(
             tagging_schema_enforcement(&ProviderType::OpenRouter),
             SchemaEnforcement::PromptOnly,
-            "heterogeneous gateway: the decoder is unknowable, so don't depend on it"
+            "heterogeneous gateway: the decoder is unknowable and fails silently"
         );
         assert_eq!(
             tagging_schema_enforcement(&ProviderType::Ollama),
             SchemaEnforcement::Strict,
-            "local llama.cpp grammar carries small models; removing it emptied \
-             3 of 6 extractions on llama3.2"
+            "prompt-only is also correct here; the grammar just avoids a \
+             fallback round-trip on ~half of calls"
         );
         assert_eq!(
             tagging_schema_enforcement(&ProviderType::OpenAICompat),

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles automatic tag extraction from atom content.
 
-use crate::providers::structured::{call_structured, StructuredCall};
+use crate::providers::structured::{call_structured, SchemaEnforcement, StructuredCall};
 use crate::providers::types::{GenerationParams, Message};
 use crate::providers::ProviderConfig;
 use rusqlite::Connection;
@@ -251,6 +251,30 @@ pub(crate) fn consolidation_schema() -> serde_json::Value {
 /// (tag-picking is nearly deterministic), reasoning minimized, optional
 /// `supported_params` threaded through so we don't send fields the router's
 /// downstream provider doesn't accept.
+/// How the tagging schema reaches the model.
+///
+/// Tag extraction is *generative*: the model decides how many tags to emit, so
+/// a decoder that shortens the output silently changes the answer rather than
+/// just its shape. Wire-level `response_format` does exactly that on some
+/// OpenRouter endpoints — measured 2026-08-09 on `google/gemma-4-26b-a4b-it`,
+/// DeepInfra's schema-enforced endpoint returned `{"tags": []}` (8 completion
+/// tokens, `finish_reason: stop`, no error signal) on ~1 call in 3, and
+/// schema-mode tag counts swung 5–13 on identical input. The same content sent
+/// with the schema in the prompt returned 7–8 tags on 8 of 8 calls.
+///
+/// The trade is a decoding guarantee for a tolerant parser, and the parser was
+/// measured never to be exercised: across `openai/gpt-5-nano`,
+/// `google/gemma-4-26b-a4b-it`, `openai/gpt-5-mini` and `z-ai/glm-5.2`, all 24
+/// prompt-mode replies parsed directly — no fences, no surrounding prose.
+/// Prompt mode also matched or beat schema mode on tag count for three of the
+/// four models, and was consistently less erratic.
+///
+/// An empty-but-valid extraction is the failure this avoids: it parses, so the
+/// prompt-based fallback in `call_structured` never fires, and it reaches the
+/// pipeline looking like a real answer — the atom is then recorded as tagged
+/// with nothing.
+const TAGGING_SCHEMA_ENFORCEMENT: SchemaEnforcement = SchemaEnforcement::PromptOnly;
+
 /// Output ceiling for tag extraction.
 ///
 /// A tag list is a few hundred tokens, but reasoning models spend completion
@@ -342,6 +366,7 @@ pub async fn extract_tags_from_content(
         extraction_schema(),
     )
     .with_params(extraction_params(supported_params))
+    .with_schema_enforcement(TAGGING_SCHEMA_ENFORCEMENT)
     .with_max_retries(3);
 
     match call_structured::<ExtractionResult>(call).await {
@@ -379,6 +404,7 @@ pub async fn extract_tags_from_chunk(
         extraction_schema(),
     )
     .with_params(extraction_params(supported_params))
+    .with_schema_enforcement(TAGGING_SCHEMA_ENFORCEMENT)
     .with_max_retries(3);
 
     match call_structured::<ExtractionResult>(call).await {
@@ -699,6 +725,9 @@ pub async fn consolidate_atom_tags(
         "consolidation_result",
         consolidation_schema(),
     )
+    // Left on the default (constrained decoding) deliberately: the empty-list
+    // degradation was measured for tag *extraction*, not for consolidation,
+    // whose prompt and output shape differ. Worth measuring before moving it.
     .with_params(extraction_params(supported_params))
     .with_max_retries(3);
 

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -2,7 +2,9 @@
 //!
 //! This module handles automatic tag extraction from atom content.
 
-use crate::providers::structured::{call_structured, SchemaEnforcement, StructuredCall};
+use crate::providers::structured::{
+    call_structured, SchemaEnforcement, StructuredCall, GENERATIVE_CALL_ENFORCEMENT,
+};
 use crate::providers::types::{GenerationParams, Message};
 use crate::providers::ProviderConfig;
 use rusqlite::Connection;
@@ -247,42 +249,16 @@ pub(crate) fn consolidation_schema() -> serde_json::Value {
     })
 }
 
-/// How the tagging schema reaches the model.
-///
-/// Tag extraction is *generative*: the model decides how many tags to emit, so
-/// a decoder that shortens the output silently changes the answer rather than
-/// just its shape. Wire-level `response_format` does exactly that on
-/// OpenRouter — measured 2026-08-09 on `google/gemma-4-26b-a4b-it` pinned to
-/// DeepInfra, it returned `{"tags": []}` on 3 calls of 6, with counts swinging
-/// 5–13 on identical input. That failure is **silent**: an empty-but-valid
-/// result parses, so no fallback fires, and the atom is recorded tagged with
-/// nothing. Schema in the prompt returned 4–8 tags on 8 of 8.
-///
-/// This started out provider-dependent, on a measurement that said prompt mode
-/// emptied half of `llama3.2`'s extractions. That was wrong twice over: the
-/// model was echoing the *schema* back rather than returning nothing, and it
-/// was doing so because the instruction handed it a JSON Schema document and
-/// asked it to "match this schema" — genuinely ambiguous input for a 3B model.
-/// Once [`crate::providers::structured`] began leading with a concrete example
-/// of the shape, `llama3.2` produced valid output on 8 of 8 first attempts, and
-/// the provider distinction had nothing left to stand on.
-///
-/// So: one transport everywhere. It is required on OpenRouter, free on Ollama,
-/// and its failure mode — a reply the tolerant parser rejects, which re-asks
-/// and retries — is the one we can actually see.
-const TAGGING_SCHEMA_ENFORCEMENT: SchemaEnforcement = SchemaEnforcement::PromptOnly;
+/// Extraction and consolidation are generative — see
+/// [`GENERATIVE_CALL_ENFORCEMENT`]. Applies to every provider: an earlier
+/// Ollama-specific exception turned out to rest on a measurement error.
+const TAGGING_SCHEMA_ENFORCEMENT: SchemaEnforcement = GENERATIVE_CALL_ENFORCEMENT;
 
-/// Output ceiling for tag extraction.
-///
-/// A tag list is a few hundred tokens, but reasoning models spend completion
-/// tokens thinking before emitting the JSON — a field failure was observed at
-/// 3091 completion tokens for 300 characters of tags — so the cap has to clear
-/// that comfortably. It is deliberately far below
-/// [`DEFAULT_MAX_OUTPUT_TOKENS`]: OpenRouter routes only to endpoints whose
-/// `max_completion_tokens` covers the request, and 32k prunes real endpoints
-/// from the pool (`google/gemma-4-26b-a4b-it` on DeepInfra caps at 16384 and
-/// drops out entirely, taking the request to a 404 when pinned). 8192 keeps
-/// the pool intact with ~2.6x headroom over the worst generation seen.
+/// Output ceiling for tag extraction. Deliberately well below the 32k default:
+/// OpenRouter only routes to endpoints whose `max_completion_tokens` covers the
+/// request, and 32k prunes real ones from the pool. 8192 keeps the pool intact
+/// with ~2.6x headroom over the largest generation observed (3091 tokens, most
+/// of it a reasoning model thinking before it answers).
 const TAGGING_MAX_OUTPUT_TOKENS: u32 = 8192;
 
 /// Build the shared generation params for extraction calls. Temperature 0.1
@@ -726,10 +702,8 @@ pub async fn consolidate_atom_tags(
         "consolidation_result",
         consolidation_schema(),
     )
-    // Left on the default (constrained decoding) deliberately: the empty-list
-    // degradation was measured for tag *extraction*, not for consolidation,
-    // whose prompt and output shape differ. Worth measuring before moving it.
     .with_params(extraction_params(supported_params))
+    .with_schema_enforcement(TAGGING_SCHEMA_ENFORCEMENT)
     .with_max_retries(3);
 
     match call_structured::<TagConsolidationResult>(call).await {

--- a/crates/atomic-core/src/extraction.rs
+++ b/crates/atomic-core/src/extraction.rs
@@ -4,7 +4,7 @@
 
 use crate::providers::structured::{call_structured, SchemaEnforcement, StructuredCall};
 use crate::providers::types::{GenerationParams, Message};
-use crate::providers::ProviderConfig;
+use crate::providers::{ProviderConfig, ProviderType};
 use rusqlite::Connection;
 use serde::Deserialize;
 use std::sync::{LazyLock, Mutex};
@@ -247,33 +247,37 @@ pub(crate) fn consolidation_schema() -> serde_json::Value {
     })
 }
 
-/// Build the shared generation params for extraction calls. Temperature 0.1
-/// (tag-picking is nearly deterministic), reasoning minimized, optional
-/// `supported_params` threaded through so we don't send fields the router's
-/// downstream provider doesn't accept.
-/// How the tagging schema reaches the model.
+/// How the tagging schema reaches the model — a property of the **provider**,
+/// not of the task alone.
 ///
 /// Tag extraction is *generative*: the model decides how many tags to emit, so
 /// a decoder that shortens the output silently changes the answer rather than
-/// just its shape. Wire-level `response_format` does exactly that on some
-/// OpenRouter endpoints — measured 2026-08-09 on `google/gemma-4-26b-a4b-it`,
-/// DeepInfra's schema-enforced endpoint returned `{"tags": []}` (8 completion
-/// tokens, `finish_reason: stop`, no error signal) on ~1 call in 3, and
-/// schema-mode tag counts swung 5–13 on identical input. The same content sent
-/// with the schema in the prompt returned 7–8 tags on 8 of 8 calls.
+/// just its shape. Whether that risk outweighs the schema guarantee depends
+/// entirely on whose decoder is in the path, and the two deployments we support
+/// sit at opposite ends. Measured 2026-08-09, same content, same task:
 ///
-/// The trade is a decoding guarantee for a tolerant parser, and the parser was
-/// measured never to be exercised: across `openai/gpt-5-nano`,
-/// `google/gemma-4-26b-a4b-it`, `openai/gpt-5-mini` and `z-ai/glm-5.2`, all 24
-/// prompt-mode replies parsed directly — no fences, no surrounding prose.
-/// Prompt mode also matched or beat schema mode on tag count for three of the
-/// four models, and was consistently less erratic.
+/// | provider | schema on the wire | schema in the prompt |
+/// |---|---|---|
+/// | OpenRouter (`gemma-4-26b-a4b-it` → DeepInfra) | `{"tags": []}` on ~1 call in 3; counts swing 5–13 | 7–8 tags, 8 of 8 |
+/// | Ollama (`llama3.2`, 3B, local) | 2 tags, 6 of 6 | **empty on 3 of 6** |
 ///
-/// An empty-but-valid extraction is the failure this avoids: it parses, so the
-/// prompt-based fallback in `call_structured` never fires, and it reaches the
-/// pipeline looking like a real answer — the atom is then recorded as tagged
-/// with nothing.
-const TAGGING_SCHEMA_ENFORCEMENT: SchemaEnforcement = SchemaEnforcement::PromptOnly;
+/// The inversion is the point. OpenRouter is a *heterogeneous gateway*: the
+/// constrained-decoding implementation belongs to whichever endpoint we happen
+/// to route to, we cannot see or test it, and it changes without notice — so
+/// the schema guarantee is really a dependency on the worst decoder in the
+/// pool. Ollama is one local implementation (llama.cpp grammars) paired with
+/// models small enough that instruction-following is the weaker link; there the
+/// grammar is doing real work and removing it costs half the extractions.
+///
+/// So: prompt-only where the decoder is unknowable, wire-level where it is
+/// known and the model needs the help. OpenAI-compatible servers keep the
+/// wire-level default because they are unmeasured, and that is the status quo.
+fn tagging_schema_enforcement(provider: &ProviderType) -> SchemaEnforcement {
+    match provider {
+        ProviderType::OpenRouter => SchemaEnforcement::PromptOnly,
+        ProviderType::Ollama | ProviderType::OpenAICompat => SchemaEnforcement::Strict,
+    }
+}
 
 /// Output ceiling for tag extraction.
 ///
@@ -288,6 +292,10 @@ const TAGGING_SCHEMA_ENFORCEMENT: SchemaEnforcement = SchemaEnforcement::PromptO
 /// the pool intact with ~2.6x headroom over the worst generation seen.
 const TAGGING_MAX_OUTPUT_TOKENS: u32 = 8192;
 
+/// Build the shared generation params for extraction calls. Temperature 0.1
+/// (tag-picking is nearly deterministic), reasoning minimized, optional
+/// `supported_params` threaded through so we don't send fields the router's
+/// downstream provider doesn't accept.
 fn extraction_params(supported_params: Option<Vec<String>>) -> GenerationParams {
     let mut params = GenerationParams::new()
         .with_temperature(0.1)
@@ -366,7 +374,7 @@ pub async fn extract_tags_from_content(
         extraction_schema(),
     )
     .with_params(extraction_params(supported_params))
-    .with_schema_enforcement(TAGGING_SCHEMA_ENFORCEMENT)
+    .with_schema_enforcement(tagging_schema_enforcement(&provider_config.provider_type))
     .with_max_retries(3);
 
     match call_structured::<ExtractionResult>(call).await {
@@ -404,7 +412,7 @@ pub async fn extract_tags_from_chunk(
         extraction_schema(),
     )
     .with_params(extraction_params(supported_params))
-    .with_schema_enforcement(TAGGING_SCHEMA_ENFORCEMENT)
+    .with_schema_enforcement(tagging_schema_enforcement(&provider_config.provider_type))
     .with_max_retries(3);
 
     match call_structured::<ExtractionResult>(call).await {
@@ -751,6 +759,32 @@ mod tests {
         let temp_file = NamedTempFile::new().unwrap();
         let db = Database::open_or_create(temp_file.path()).unwrap();
         (db, temp_file)
+    }
+
+    /// The transport choice is provider-dependent, and the dependence runs in
+    /// *opposite* directions — that is the whole finding, so pin it. Dropping
+    /// the schema costs nothing behind a gateway whose decoder we can't see,
+    /// and costs half the extractions on a 3B local model leaning on the
+    /// grammar. A future refactor that collapses this to one constant would
+    /// silently regress one deployment or the other.
+    #[test]
+    fn tagging_transport_follows_the_provider() {
+        assert_eq!(
+            tagging_schema_enforcement(&ProviderType::OpenRouter),
+            SchemaEnforcement::PromptOnly,
+            "heterogeneous gateway: the decoder is unknowable, so don't depend on it"
+        );
+        assert_eq!(
+            tagging_schema_enforcement(&ProviderType::Ollama),
+            SchemaEnforcement::Strict,
+            "local llama.cpp grammar carries small models; removing it emptied \
+             3 of 6 extractions on llama3.2"
+        );
+        assert_eq!(
+            tagging_schema_enforcement(&ProviderType::OpenAICompat),
+            SchemaEnforcement::Strict,
+            "unmeasured: keep the status quo rather than guessing"
+        );
     }
 
     // ==================== Schema lint regression tests ====================

--- a/crates/atomic-core/src/providers/error.rs
+++ b/crates/atomic-core/src/providers/error.rs
@@ -312,3 +312,177 @@ pub fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
     }
     &s[..end]
 }
+
+/// The gateway's own identifier for a request, when it sends one.
+///
+/// OpenRouter returns `x-generation-id` **in the response headers**, which
+/// arrive long before the body — so it survives exactly the failures where
+/// the body doesn't, and resolves via `GET /api/v1/generation?id=…` to the
+/// upstream provider, timings, finish reason, and cost. It is the only
+/// thread back to what actually happened on a call that delivered nothing.
+/// `x-request-id` is the common spelling among other OpenAI-compatible
+/// gateways.
+pub fn gateway_trace_id(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    ["x-generation-id", "x-request-id"]
+        .iter()
+        .find_map(|name| headers.get(*name))
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+}
+
+/// Render a response body for a log line.
+///
+/// Never emit a body raw. Gateways pad responses with insignificant JSON
+/// whitespace (see [`decode_error`]), and a raw preview of one prints as an
+/// empty field followed by a few hundred newlines dumped into the log
+/// stream — the diagnostic goes blank at exactly the moment the body is the
+/// thing you need to see. Whitespace-only bodies are therefore described
+/// rather than shown, and everything else is escaped.
+pub fn body_for_log(body: &str, max_bytes: usize) -> String {
+    if body.is_empty() {
+        return "<empty body>".to_string();
+    }
+    if body.trim().is_empty() {
+        return format!(
+            "<{} bytes of gateway padding, {} newlines, no payload>",
+            body.len(),
+            body.matches('\n').count()
+        );
+    }
+    format!("{:?}", truncate_utf8(body, max_bytes))
+}
+
+/// Classify a 2xx response body that would not deserialize.
+///
+/// A gateway fronting a slow upstream commits `200 OK` **before** the work is
+/// done — it must return a response object immediately — and then holds the
+/// connection open with insignificant JSON whitespace (OpenRouter writes a
+/// newline-and-spaces heartbeat every ~425ms, legal because RFC 8259 permits
+/// arbitrary whitespace before the top-level value, so a compliant parser
+/// cannot see it). Once that status is committed it cannot be retracted: a
+/// late failure can no longer be expressed as 502 or 504. The gateway's only
+/// remaining exits are to write an error object into the body, or to stop
+/// writing and end the stream.
+///
+/// When it ends the stream, the client receives a complete, well-formed 200
+/// whose entire body is padding. That is a **transport** failure wearing a
+/// parse error's clothes, and the distinction decides whether the work is
+/// retried or dropped: the identical event cut a moment earlier arrives as
+/// [`ProviderError::Network`] and is retried, while the padded form used to
+/// land as a permanent [`ProviderError::ParseError`].
+///
+/// `serde_json` draws the line for us. [`Category::Eof`] means the input ran
+/// out — a body that is empty, all padding, or cut mid-JSON — and is always a
+/// truncated transfer. `Syntax` and `Data` mean bytes genuinely arrived and
+/// were wrong, which no retry fixes.
+pub fn decode_error(
+    what: &str,
+    body: &str,
+    err: &serde_json::Error,
+    trace_id: Option<&str>,
+) -> ProviderError {
+    let trace = trace_id
+        .map(|id| format!(" [generation {id}]"))
+        .unwrap_or_default();
+
+    if err.classify() != serde_json::error::Category::Eof {
+        return ProviderError::ParseError(format!("Failed to parse {what}: {err}{trace}"));
+    }
+
+    let detail = if body.is_empty() {
+        "the gateway committed 200 and sent no body at all".to_string()
+    } else if body.trim().is_empty() {
+        format!(
+            "the gateway committed 200, padded for {} bytes ({} newlines), and ended the \
+             body without ever sending a payload",
+            body.len(),
+            body.matches('\n').count()
+        )
+    } else {
+        format!("the body ended mid-JSON after {} bytes ({err})", body.len())
+    };
+    // Rendered as "Network error: …", which `is_retryable` and
+    // `classify_provider_failure` both already read as transient.
+    ProviderError::Network(format!("truncated {what}: {detail}{trace}"))
+}
+
+/// The streaming counterpart of [`decode_error`]'s truncated-body case: a
+/// committed 200 whose stream closed without ever carrying a payload.
+///
+/// Kept distinct from "the model returned empty content", which is a real
+/// (if unusual) answer. This is the absence of an answer, and like every
+/// other form of a body that never arrived it is transient.
+pub fn stream_delivered_nothing(what: &str, trace_id: Option<&str>) -> ProviderError {
+    let trace = trace_id
+        .map(|id| format!(" [generation {id}]"))
+        .unwrap_or_default();
+    ProviderError::Network(format!(
+        "truncated {what}: the gateway committed 200 and closed the stream without \
+         delivering any payload{trace}"
+    ))
+}
+
+#[cfg(test)]
+mod transport_tests {
+    use super::*;
+
+    fn eof_err(body: &str) -> serde_json::Error {
+        serde_json::from_str::<serde_json::Value>(body).unwrap_err()
+    }
+
+    /// The reported failure: a complete 200 whose body is nothing but
+    /// keepalive padding must be retryable, and must read as `Transient` to a
+    /// scheduler.
+    #[test]
+    fn padded_body_is_a_retryable_transient_failure() {
+        let body = "\n         \n".repeat(116);
+        let err = decode_error("chat response", &body, &eof_err(&body), Some("gen-abc"));
+
+        assert!(matches!(err, ProviderError::Network(_)), "got {err:?}");
+        assert!(err.is_retryable());
+        assert_eq!(
+            classify_provider_failure(&err.to_string()),
+            ProviderFailureClass::Transient
+        );
+        let rendered = err.to_string();
+        assert!(rendered.contains("232 newlines"), "{rendered}");
+        assert!(rendered.contains("gen-abc"), "{rendered}");
+    }
+
+    /// A body cut mid-JSON is the same transfer failure.
+    #[test]
+    fn truncated_json_is_transient_too() {
+        let body = r#"{"id":"gen-1","choices":["#;
+        let err = decode_error("chat response", body, &eof_err(body), None);
+        assert!(matches!(err, ProviderError::Network(_)), "got {err:?}");
+        assert!(err.is_retryable());
+    }
+
+    /// Bytes that genuinely arrived and were wrong stay a parse error — no
+    /// retry fixes a schema mismatch or malformed JSON.
+    #[test]
+    fn real_parse_failures_stay_permanent() {
+        let syntax = "{not json";
+        let err = decode_error("chat response", syntax, &eof_err(syntax), None);
+        assert!(matches!(err, ProviderError::ParseError(_)), "got {err:?}");
+        assert!(!err.is_retryable());
+
+        // Valid JSON, wrong shape: serde reports Data, not Eof.
+        let data_err = serde_json::from_str::<Vec<u32>>("{\"a\":1}").unwrap_err();
+        let err = decode_error("chat response", "{\"a\":1}", &data_err, None);
+        assert!(matches!(err, ProviderError::ParseError(_)), "got {err:?}");
+    }
+
+    /// A padded body must never be logged raw — that is why the field came
+    /// back blank in the original report.
+    #[test]
+    fn padding_is_described_not_dumped() {
+        let body = "\n         \n".repeat(116);
+        let rendered = body_for_log(&body, 500);
+        assert!(!rendered.contains('\n'), "log line must stay one line");
+        assert!(rendered.contains("232 newlines"), "{rendered}");
+
+        assert_eq!(body_for_log("", 500), "<empty body>");
+        assert_eq!(body_for_log("{\"a\":1}", 500), "\"{\\\"a\\\":1}\"");
+    }
+}

--- a/crates/atomic-core/src/providers/error.rs
+++ b/crates/atomic-core/src/providers/error.rs
@@ -313,15 +313,10 @@ pub fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
     &s[..end]
 }
 
-/// The gateway's own identifier for a request, when it sends one.
-///
-/// OpenRouter returns `x-generation-id` **in the response headers**, which
-/// arrive long before the body — so it survives exactly the failures where
-/// the body doesn't, and resolves via `GET /api/v1/generation?id=…` to the
-/// upstream provider, timings, finish reason, and cost. It is the only
-/// thread back to what actually happened on a call that delivered nothing.
-/// `x-request-id` is the common spelling among other OpenAI-compatible
-/// gateways.
+/// The gateway's id for a request. Lives in the headers, which arrive before
+/// the body — so it survives the failures where the body doesn't, and resolves
+/// via `GET /api/v1/generation?id=…` to provider, timings, finish reason and
+/// cost. Often the only thread back to a call that delivered nothing.
 pub fn gateway_trace_id(headers: &reqwest::header::HeaderMap) -> Option<String> {
     ["x-generation-id", "x-request-id"]
         .iter()
@@ -330,14 +325,10 @@ pub fn gateway_trace_id(headers: &reqwest::header::HeaderMap) -> Option<String> 
         .map(str::to_string)
 }
 
-/// Render a response body for a log line.
-///
-/// Never emit a body raw. Gateways pad responses with insignificant JSON
-/// whitespace (see [`decode_error`]), and a raw preview of one prints as an
-/// empty field followed by a few hundred newlines dumped into the log
-/// stream — the diagnostic goes blank at exactly the moment the body is the
-/// thing you need to see. Whitespace-only bodies are therefore described
-/// rather than shown, and everything else is escaped.
+/// Render a response body for a log line. Never raw: a padded body (see
+/// [`decode_error`]) prints as an empty field plus a few hundred newlines
+/// dumped into the log, so the diagnostic goes blank exactly when the body is
+/// what you need. Whitespace bodies are described; everything else is escaped.
 pub fn body_for_log(body: &str, max_bytes: usize) -> String {
     if body.is_empty() {
         return "<empty body>".to_string();
@@ -352,29 +343,18 @@ pub fn body_for_log(body: &str, max_bytes: usize) -> String {
     format!("{:?}", truncate_utf8(body, max_bytes))
 }
 
-/// Classify a 2xx response body that would not deserialize.
+/// Classify a 2xx body that would not deserialize.
 ///
-/// A gateway fronting a slow upstream commits `200 OK` **before** the work is
-/// done — it must return a response object immediately — and then holds the
-/// connection open with insignificant JSON whitespace (OpenRouter writes a
-/// newline-and-spaces heartbeat every ~425ms, legal because RFC 8259 permits
-/// arbitrary whitespace before the top-level value, so a compliant parser
-/// cannot see it). Once that status is committed it cannot be retracted: a
-/// late failure can no longer be expressed as 502 or 504. The gateway's only
-/// remaining exits are to write an error object into the body, or to stop
-/// writing and end the stream.
+/// OpenRouter commits `200 OK` before the upstream produces anything, then
+/// holds the connection open with JSON whitespace (invisible to a parser, per
+/// RFC 8259). The status can't be retracted afterwards, so a late failure ends
+/// the body instead — leaving a complete, well-formed 200 containing only
+/// padding. That's a transport failure, not a malformed answer, and the
+/// difference decides whether the work is retried or dropped.
 ///
-/// When it ends the stream, the client receives a complete, well-formed 200
-/// whose entire body is padding. That is a **transport** failure wearing a
-/// parse error's clothes, and the distinction decides whether the work is
-/// retried or dropped: the identical event cut a moment earlier arrives as
-/// [`ProviderError::Network`] and is retried, while the padded form used to
-/// land as a permanent [`ProviderError::ParseError`].
-///
-/// `serde_json` draws the line for us. [`Category::Eof`] means the input ran
-/// out — a body that is empty, all padding, or cut mid-JSON — and is always a
-/// truncated transfer. `Syntax` and `Data` mean bytes genuinely arrived and
-/// were wrong, which no retry fixes.
+/// `serde_json` draws the line: `Category::Eof` means the input ran out (empty,
+/// all padding, or cut mid-JSON) — always a truncated transfer. `Syntax` and
+/// `Data` mean bytes arrived and were wrong, which no retry fixes.
 pub fn decode_error(
     what: &str,
     body: &str,
@@ -406,12 +386,9 @@ pub fn decode_error(
     ProviderError::Network(format!("truncated {what}: {detail}{trace}"))
 }
 
-/// The streaming counterpart of [`decode_error`]'s truncated-body case: a
-/// committed 200 whose stream closed without ever carrying a payload.
-///
-/// Kept distinct from "the model returned empty content", which is a real
-/// (if unusual) answer. This is the absence of an answer, and like every
-/// other form of a body that never arrived it is transient.
+/// Streaming counterpart of [`decode_error`]: a committed 200 whose stream
+/// closed without carrying a payload. Distinct from "the model returned empty
+/// content", which is a real answer; this is the absence of one.
 pub fn stream_delivered_nothing(what: &str, trace_id: Option<&str>) -> ProviderError {
     let trace = trace_id
         .map(|id| format!(" [generation {id}]"))

--- a/crates/atomic-core/src/providers/openai_compat/embedding.rs
+++ b/crates/atomic-core/src/providers/openai_compat/embedding.rs
@@ -47,6 +47,8 @@ pub async fn embed_batch(
 
     let response = req.json(&request).send().await?;
 
+    let trace_id = crate::providers::error::gateway_trace_id(response.headers());
+
     if !response.status().is_success() {
         let status = response.status().as_u16();
         let retry_after = response
@@ -57,13 +59,13 @@ pub async fn embed_batch(
         let body = response.text().await.unwrap_or_default();
 
         if status == 429 {
-            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 200), "OpenAI-compat embedding rate limited");
+            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::body_for_log(&body, 200), "OpenAI-compat embedding rate limited");
             return Err(ProviderError::RateLimited {
                 retry_after_secs: retry_after,
             });
         }
 
-        tracing::error!(status, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenAI-compat embedding API error");
+        tracing::error!(status, model = %config.model, request_id = trace_id.as_deref().unwrap_or("-"), body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenAI-compat embedding API error");
         return Err(ProviderError::Api {
             status,
             message: body,
@@ -74,8 +76,8 @@ pub async fn embed_batch(
 
     let embedding_response: EmbeddingResponse = serde_json::from_str(&body)
         .map_err(|e| {
-            tracing::error!(error = %e, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenAI-compat embedding parse error");
-            ProviderError::ParseError(format!("Failed to parse embedding response: {e}"))
+            tracing::error!(error = %e, model = %config.model, request_id = trace_id.as_deref().unwrap_or("-"), body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenAI-compat embedding response decode failed");
+            crate::providers::error::decode_error("embedding response", &body, &e, trace_id.as_deref())
         })?;
 
     Ok(embedding_response

--- a/crates/atomic-core/src/providers/openai_compat/llm.rs
+++ b/crates/atomic-core/src/providers/openai_compat/llm.rs
@@ -284,6 +284,8 @@ async fn complete_internal(
 
     let response = req.json(&request).send().await?;
 
+    let trace_id = crate::providers::error::gateway_trace_id(response.headers());
+
     if !response.status().is_success() {
         let status = response.status().as_u16();
         let retry_after = response
@@ -294,13 +296,13 @@ async fn complete_internal(
         let body = response.text().await.unwrap_or_default();
 
         if status == 429 {
-            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 200), "OpenAI-compat LLM rate limited");
+            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::body_for_log(&body, 200), "OpenAI-compat LLM rate limited");
             return Err(ProviderError::RateLimited {
                 retry_after_secs: retry_after,
             });
         }
 
-        tracing::error!(status, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenAI-compat LLM API error");
+        tracing::error!(status, model = %config.model, request_id = trace_id.as_deref().unwrap_or("-"), body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenAI-compat LLM API error");
         return Err(ProviderError::Api {
             status,
             message: body,
@@ -311,8 +313,8 @@ async fn complete_internal(
 
     let chat_response: ChatResponse = serde_json::from_str(&body)
         .map_err(|e| {
-            tracing::error!(error = %e, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenAI-compat LLM parse error");
-            ProviderError::ParseError(format!("Failed to parse chat response: {e}"))
+            tracing::error!(error = %e, model = %config.model, request_id = trace_id.as_deref().unwrap_or("-"), body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenAI-compat LLM response decode failed");
+            crate::providers::error::decode_error("chat response", &body, &e, trace_id.as_deref())
         })?;
 
     let choice = chat_response
@@ -384,13 +386,13 @@ pub async fn complete_streaming_with_tools(
         let body = response.text().await.unwrap_or_default();
 
         if status == 429 {
-            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 200), "OpenAI-compat streaming LLM rate limited");
+            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::body_for_log(&body, 200), "OpenAI-compat streaming LLM rate limited");
             return Err(ProviderError::RateLimited {
                 retry_after_secs: retry_after,
             });
         }
 
-        tracing::error!(status, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenAI-compat streaming LLM API error");
+        tracing::error!(status, model = %config.model, body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenAI-compat streaming LLM API error");
         return Err(ProviderError::Api {
             status,
             message: body,
@@ -402,6 +404,10 @@ pub async fn complete_streaming_with_tools(
     let mut buffer = String::new();
     let mut finish_reason = None;
     let mut done_emitted = false;
+    // See the OpenRouter parser: a stream that carries no payload and no
+    // terminator delivered nothing, which must not be mistaken for a model
+    // that chose to say nothing.
+    let mut saw_payload = false;
 
     let mut stream = response.bytes_stream();
 
@@ -432,6 +438,7 @@ pub async fn complete_streaming_with_tools(
                         tracing::debug!(error = %e, chunk_preview = %crate::providers::error::truncate_utf8(json_str, 200), "OpenAI-compat stream chunk parse error");
                     }
                     Ok(response) => {
+                        saw_payload = true;
                         if let Some(choice) = response.choices.first() {
                             if choice.finish_reason.is_some() {
                                 finish_reason = choice.finish_reason.clone();
@@ -497,6 +504,17 @@ pub async fn complete_streaming_with_tools(
                 }
             }
         }
+    }
+
+    if !saw_payload && !done_emitted {
+        tracing::error!(
+            model = %config.model,
+            "OpenAI-compat stream closed without delivering any payload"
+        );
+        return Err(crate::providers::error::stream_delivered_nothing(
+            "chat stream",
+            None,
+        ));
     }
 
     // Some OpenAI-compatible servers close the stream without sending [DONE]

--- a/crates/atomic-core/src/providers/openrouter/embedding.rs
+++ b/crates/atomic-core/src/providers/openrouter/embedding.rs
@@ -47,21 +47,6 @@ struct EmbeddingData {
     embedding: Vec<f32>,
 }
 
-/// OpenRouter may return HTTP 200 with an error body when the upstream provider
-/// fails after OpenRouter has started proxying the request.
-#[derive(Deserialize)]
-struct OpenRouterErrorResponse {
-    error: OpenRouterErrorDetail,
-}
-
-#[derive(Deserialize)]
-struct OpenRouterErrorDetail {
-    #[serde(default)]
-    code: Option<serde_json::Value>,
-    #[serde(default)]
-    message: Option<String>,
-}
-
 /// Generate embeddings for multiple texts via OpenRouter API
 pub async fn embed_batch(
     provider: &OpenRouterProvider,
@@ -90,6 +75,8 @@ pub async fn embed_batch(
         .send()
         .await?;
 
+    let trace_id = crate::providers::error::gateway_trace_id(response.headers());
+
     if !response.status().is_success() {
         let status = response.status().as_u16();
         let retry_after = response
@@ -100,13 +87,13 @@ pub async fn embed_batch(
         let body = response.text().await.unwrap_or_default();
 
         if status == 429 {
-            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 200), "OpenRouter embedding rate limited");
+            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::body_for_log(&body, 200), "OpenRouter embedding rate limited");
             return Err(ProviderError::RateLimited {
                 retry_after_secs: retry_after,
             });
         }
 
-        tracing::error!(status, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenRouter embedding API error");
+        tracing::error!(status, model = %config.model, generation_id = trace_id.as_deref().unwrap_or("-"), body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenRouter embedding API error");
         return Err(ProviderError::Api {
             status,
             message: body,
@@ -118,20 +105,12 @@ pub async fn embed_batch(
     // OpenRouter can return HTTP 200 with an error body when the upstream
     // provider fails after proxying has started. Check for this before
     // trying to parse as a successful embedding response.
-    if let Ok(err_resp) = serde_json::from_str::<OpenRouterErrorResponse>(&body) {
-        let message = err_resp
-            .error
-            .message
-            .unwrap_or_else(|| "Unknown upstream error".to_string());
-        let code = err_resp
-            .error
-            .code
-            .map(|c| c.to_string())
-            .unwrap_or_default();
+    if let Some((code, message)) = super::upstream_error(&body) {
         tracing::error!(
             model = %config.model,
             error_code = %code,
             error_message = %message,
+            generation_id = trace_id.as_deref().unwrap_or("-"),
             "OpenRouter returned 200 with error body (upstream provider failure)"
         );
         // Always treat as 502 (upstream failure) so the adaptive retry
@@ -145,8 +124,8 @@ pub async fn embed_batch(
 
     let embedding_response: EmbeddingResponse = serde_json::from_str(&body)
         .map_err(|e| {
-            tracing::error!(error = %e, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenRouter embedding parse error");
-            ProviderError::ParseError(format!("Failed to parse embedding response: {e}"))
+            tracing::error!(error = %e, model = %config.model, generation_id = trace_id.as_deref().unwrap_or("-"), body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenRouter embedding response decode failed");
+            crate::providers::error::decode_error("embedding response", &body, &e, trace_id.as_deref())
         })?;
 
     let mut vectors: Vec<Vec<f32>> = embedding_response

--- a/crates/atomic-core/src/providers/openrouter/llm.rs
+++ b/crates/atomic-core/src/providers/openrouter/llm.rs
@@ -676,13 +676,10 @@ async fn complete_streaming_internal(
         }
     }
 
-    // A stream that carried no payload and no terminator delivered nothing at
-    // all — the streaming face of a gateway that committed 200 and then ended
-    // the body on padding. Returning `Ok` here would hand back an empty
-    // completion that looks like a model choosing to say nothing, and the
-    // caller would persist that silence as a result. Fail transiently instead,
-    // matching the non-streaming path; errors return before `Done` is emitted,
-    // as every earlier bail in this function does.
+    // No payload and no terminator means the stream delivered nothing. `Ok`
+    // here would look like a model choosing to say nothing, and the caller
+    // would persist that silence. Errors return before `Done` is emitted, as
+    // every earlier bail in this function does.
     if !saw_payload && !done_emitted {
         tracing::error!(
             model = %config.model,

--- a/crates/atomic-core/src/providers/openrouter/llm.rs
+++ b/crates/atomic-core/src/providers/openrouter/llm.rs
@@ -371,6 +371,12 @@ async fn complete_internal(
         .send()
         .await?;
 
+    // The gateway's id for this request rides in the HEADERS, which arrive
+    // before any body — so it survives exactly the failures where the body
+    // does not. Capture it before anything consumes the response; without it
+    // a call that delivered nothing leaves no thread back to what happened.
+    let trace_id = crate::providers::error::gateway_trace_id(response.headers());
+
     if !response.status().is_success() {
         let status = response.status().as_u16();
         let retry_after = response
@@ -381,13 +387,13 @@ async fn complete_internal(
         let body = response.text().await.unwrap_or_default();
 
         if status == 429 {
-            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 200), "OpenRouter LLM rate limited");
+            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::body_for_log(&body, 200), "OpenRouter LLM rate limited");
             return Err(ProviderError::RateLimited {
                 retry_after_secs: retry_after,
             });
         }
 
-        tracing::error!(status, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenRouter LLM API error");
+        tracing::error!(status, model = %config.model, generation_id = trace_id.as_deref().unwrap_or("-"), body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenRouter LLM API error");
         return Err(ProviderError::Api {
             status,
             message: body,
@@ -395,10 +401,29 @@ async fn complete_internal(
     }
 
     let body = response.text().await?;
+
+    // A 200 carrying an error object instead of a completion — one of the two
+    // exits left to a gateway that already committed its status. `choices` is
+    // required, so without this the envelope would land as a permanent parse
+    // failure. 502 marks it upstream-transient, matching the embedding path.
+    if let Some((code, message)) = super::upstream_error(&body) {
+        tracing::error!(
+            model = %config.model,
+            error_code = %code,
+            error_message = %message,
+            generation_id = trace_id.as_deref().unwrap_or("-"),
+            "OpenRouter returned 200 with error body (upstream provider failure)"
+        );
+        return Err(ProviderError::Api {
+            status: 502,
+            message: format!("[upstream {}] {}", code, message),
+        });
+    }
+
     let chat_response: ChatResponse = serde_json::from_str(&body)
         .map_err(|e| {
-            tracing::error!(error = %e, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenRouter LLM parse error");
-            ProviderError::ParseError(format!("Failed to parse chat response: {e}"))
+            tracing::error!(error = %e, model = %config.model, generation_id = trace_id.as_deref().unwrap_or("-"), body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenRouter LLM response decode failed");
+            crate::providers::error::decode_error("chat response", &body, &e, trace_id.as_deref())
         })?;
 
     let completion_tokens = chat_response
@@ -504,6 +529,8 @@ async fn complete_streaming_internal(
         .send()
         .await?;
 
+    let trace_id = crate::providers::error::gateway_trace_id(response.headers());
+
     if !response.status().is_success() {
         let status = response.status().as_u16();
         let retry_after = response
@@ -514,13 +541,13 @@ async fn complete_streaming_internal(
         let body = response.text().await.unwrap_or_default();
 
         if status == 429 {
-            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 200), "OpenRouter streaming LLM rate limited");
+            tracing::warn!(status, retry_after, model = %config.model, body_preview = %crate::providers::error::body_for_log(&body, 200), "OpenRouter streaming LLM rate limited");
             return Err(ProviderError::RateLimited {
                 retry_after_secs: retry_after,
             });
         }
 
-        tracing::error!(status, model = %config.model, body_preview = %crate::providers::error::truncate_utf8(&body, 500), "OpenRouter streaming LLM API error");
+        tracing::error!(status, model = %config.model, generation_id = trace_id.as_deref().unwrap_or("-"), body_preview = %crate::providers::error::body_for_log(&body, 500), "OpenRouter streaming LLM API error");
         return Err(ProviderError::Api {
             status,
             message: body,
@@ -536,6 +563,11 @@ async fn complete_streaming_internal(
     let mut upstream_provider = None;
     let mut generation_id = None;
     let mut done_emitted = false;
+    // Did the stream carry a single parseable SSE payload? A committed 200
+    // that then delivers nothing but keepalive padding yields zero of them,
+    // and would otherwise be indistinguishable from a model that legitimately
+    // returned empty content.
+    let mut saw_payload = false;
 
     let mut stream = response.bytes_stream();
 
@@ -570,6 +602,7 @@ async fn complete_streaming_internal(
                         tracing::debug!(error = %e, chunk_preview = %crate::providers::error::truncate_utf8(json_str, 200), "OpenRouter stream chunk parse error");
                     }
                     Ok(response) => {
+                        saw_payload = true;
                         if response.provider.is_some() {
                             upstream_provider = response.provider.clone();
                         }
@@ -641,6 +674,25 @@ async fn complete_streaming_internal(
                 }
             }
         }
+    }
+
+    // A stream that carried no payload and no terminator delivered nothing at
+    // all — the streaming face of a gateway that committed 200 and then ended
+    // the body on padding. Returning `Ok` here would hand back an empty
+    // completion that looks like a model choosing to say nothing, and the
+    // caller would persist that silence as a result. Fail transiently instead,
+    // matching the non-streaming path; errors return before `Done` is emitted,
+    // as every earlier bail in this function does.
+    if !saw_payload && !done_emitted {
+        tracing::error!(
+            model = %config.model,
+            generation_id = trace_id.as_deref().unwrap_or("-"),
+            "OpenRouter stream closed without delivering any payload"
+        );
+        return Err(crate::providers::error::stream_delivered_nothing(
+            "chat stream",
+            trace_id.as_deref(),
+        ));
     }
 
     // Some upstreams close the stream without sending [DONE] — mirror the

--- a/crates/atomic-core/src/providers/openrouter/mod.rs
+++ b/crates/atomic-core/src/providers/openrouter/mod.rs
@@ -28,19 +28,12 @@ struct ErrorEnvelopeDetail {
     message: Option<String>,
 }
 
-/// Recover an upstream failure that the gateway wrote into a **200** body.
-///
-/// OpenRouter commits its status line before the upstream has produced
-/// anything, so a failure discovered afterwards cannot be reported as 5xx
-/// (see `providers::error::decode_error`). Writing an error object in place
-/// of the payload is one of the two exits left to it; ending the body
-/// mid-padding is the other.
-///
-/// Returns `(code, message)` when the body is an error envelope rather than a
-/// payload. Both the chat and embedding paths need this: their response types
-/// require a `choices`/`data` field, so an unrecognized error envelope would
-/// otherwise surface as a *permanent* parse failure and the work would be
-/// dropped rather than retried.
+/// Recover an upstream failure the gateway wrote into a **200** body, as
+/// `(code, message)`. OpenRouter commits its status before the upstream
+/// produces anything, so a later failure can only be an error object or a
+/// truncated body (see `providers::error::decode_error`). Both the chat and
+/// embedding response types require a payload field, so an unrecognised
+/// envelope would otherwise look like a permanent parse failure.
 fn upstream_error(body: &str) -> Option<(String, String)> {
     let envelope: ErrorEnvelope = serde_json::from_str(body).ok()?;
     Some((

--- a/crates/atomic-core/src/providers/openrouter/mod.rs
+++ b/crates/atomic-core/src/providers/openrouter/mod.rs
@@ -12,7 +12,49 @@ use crate::providers::traits::{
 use crate::providers::types::{CompletionResponse, Message, ToolDefinition};
 use async_trait::async_trait;
 use reqwest::Client;
+use serde::Deserialize;
 use std::time::Duration;
+
+#[derive(Deserialize)]
+struct ErrorEnvelope {
+    error: ErrorEnvelopeDetail,
+}
+
+#[derive(Deserialize)]
+struct ErrorEnvelopeDetail {
+    #[serde(default)]
+    code: Option<serde_json::Value>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// Recover an upstream failure that the gateway wrote into a **200** body.
+///
+/// OpenRouter commits its status line before the upstream has produced
+/// anything, so a failure discovered afterwards cannot be reported as 5xx
+/// (see `providers::error::decode_error`). Writing an error object in place
+/// of the payload is one of the two exits left to it; ending the body
+/// mid-padding is the other.
+///
+/// Returns `(code, message)` when the body is an error envelope rather than a
+/// payload. Both the chat and embedding paths need this: their response types
+/// require a `choices`/`data` field, so an unrecognized error envelope would
+/// otherwise surface as a *permanent* parse failure and the work would be
+/// dropped rather than retried.
+fn upstream_error(body: &str) -> Option<(String, String)> {
+    let envelope: ErrorEnvelope = serde_json::from_str(body).ok()?;
+    Some((
+        envelope
+            .error
+            .code
+            .map(|c| c.to_string())
+            .unwrap_or_default(),
+        envelope
+            .error
+            .message
+            .unwrap_or_else(|| "Unknown upstream error".to_string()),
+    ))
+}
 
 /// OpenRouter provider implementation
 /// Supports embeddings, chat completions, streaming, tool calling, and structured outputs

--- a/crates/atomic-core/src/providers/structured.rs
+++ b/crates/atomic-core/src/providers/structured.rs
@@ -62,6 +62,38 @@ use std::sync::Arc;
 /// nowhere near it.
 pub const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 32_000;
 
+/// How a structured call asks the model for its JSON.
+///
+/// The wire-level options are not strictly better than the prompt-level one.
+/// `response_format` puts the endpoint's constrained-decoding implementation in
+/// the path, and implementations vary in quality: measured against
+/// `google/gemma-4-26b-a4b-it` on OpenRouter (2026-08-09), DeepInfra's
+/// schema-enforced endpoint returned a valid-but-**empty** `{"tags": []}` on
+/// roughly a third of calls — 8 completion tokens, `finish_reason: stop`, no
+/// error signal of any kind — where the same model given the schema in the
+/// prompt returned 7–8 tags on 8 of 8 calls. Constrained decoding took the
+/// shortest grammar-valid path instead of doing the task.
+///
+/// An empty-but-valid result is the worst failure shape available: it parses,
+/// so no fallback fires, and it reaches the caller looking like an answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaEnforcement {
+    /// Wire-level `response_format` with `strict: true` — constrained decoding,
+    /// and (on OpenRouter) `provider.require_parameters` routing that narrows
+    /// the endpoint pool to those advertising support.
+    Strict,
+    /// Wire-level `response_format` without `strict`. For endpoints that reject
+    /// OpenAI strict mode but still honour the schema.
+    Lenient,
+    /// No `response_format` at all: the schema goes in the prompt and the reply
+    /// is parsed tolerantly ([`parse_tolerant`]). Trades a decoding guarantee
+    /// for the endpoint's undistorted output. The measured cost of that trade
+    /// was nil — across `openai/gpt-5-nano`, `google/gemma-4-26b-a4b-it`,
+    /// `openai/gpt-5-mini` and `z-ai/glm-5.2`, 24 of 24 prompt-mode replies
+    /// parsed directly, needing neither fence-stripping nor substring rescue.
+    PromptOnly,
+}
+
 /// A single structured-output LLM call. Construct with [`StructuredCall::new`],
 /// optionally adjust via the `with_*` methods, then pass to [`call_structured`].
 pub struct StructuredCall<'a, T> {
@@ -72,15 +104,13 @@ pub struct StructuredCall<'a, T> {
     pub schema: Value,
     pub params: GenerationParams,
     pub max_retries: usize,
-    /// Whether to request OpenAI-style strict schema enforcement. Default: `true`.
-    /// Strict mode guarantees the response adheres to the schema via
-    /// constrained decoding, but narrows the routable provider pool on
-    /// OpenRouter (since `provider.require_parameters` is also set). Opt out
-    /// with [`StructuredCall::with_strict`] when calling a model that's
-    /// known to reject strict mode (typically smaller OSS models routed via
-    /// OpenRouter or non-OpenAI backends). The linter rules + prompt-based
-    /// fallback still cover correctness when strict is off.
-    pub strict: bool,
+    /// How the schema is conveyed to the model. Default:
+    /// [`SchemaEnforcement::Strict`] — constrained decoding, which suits most
+    /// short structured calls. Callers whose task is *generative* rather than
+    /// merely shaped (tag extraction, where the model must decide how much to
+    /// produce) should consider [`SchemaEnforcement::PromptOnly`]; see that
+    /// type's documentation for the measurements behind the distinction.
+    pub enforcement: SchemaEnforcement,
     _marker: PhantomData<fn() -> T>,
 }
 
@@ -104,7 +134,7 @@ impl<'a, T> StructuredCall<'a, T> {
                 .with_temperature(0.3)
                 .with_max_tokens(DEFAULT_MAX_OUTPUT_TOKENS),
             max_retries: 2,
-            strict: true,
+            enforcement: SchemaEnforcement::Strict,
             _marker: PhantomData,
         }
     }
@@ -123,16 +153,22 @@ impl<'a, T> StructuredCall<'a, T> {
         self
     }
 
-    /// Override the strict-mode flag. Default: `true`.
-    ///
-    /// Set to `false` when the target model or provider route is known to
-    /// reject OpenAI strict schemas (e.g. OpenRouter routing to a smaller
-    /// OSS model via vLLM). The primary call still passes the schema via
-    /// `response_format`, just without the constrained-decoding guarantee —
-    /// parse failures then fall through to the prompt-based fallback path.
-    pub fn with_strict(mut self, strict: bool) -> Self {
-        self.strict = strict;
+    /// Choose how the schema reaches the model. Default:
+    /// [`SchemaEnforcement::Strict`].
+    pub fn with_schema_enforcement(mut self, enforcement: SchemaEnforcement) -> Self {
+        self.enforcement = enforcement;
         self
+    }
+
+    /// Toggle strict constrained decoding, keeping `response_format` either
+    /// way. Shorthand for [`SchemaEnforcement::Strict`] / [`SchemaEnforcement::Lenient`];
+    /// use [`Self::with_schema_enforcement`] to drop `response_format` entirely.
+    pub fn with_strict(self, strict: bool) -> Self {
+        self.with_schema_enforcement(if strict {
+            SchemaEnforcement::Strict
+        } else {
+            SchemaEnforcement::Lenient
+        })
     }
 }
 
@@ -207,6 +243,16 @@ fn early_end_reason(response: &CompletionResponse) -> Option<&str> {
         .or_else(|| response.native_finish_reason.as_deref().filter(|r| is_cut(r)))
 }
 
+/// The prompt-level statement of the output contract, used both as the primary
+/// instruction under [`SchemaEnforcement::PromptOnly`] and as the re-ask in the
+/// fallback. One wording, so the two paths cannot drift apart.
+fn schema_instruction(schema_str: &str) -> String {
+    format!(
+        "Reply with ONLY a single JSON object matching this schema. No markdown, \
+         no prose, no code fences, no surrounding text.\n\nSchema:\n{schema_str}"
+    )
+}
+
 /// Run a structured-output call against the configured provider. See the
 /// module-level docs for the full semantics.
 ///
@@ -252,7 +298,7 @@ pub async fn call_structured_with_provider<T: DeserializeOwned>(
         schema,
         params,
         max_retries,
-        strict,
+        enforcement,
         ..
     } = call;
 
@@ -274,17 +320,32 @@ pub async fn call_structured_with_provider<T: DeserializeOwned>(
 
     let schema_str = serde_json::to_string_pretty(&schema).unwrap_or_else(|_| schema.to_string());
 
-    // Primary attempt: with structured output enabled. Strict defaults to
-    // true but callers can opt out via `StructuredCall::with_strict(false)`
-    // for models that reject OpenAI strict mode.
-    let schema_wrapper = StructuredOutputSchema {
-        name: schema_name.to_string(),
-        schema: schema.clone(),
-        strict,
+    // Primary attempt. Either the schema rides on the wire as
+    // `response_format`, or it rides in the prompt and we parse tolerantly —
+    // see `SchemaEnforcement` for why the latter is sometimes the better
+    // trade.
+    let (primary_config, primary_messages) = match enforcement {
+        SchemaEnforcement::Strict | SchemaEnforcement::Lenient => {
+            let schema_wrapper = StructuredOutputSchema {
+                name: schema_name.to_string(),
+                schema: schema.clone(),
+                strict: enforcement == SchemaEnforcement::Strict,
+            };
+            (
+                LlmConfig::new(model.to_string())
+                    .with_params(params.clone().with_structured_output(schema_wrapper)),
+                messages.to_vec(),
+            )
+        }
+        SchemaEnforcement::PromptOnly => {
+            let mut prompted = messages.to_vec();
+            prompted.push(Message::user(schema_instruction(&schema_str)));
+            (
+                LlmConfig::new(model.to_string()).with_params(params.clone()),
+                prompted,
+            )
+        }
     };
-    let primary_config = LlmConfig::new(model.to_string())
-        .with_params(params.clone().with_structured_output(schema_wrapper));
-    let primary_messages = messages.to_vec();
 
     let mut last_preview = String::new();
     let mut last_parse_err = String::new();
@@ -386,15 +447,14 @@ pub async fn call_structured_with_provider<T: DeserializeOwned>(
         }
     }
 
-    // Prompt-based fallback: no schema, explicit user nudge. This handles the
-    // case where the provider silently ignored `response_format` (some weaker
-    // OpenRouter-routed models, some Ollama models) and returned prose or
-    // fenced JSON that the primary attempt couldn't cleanly parse.
+    // Prompt-based fallback: no schema on the wire, explicit user nudge. This
+    // handles the case where the provider silently ignored `response_format`
+    // (some weaker OpenRouter-routed models, some Ollama models) and returned
+    // prose or fenced JSON that the primary attempt couldn't cleanly parse.
+    // Reached from `PromptOnly` too, where it re-asks with the sharper wording.
     let nudge = format!(
-        "Your previous response could not be parsed. Reply with ONLY a single JSON \
-         object matching this schema. No markdown, no prose, no code fences, no \
-         surrounding text.\n\nSchema:\n{}",
-        schema_str
+        "Your previous response could not be parsed. {}",
+        schema_instruction(&schema_str)
     );
 
     let mut fallback_messages = messages.to_vec();
@@ -486,8 +546,14 @@ const LONG_FORM_TRAILER: &str = "CITATIONS_USED:";
 /// structural completeness check — a generation that lost its tail is
 /// missing the trailer and fails loudly into the retry below, instead of
 /// being stored as a stub. Short structured calls (tagging, extraction,
-/// section ops) should keep [`call_structured`]: their outputs are small
-/// and genuinely benefit from constrained decoding.
+/// section ops) keep [`call_structured`]: their outputs are small and the
+/// JSON envelope costs nothing there.
+///
+/// Note that "keep `call_structured`" is not the same as "keep constrained
+/// decoding" — see [`SchemaEnforcement`]. Measurement has since shown the
+/// wire-level `response_format` layer degrading *generative* short calls on
+/// some endpoints (tag extraction collapsing to an empty list), so
+/// `call_structured` now carries the choice explicitly.
 pub async fn call_long_form_markdown(
     provider_config: &ProviderConfig,
     model: &str,
@@ -1450,7 +1516,7 @@ mod tests {
     // ==================== Strict-mode escape hatch ====================
 
     #[test]
-    fn structured_call_default_strict_is_true() {
+    fn structured_call_defaults_to_strict_enforcement() {
         let config = test_provider_config();
         let messages: Vec<Message> = vec![];
         let call = StructuredCall::<Sample>::new(
@@ -1460,22 +1526,23 @@ mod tests {
             "sample_result",
             sample_schema(),
         );
-        assert!(call.strict, "default strict must be true");
+        assert_eq!(call.enforcement, SchemaEnforcement::Strict);
     }
 
+    /// `with_strict` stays a shorthand over the two wire-level modes; it must
+    /// never reach `PromptOnly`, which is a different transport, not a
+    /// loosening of this one.
     #[test]
-    fn with_strict_false_sets_field() {
+    fn with_strict_maps_onto_the_wire_level_modes() {
         let config = test_provider_config();
         let messages: Vec<Message> = vec![];
-        let call = StructuredCall::<Sample>::new(
-            &config,
-            "m",
-            &messages,
-            "sample_result",
-            sample_schema(),
-        )
-        .with_strict(false);
-        assert!(!call.strict);
+        let build = |strict: bool| {
+            StructuredCall::<Sample>::new(&config, "m", &messages, "sample_result", sample_schema())
+                .with_strict(strict)
+                .enforcement
+        };
+        assert_eq!(build(false), SchemaEnforcement::Lenient);
+        assert_eq!(build(true), SchemaEnforcement::Strict);
     }
 
     #[tokio::test]
@@ -1519,6 +1586,76 @@ mod tests {
             !primary.strict,
             "with_strict(false) must propagate to the outbound request"
         );
+    }
+
+    /// `PromptOnly` must put nothing on the wire and everything in the prompt.
+    /// The wire half is the point: a `response_format` that reaches a weak
+    /// constrained-decoding endpoint is what collapsed tag extraction to an
+    /// empty list.
+    #[tokio::test]
+    async fn prompt_only_sends_no_response_format_and_states_the_schema() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response(OK_JSON);
+
+        let config = test_provider_config();
+        let messages = vec![Message::user("tag this")];
+        let call = StructuredCall::<Sample>::new(
+            &config,
+            "m",
+            &messages,
+            "sample_result",
+            sample_schema(),
+        )
+        .with_schema_enforcement(SchemaEnforcement::PromptOnly);
+        call_structured_with_provider::<Sample>(call, provider.clone())
+            .await
+            .expect("a directly parseable reply needs no fallback");
+
+        let schemas = provider.captured_schemas();
+        assert_eq!(schemas.len(), 1, "one call, no fallback");
+        assert!(
+            schemas[0].is_none(),
+            "PromptOnly must not send response_format"
+        );
+
+        let sent = provider.captured_messages();
+        let last = sent[0].last().expect("an instruction is appended");
+        let text = last.content.as_deref().expect("instruction has content");
+        assert!(text.contains("ONLY a single JSON object"), "{text}");
+        assert!(
+            text.contains("\"count\""),
+            "the schema itself must reach the model: {text}"
+        );
+        assert!(
+            !text.contains("could not be parsed"),
+            "the primary instruction must not claim a prior failure: {text}"
+        );
+    }
+
+    /// A reply wrapped in prose or fences is exactly what dropping
+    /// `response_format` risks, so the tolerant parser must absorb it without
+    /// spending the fallback call.
+    #[tokio::test]
+    async fn prompt_only_tolerates_a_fenced_reply() {
+        let provider = Arc::new(MockLlmProvider::new());
+        provider.queue_response(format!("Here you go:\n\n```json\n{OK_JSON}\n```"));
+
+        let config = test_provider_config();
+        let messages = vec![Message::user("tag this")];
+        let call = StructuredCall::<Sample>::new(
+            &config,
+            "m",
+            &messages,
+            "sample_result",
+            sample_schema(),
+        )
+        .with_schema_enforcement(SchemaEnforcement::PromptOnly);
+
+        let out = call_structured_with_provider::<Sample>(call, provider.clone())
+            .await
+            .expect("fenced JSON must parse tolerantly");
+        assert_eq!(out.count, 7);
+        assert_eq!(provider.call_count(), 1, "no fallback call needed");
     }
 
     #[tokio::test]

--- a/crates/atomic-core/src/providers/structured.rs
+++ b/crates/atomic-core/src/providers/structured.rs
@@ -62,37 +62,36 @@ use std::sync::Arc;
 /// nowhere near it.
 pub const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 32_000;
 
-/// How a structured call asks the model for its JSON.
-///
-/// The wire-level options are not strictly better than the prompt-level one.
-/// `response_format` puts the endpoint's constrained-decoding implementation in
-/// the path, and implementations vary in quality: measured against
-/// `google/gemma-4-26b-a4b-it` on OpenRouter (2026-08-09), DeepInfra's
-/// schema-enforced endpoint returned a valid-but-**empty** `{"tags": []}` on
-/// roughly a third of calls — 8 completion tokens, `finish_reason: stop`, no
-/// error signal of any kind — where the same model given the schema in the
-/// prompt returned 7–8 tags on 8 of 8 calls. Constrained decoding took the
-/// shortest grammar-valid path instead of doing the task.
-///
-/// An empty-but-valid result is the worst failure shape available: it parses,
-/// so no fallback fires, and it reaches the caller looking like an answer.
+/// How a structured call asks the model for its JSON. Wire-level is not
+/// strictly better — see [`GENERATIVE_CALL_ENFORCEMENT`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SchemaEnforcement {
-    /// Wire-level `response_format` with `strict: true` — constrained decoding,
-    /// and (on OpenRouter) `provider.require_parameters` routing that narrows
-    /// the endpoint pool to those advertising support.
+    /// `response_format` with `strict: true`. On OpenRouter this also sets
+    /// `provider.require_parameters`, narrowing routing to endpoints that
+    /// advertise support.
     Strict,
-    /// Wire-level `response_format` without `strict`. For endpoints that reject
-    /// OpenAI strict mode but still honour the schema.
+    /// `response_format` without `strict`, for endpoints that reject strict
+    /// mode but still honour the schema.
     Lenient,
-    /// No `response_format` at all: the schema goes in the prompt and the reply
-    /// is parsed tolerantly ([`parse_tolerant`]). Trades a decoding guarantee
-    /// for the endpoint's undistorted output. The measured cost of that trade
-    /// was nil — across `openai/gpt-5-nano`, `google/gemma-4-26b-a4b-it`,
-    /// `openai/gpt-5-mini` and `z-ai/glm-5.2`, 24 of 24 prompt-mode replies
-    /// parsed directly, needing neither fence-stripping nor substring rescue.
+    /// No `response_format`: the schema goes in the prompt and the reply is
+    /// parsed tolerantly ([`parse_tolerant`]).
     PromptOnly,
 }
+
+/// Transport for **generative** structured calls: the model decides how much to
+/// emit and an empty result is legal (tag extraction, consolidation, merge,
+/// wiki section ops).
+///
+/// A constrained decoder can take the shortest grammar-valid path and return
+/// the empty list. That parses, fires no fallback, and is indistinguishable
+/// from a considered "nothing to do" — so the work is silently skipped.
+/// Measured against a weak OpenRouter endpoint: 5/6 empty extractions, 2/6
+/// empty merges, 3/6 no-op wiki updates. Prompt-only: 0 across all of them,
+/// with no reply even needing fence-stripping.
+///
+/// Not for closed-shape calls (one enum choice, fixed-arity object) — nothing
+/// there for a decoder to shorten, so constrained decoding is free.
+pub const GENERATIVE_CALL_ENFORCEMENT: SchemaEnforcement = SchemaEnforcement::PromptOnly;
 
 /// A single structured-output LLM call. Construct with [`StructuredCall::new`],
 /// optionally adjust via the `with_*` methods, then pass to [`call_structured`].
@@ -243,21 +242,15 @@ fn early_end_reason(response: &CompletionResponse) -> Option<&str> {
         .or_else(|| response.native_finish_reason.as_deref().filter(|r| is_cut(r)))
 }
 
-/// A concrete illustration of a schema's output shape: the same structure with
-/// every leaf replaced by an angle-bracketed placeholder drawn from the field's
-/// `description`, and enums shown as their alternatives.
+/// The schema's output shape with leaves replaced by `<placeholder>` text from
+/// each field's `description`, enums shown as their alternatives.
 ///
-/// Exists because a JSON Schema is itself a JSON document, and "reply with an
-/// object matching this schema" followed by a schema is genuinely ambiguous to
-/// a small model — measured on `llama3.2`, 4 or 5 replies in 8 came back as the
-/// *schema* with the answer nested under `properties`. Showing the shape
-/// instead removes the ambiguity: 8 of 8 valid, with or without the schema also
-/// present.
-///
-/// Placeholders rather than plausible values on purpose. Invented values get
-/// copied — and for an enum whose first variant is the do-nothing case
-/// (`wiki_update_section_ops`), a "realistic" example would nudge the model
-/// straight at the degenerate answer this module exists to avoid.
+/// A JSON Schema is itself JSON, so "reply with an object matching this schema"
+/// followed by a schema is ambiguous: `llama3.2` returned the *schema*, answer
+/// nested under `properties`, in half of replies. Showing the shape fixes it
+/// (8/8 valid). Placeholders not plausible values — invented values get copied,
+/// and for an enum whose first variant is the do-nothing case (section ops)
+/// that would point straight at the degenerate answer.
 fn example_from_schema(schema: &Value) -> Value {
     let placeholder = |schema: &Value| -> Value {
         if let Some(values) = schema.get("enum").and_then(Value::as_array) {
@@ -298,13 +291,10 @@ fn example_from_schema(schema: &Value) -> Value {
     }
 }
 
-/// The prompt-level statement of the output contract, used both as the primary
-/// instruction under [`SchemaEnforcement::PromptOnly`] and as the re-ask in the
-/// fallback. One wording, so the two paths cannot drift apart.
-///
-/// Leads with the shape and keeps the schema behind it: the example is what
-/// small models actually follow, and the schema still carries the constraints
-/// an example cannot express (enums, required fields, `additionalProperties`).
+/// The prompt-level output contract — the primary instruction under
+/// [`SchemaEnforcement::PromptOnly`] and the re-ask in the fallback, so the two
+/// cannot drift apart. Shape first (what weak models follow), schema behind it
+/// (constraints an example can't express).
 fn schema_instruction(schema: &Value) -> String {
     let example = serde_json::to_string_pretty(&example_from_schema(schema))
         .unwrap_or_else(|_| "{}".to_string());
@@ -365,16 +355,10 @@ pub async fn call_structured_with_provider<T: DeserializeOwned>(
         ..
     } = call;
 
-    // Guarantee an output cap. `StructuredCall::new` sets one, but
-    // `with_params` replaces the params struct wholesale, so any caller that
-    // builds its own `GenerationParams` silently drops it — tag extraction
-    // did exactly that, and an absent `max_tokens` is the harmful direction:
-    // it hands the ceiling to whatever default the router or upstream picks,
-    // and it changes *routing* (OpenRouter filters endpoints by their
-    // `max_completion_tokens`, so sending nothing widens the pool while
-    // sending 32k can narrow it to none). Callers with a smaller natural
-    // ceiling should set it explicitly; forgetting entirely must not be an
-    // option.
+    // Guarantee an output cap. `with_params` replaces the params struct
+    // wholesale, so a caller building its own `GenerationParams` drops the
+    // default silently — tag extraction did. An absent `max_tokens` hands the
+    // ceiling to the router and changes which endpoints it will route to.
     let params = if params.max_tokens.is_some() {
         params
     } else {
@@ -610,11 +594,8 @@ const LONG_FORM_TRAILER: &str = "CITATIONS_USED:";
 /// section ops) keep [`call_structured`]: their outputs are small and the
 /// JSON envelope costs nothing there.
 ///
-/// Note that "keep `call_structured`" is not the same as "keep constrained
-/// decoding" — see [`SchemaEnforcement`]. Measurement has since shown the
-/// wire-level `response_format` layer degrading *generative* short calls on
-/// some endpoints (tag extraction collapsing to an empty list), so
-/// `call_structured` now carries the choice explicitly.
+/// Note that keeping `call_structured` is not the same as keeping constrained
+/// decoding — see [`GENERATIVE_CALL_ENFORCEMENT`].
 pub async fn call_long_form_markdown(
     provider_config: &ProviderConfig,
     model: &str,

--- a/crates/atomic-core/src/providers/structured.rs
+++ b/crates/atomic-core/src/providers/structured.rs
@@ -243,13 +243,76 @@ fn early_end_reason(response: &CompletionResponse) -> Option<&str> {
         .or_else(|| response.native_finish_reason.as_deref().filter(|r| is_cut(r)))
 }
 
+/// A concrete illustration of a schema's output shape: the same structure with
+/// every leaf replaced by an angle-bracketed placeholder drawn from the field's
+/// `description`, and enums shown as their alternatives.
+///
+/// Exists because a JSON Schema is itself a JSON document, and "reply with an
+/// object matching this schema" followed by a schema is genuinely ambiguous to
+/// a small model — measured on `llama3.2`, 4 or 5 replies in 8 came back as the
+/// *schema* with the answer nested under `properties`. Showing the shape
+/// instead removes the ambiguity: 8 of 8 valid, with or without the schema also
+/// present.
+///
+/// Placeholders rather than plausible values on purpose. Invented values get
+/// copied — and for an enum whose first variant is the do-nothing case
+/// (`wiki_update_section_ops`), a "realistic" example would nudge the model
+/// straight at the degenerate answer this module exists to avoid.
+fn example_from_schema(schema: &Value) -> Value {
+    let placeholder = |schema: &Value| -> Value {
+        if let Some(values) = schema.get("enum").and_then(Value::as_array) {
+            let alternatives: Vec<String> = values
+                .iter()
+                .map(|v| {
+                    v.as_str()
+                        .map(str::to_string)
+                        .unwrap_or_else(|| v.to_string())
+                })
+                .collect();
+            return Value::String(format!("<{}>", alternatives.join(" | ")));
+        }
+        match schema.get("description").and_then(Value::as_str) {
+            Some(description) => Value::String(format!("<{description}>")),
+            None => Value::String("<value>".to_string()),
+        }
+    };
+
+    match schema.get("type").and_then(Value::as_str) {
+        Some("object") => {
+            let mut example = serde_json::Map::new();
+            if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+                for (name, property) in properties {
+                    example.insert(name.clone(), example_from_schema(property));
+                }
+            }
+            Value::Object(example)
+        }
+        // One element is enough to show the shape; more would suggest a count.
+        Some("array") => match schema.get("items") {
+            Some(items) => Value::Array(vec![example_from_schema(items)]),
+            None => Value::Array(vec![]),
+        },
+        Some("integer") | Some("number") => Value::from(1),
+        Some("boolean") => Value::Bool(true),
+        _ => placeholder(schema),
+    }
+}
+
 /// The prompt-level statement of the output contract, used both as the primary
 /// instruction under [`SchemaEnforcement::PromptOnly`] and as the re-ask in the
 /// fallback. One wording, so the two paths cannot drift apart.
-fn schema_instruction(schema_str: &str) -> String {
+///
+/// Leads with the shape and keeps the schema behind it: the example is what
+/// small models actually follow, and the schema still carries the constraints
+/// an example cannot express (enums, required fields, `additionalProperties`).
+fn schema_instruction(schema: &Value) -> String {
+    let example = serde_json::to_string_pretty(&example_from_schema(schema))
+        .unwrap_or_else(|_| "{}".to_string());
+    let schema_str = serde_json::to_string_pretty(schema).unwrap_or_else(|_| schema.to_string());
     format!(
-        "Reply with ONLY a single JSON object matching this schema. No markdown, \
-         no prose, no code fences, no surrounding text.\n\nSchema:\n{schema_str}"
+        "Reply with ONLY a single JSON object in exactly this form, replacing each \
+         <placeholder> with a real value. No markdown, no prose, no code fences, no \
+         surrounding text.\n\n{example}\n\nThe object must satisfy this JSON Schema:\n{schema_str}"
     )
 }
 
@@ -318,8 +381,6 @@ pub async fn call_structured_with_provider<T: DeserializeOwned>(
         params.with_max_tokens(DEFAULT_MAX_OUTPUT_TOKENS)
     };
 
-    let schema_str = serde_json::to_string_pretty(&schema).unwrap_or_else(|_| schema.to_string());
-
     // Primary attempt. Either the schema rides on the wire as
     // `response_format`, or it rides in the prompt and we parse tolerantly —
     // see `SchemaEnforcement` for why the latter is sometimes the better
@@ -339,7 +400,7 @@ pub async fn call_structured_with_provider<T: DeserializeOwned>(
         }
         SchemaEnforcement::PromptOnly => {
             let mut prompted = messages.to_vec();
-            prompted.push(Message::user(schema_instruction(&schema_str)));
+            prompted.push(Message::user(schema_instruction(&schema)));
             (
                 LlmConfig::new(model.to_string()).with_params(params.clone()),
                 prompted,
@@ -454,7 +515,7 @@ pub async fn call_structured_with_provider<T: DeserializeOwned>(
     // Reached from `PromptOnly` too, where it re-asks with the sharper wording.
     let nudge = format!(
         "Your previous response could not be parsed. {}",
-        schema_instruction(&schema_str)
+        schema_instruction(&schema)
     );
 
     let mut fallback_messages = messages.to_vec();
@@ -1585,6 +1646,52 @@ mod tests {
         assert!(
             !primary.strict,
             "with_strict(false) must propagate to the outbound request"
+        );
+    }
+
+    /// The instruction must lead with the *shape*, because a schema alone is
+    /// ambiguous to a small model — it is itself a JSON document, and half the
+    /// time `llama3.2` returned that document with the answer buried under
+    /// `properties`.
+    #[test]
+    fn schema_instruction_shows_the_shape_before_the_schema() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "operations": {"type": "array", "items": {
+                    "type": "object",
+                    "properties": {
+                        "op": {"type": "string", "enum": ["NoChange", "AppendToSection"],
+                               "description": "Operation type."},
+                        "heading": {"type": "string", "description": "Target heading."}},
+                    "required": ["op", "heading"], "additionalProperties": false}},
+                "citations_used": {"type": "array", "items": {"type": "integer"}}},
+            "required": ["operations", "citations_used"], "additionalProperties": false
+        });
+
+        let example = example_from_schema(&schema);
+        assert_eq!(
+            example,
+            serde_json::json!({
+                "operations": [{"op": "<NoChange | AppendToSection>", "heading": "<Target heading.>"}],
+                "citations_used": [1]
+            }),
+            "descriptions become placeholders; enums list their alternatives"
+        );
+
+        let instruction = schema_instruction(&schema);
+        let example_at = instruction.find("\"operations\"").expect("example present");
+        let schema_at = instruction.find("JSON Schema:").expect("schema present");
+        assert!(
+            example_at < schema_at,
+            "the shape must come first — it is what a weak model follows"
+        );
+        // Enum placeholders must not name a single variant: for section ops the
+        // first variant is the do-nothing case, and a "realistic" example would
+        // point the model straight at the degenerate answer.
+        assert!(
+            !instruction.contains("\"op\": \"NoChange\""),
+            "an enum example must not pick a variant: {instruction}"
         );
     }
 

--- a/crates/atomic-core/src/providers/structured.rs
+++ b/crates/atomic-core/src/providers/structured.rs
@@ -256,6 +256,22 @@ pub async fn call_structured_with_provider<T: DeserializeOwned>(
         ..
     } = call;
 
+    // Guarantee an output cap. `StructuredCall::new` sets one, but
+    // `with_params` replaces the params struct wholesale, so any caller that
+    // builds its own `GenerationParams` silently drops it — tag extraction
+    // did exactly that, and an absent `max_tokens` is the harmful direction:
+    // it hands the ceiling to whatever default the router or upstream picks,
+    // and it changes *routing* (OpenRouter filters endpoints by their
+    // `max_completion_tokens`, so sending nothing widens the pool while
+    // sending 32k can narrow it to none). Callers with a smaller natural
+    // ceiling should set it explicitly; forgetting entirely must not be an
+    // option.
+    let params = if params.max_tokens.is_some() {
+        params
+    } else {
+        params.with_max_tokens(DEFAULT_MAX_OUTPUT_TOKENS)
+    };
+
     let schema_str = serde_json::to_string_pretty(&schema).unwrap_or_else(|_| schema.to_string());
 
     // Primary attempt: with structured output enabled. Strict defaults to

--- a/crates/atomic-core/src/wiki/mod.rs
+++ b/crates/atomic-core/src/wiki/mod.rs
@@ -16,7 +16,9 @@ use crate::models::{
     WikiArticleSummary, WikiArticleVersion, WikiArticleWithCitations, WikiCitation, WikiLink,
     WikiVersionSummary,
 };
-use crate::providers::structured::{call_structured, StructuredCall};
+use crate::providers::structured::{
+    call_structured, StructuredCall, GENERATIVE_CALL_ENFORCEMENT,
+};
 use crate::providers::types::Message;
 use crate::providers::ProviderConfig;
 use crate::storage::StorageBackend;
@@ -657,7 +659,10 @@ pub(crate) async fn call_llm_for_wiki_typed<T: DeserializeOwned>(
 
     let messages = vec![Message::system(system_prompt), Message::user(user_content)];
 
-    let call = StructuredCall::<T>::new(provider_config, model, &messages, schema_name, schema);
+    // Section ops are generative and "no operations" is a legal answer, so a
+    // constrained decoder can silently return a no-op update.
+    let call = StructuredCall::<T>::new(provider_config, model, &messages, schema_name, schema)
+        .with_schema_enforcement(GENERATIVE_CALL_ENFORCEMENT);
 
     let started = std::time::Instant::now();
     match call_structured::<T>(call).await {

--- a/crates/atomic-core/tests/gateway_truncated_response_tests.rs
+++ b/crates/atomic-core/tests/gateway_truncated_response_tests.rs
@@ -1,0 +1,466 @@
+//! Regression cover for the 2026-08-09 auto-tagging failure on
+//! `google/gemma-4-26b-a4b-it`:
+//!
+//! ```text
+//! INFO  Starting auto-tagging atom_id=7922b646… model=google/gemma-4-26b-a4b-it   [15:00:19.103]
+//! ERROR OpenRouter LLM parse error error=EOF while parsing a value at line 233
+//!       column 0 model=google/gemma-4-26b-a4b-it body_preview=                    [15:01:08.232]
+//! ```
+//!
+//! ## What the wire actually carries
+//!
+//! Verified against live OpenRouter traffic (2026-08-09, this exact model and
+//! the exact request the tagging path builds):
+//!
+//! - OpenRouter pads **non-streaming** `/chat/completions` responses with
+//!   whitespace while it waits on the upstream. The unit is
+//!   [`PADDING_UNIT`] — captured verbatim; the body's only byte values are
+//!   `0x0a` and `0x20`. Padding appeared on **every** observed call (6–112
+//!   newlines).
+//! - The real JSON payload that follows is **compact — zero newlines**.
+//!   Therefore every line counted in a serde error on this path came from
+//!   padding, and nothing else. `line 233` means 232 padding newlines.
+//! - The cadence is [`PADDING_NEWLINES_PER_SEC`] ≈ 4.66/s, stable across
+//!   calls from 4.5s to 8 minutes. 232 newlines ⇒ ~49.8s of waiting; the
+//!   report's own timestamps span 49.13s. The body shape and the wall-clock
+//!   agree independently.
+//! - When a call goes wrong, padding is *all* that ever arrives: one captured
+//!   call ran 8 minutes and delivered 12288 bytes / 2235 newlines / no JSON.
+//!
+//! ## Why the gateway can only fail this way
+//!
+//! OpenRouter commits `HTTP/2 200` and sends headers *before* the upstream has
+//! produced anything (verified: a request cut after 3s had already returned
+//! full headers and a body of nothing but padding). After that commit no
+//! failure can be expressed as an HTTP status — the only exits are a JSON
+//! error body or simply ending the body. Ending it leaves the client holding
+//! whitespace. So *any* late fault, on *any* upstream, degrades into this
+//! shape. It is a property of the gateway, not of one provider.
+//!
+//! Note what the failing body does NOT contain: a `provider` field. The
+//! upstream that served a failed call is therefore unknowable from the
+//! response — but `x-generation-id` is in the *headers*, arrives before the
+//! body, and resolves via `GET /api/v1/generation?id=…` to the provider,
+//! timings, finish reason, and cost. It is now captured into the error and
+//! the log line (`providers::error::gateway_trace_id`).
+//!
+//! ## What these tests hold in place
+//!
+//! Both errors in the report are the same event, differing only in whether
+//! the terminating chunk arrived: `Network` ("error decoding response body",
+//! stream cut) or `ParseError` ("EOF while parsing a value", stream ended on
+//! padding). Classifying the second as permanent is what dropped the work —
+//! one attempt of a three-attempt budget, on a fault a retry fixes. Both are
+//! now transport failures, retryable and `Transient`.
+//!
+//! Worth knowing when reading a future report: OpenRouter records these as
+//! **successes**. Three deliberately abandoned calls came back
+//! `finish_reason: stop`, `cancelled: false`, fully billed — delivery is not
+//! modelled in a generation record, so the client seeing nothing leaves no
+//! trace on their side. An absence of errors in their dashboard is consistent
+//! with this failure, not evidence against it.
+//!
+//! What is NOT established: what tipped that particular request over. The
+//! report's `upstream_provider="DeepInfra"` belongs to the *previous,
+//! successful* call for a different atom, not to the failure.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use atomic_core::providers::error::{
+    classify_provider_failure, ProviderError, ProviderFailureClass,
+};
+use atomic_core::providers::openrouter::OpenRouterProvider;
+use atomic_core::providers::structured::{
+    call_structured_with_provider, StructuredCall, DEFAULT_MAX_OUTPUT_TOKENS,
+};
+use atomic_core::providers::traits::{LlmConfig, LlmProvider, StreamingLlmProvider};
+use atomic_core::providers::types::Message;
+use atomic_core::providers::ProviderConfig;
+use serde::Deserialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// OpenRouter's keepalive padding unit, captured byte-for-byte from a live
+/// non-streaming `/chat/completions` response: newline, nine spaces, newline.
+const PADDING_UNIT: &str = "\n         \n";
+
+/// Measured padding cadence (newlines/second), stable across observed calls.
+/// Only used to document what a given line number implies in wall-clock.
+const PADDING_NEWLINES_PER_SEC: f64 = 4.66;
+
+/// A raw-socket HTTP server: answers every connection with the exact bytes
+/// `response`, then closes. Raw bytes rather than a framework because the
+/// point is to serve a body no well-behaved server would send. Records each
+/// request body so tests can assert what Atomic actually puts on the wire.
+struct RawServer {
+    base_url: String,
+    hits: Arc<AtomicUsize>,
+    requests: Arc<Mutex<Vec<String>>>,
+}
+
+impl RawServer {
+    async fn start(response: Vec<u8>) -> Self {
+        Self::start_sequence(vec![response]).await
+    }
+
+    /// Serve `responses[n]` to the nth connection, repeating the last entry
+    /// once the sequence is exhausted. Lets a test script a gateway that fails
+    /// one attempt and answers the next.
+    async fn start_sequence(responses: Vec<Vec<u8>>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let (hits_t, reqs_t) = (hits.clone(), requests.clone());
+        let responses = Arc::new(responses);
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let nth = hits_t.fetch_add(1, Ordering::SeqCst);
+                let response = responses[nth.min(responses.len() - 1)].clone();
+                let reqs = reqs_t.clone();
+                tokio::spawn(async move {
+                    // Read headers, then exactly Content-Length body bytes, so
+                    // the captured request is complete and the client is never
+                    // left blocked on a half-drained socket.
+                    let mut raw = Vec::new();
+                    let mut buf = [0u8; 8192];
+                    loop {
+                        let Ok(n) = socket.read(&mut buf).await else {
+                            return;
+                        };
+                        if n == 0 {
+                            break;
+                        }
+                        raw.extend_from_slice(&buf[..n]);
+                        let text = String::from_utf8_lossy(&raw).to_string();
+                        if let Some(head_end) = text.find("\r\n\r\n") {
+                            let len: usize = text[..head_end]
+                                .lines()
+                                .find_map(|l| {
+                                    let (k, v) = l.split_once(':')?;
+                                    k.eq_ignore_ascii_case("content-length")
+                                        .then(|| v.trim().parse().ok())?
+                                })
+                                .unwrap_or(0);
+                            if raw.len() >= head_end + 4 + len {
+                                reqs.lock().unwrap().push(
+                                    String::from_utf8_lossy(&raw[head_end + 4..]).to_string(),
+                                );
+                                break;
+                            }
+                        }
+                    }
+                    let _ = socket.write_all(&response).await;
+                    let _ = socket.flush().await;
+                    // Drop closes the connection — how a short body ends.
+                });
+            }
+        });
+
+        Self {
+            base_url: format!("http://{addr}"),
+            hits,
+            requests,
+        }
+    }
+
+    fn provider(&self) -> OpenRouterProvider {
+        OpenRouterProvider::with_base_url("test-key".to_string(), self.base_url.clone())
+    }
+
+    fn hits(&self) -> usize {
+        self.hits.load(Ordering::SeqCst)
+    }
+
+    fn last_request(&self) -> serde_json::Value {
+        let reqs = self.requests.lock().unwrap();
+        serde_json::from_str(reqs.last().expect("a request was made")).expect("request is JSON")
+    }
+}
+
+/// Frame a body the way OpenRouter actually does: `Transfer-Encoding: chunked`,
+/// one chunk per gateway write. `terminate` controls the *only* thing that
+/// differs between the report's two error lines — whether the final
+/// `0\r\n\r\n` chunk arrives before the socket closes.
+fn chunked_response(parts: &[String], terminate: bool) -> Vec<u8> {
+    let mut out = String::from(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\n\r\n",
+    );
+    for part in parts {
+        out.push_str(&format!("{:x}\r\n{part}\r\n", part.len()));
+    }
+    if terminate {
+        out.push_str("0\r\n\r\n");
+    }
+    out.into_bytes()
+}
+
+/// `newlines` worth of real keepalive padding, properly terminated: a
+/// **complete** HTTP message whose entire body is whitespace. There is nothing
+/// further to wait for — the server said "that's all".
+fn padded_response(newlines: usize) -> Vec<u8> {
+    let writes = newlines / PADDING_UNIT.matches('\n').count();
+    let body = PADDING_UNIT.repeat(writes);
+    assert_eq!(body.matches('\n').count(), newlines);
+    assert!(body.trim().is_empty(), "padding is whitespace-only");
+    // Why the report's `body_preview=` was blank: the preview is logged raw,
+    // so a whitespace body renders as nothing at all. The diagnostic goes
+    // dark exactly when the body is the thing you need to see.
+    assert!(
+        atomic_core::providers::error::truncate_utf8(&body, 500)
+            .trim()
+            .is_empty(),
+        "preview of a padded body is visually empty"
+    );
+    // One chunk per gateway heartbeat, then the terminator.
+    chunked_response(&vec![PADDING_UNIT.to_string(); writes], true)
+}
+
+/// The same padding, but the socket closes without the terminating chunk —
+/// the stream is cut rather than ended.
+fn cut_mid_body_response() -> Vec<u8> {
+    chunked_response(&vec![PADDING_UNIT.to_string(); 20], false)
+}
+
+fn ok_response() -> Vec<u8> {
+    let body = serde_json::json!({
+        "id": "gen-ok", "provider": "DeepInfra",
+        "choices": [{"message": {"role": "assistant",
+            "content": "{\"tags\":[{\"name\":\"Rust\",\"parent_name\":\"Topics\"}]}"},
+            "finish_reason": "stop"}],
+        "usage": {"completion_tokens": 42}
+    })
+    .to_string();
+    format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    )
+    .into_bytes()
+}
+
+#[derive(Debug, Deserialize)]
+struct ExtractionResult {
+    #[allow(dead_code)]
+    tags: Vec<serde_json::Value>,
+}
+
+fn extraction_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {"tags": {"type": "array", "items": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "parent_name": {"type": "string"}},
+            "required": ["name", "parent_name"], "additionalProperties": false}}},
+        "required": ["tags"],
+        "additionalProperties": false
+    })
+}
+
+async fn complete_against(server: &RawServer) -> ProviderError {
+    server
+        .provider()
+        .complete(
+            &[Message::user("tag this atom")],
+            &LlmConfig::new("google/gemma-4-26b-a4b-it".to_string()),
+        )
+        .await
+        .expect_err("a padded/cut body cannot produce a completion")
+}
+
+/// The reported failure, driven from real captured padding: a complete 200
+/// whose body is nothing but keepalive whitespace is a transport fault, and
+/// must be reported as one.
+#[tokio::test]
+async fn padded_body_is_a_retryable_transport_failure() {
+    let server = RawServer::start(padded_response(232)).await;
+
+    let err = complete_against(&server).await;
+
+    // 232 newlines is not an arbitrary number — it is how long the call was in
+    // flight. The report's own timestamps span 49.13s.
+    let implied_wait = 232.0 / PADDING_NEWLINES_PER_SEC;
+    assert!(
+        (implied_wait - 49.13).abs() < 2.0,
+        "padding cadence should explain the reported 49.13s gap, got {implied_wait:.1}s"
+    );
+
+    let ProviderError::Network(msg) = &err else {
+        panic!("a padded body is a truncated transfer, not a parse failure: {err:?}");
+    };
+    assert!(
+        msg.contains("232 newlines") && msg.contains("without ever sending a payload"),
+        "the error should say what actually arrived, got: {msg}"
+    );
+
+    // Both consequences that used to bite, now inverted:
+    assert!(err.is_retryable(), "the call must be retried");
+    assert_eq!(
+        classify_provider_failure(&err.to_string()),
+        ProviderFailureClass::Transient,
+        "schedulers must back off rather than terminally failing the work"
+    );
+}
+
+/// One event, two framings — cut mid-stream, or ended politely on padding.
+/// Both of the report's error lines are this. Neither may be permanent.
+///
+/// This is also where "why not just wait for the body?" is answered: we *do*
+/// wait. In the terminated case the wait **succeeded** — reqwest read the
+/// message to completion and handed us the whole body. That the body was
+/// whitespace is not something more waiting fixes; the server already said
+/// "that's all". Waiting is only meaningful while a stream is open, and
+/// neither of these is.
+#[tokio::test]
+async fn both_framings_of_a_delivered_nothing_are_retryable() {
+    let cut = RawServer::start(cut_mid_body_response()).await;
+    let terminated = RawServer::start(padded_response(232)).await;
+
+    let cut_err = complete_against(&cut).await;
+    let terminated_err = complete_against(&terminated).await;
+
+    for (label, err) in [
+        ("cut mid-stream", &cut_err),
+        ("ended on padding", &terminated_err),
+    ] {
+        assert!(
+            matches!(err, ProviderError::Network(_)),
+            "{label}: expected a transport error, got {err:?}"
+        );
+        assert!(err.is_retryable(), "{label}: must be retried");
+        assert_eq!(
+            classify_provider_failure(&err.to_string()),
+            ProviderFailureClass::Transient,
+            "{label}: schedulers must see a transient fault"
+        );
+    }
+}
+
+/// The streaming face of the same failure: a committed 200 that closes having
+/// carried no SSE payload at all. Returning `Ok` with empty content would
+/// persist the silence as if the model had chosen it.
+#[tokio::test]
+async fn a_stream_that_carries_nothing_fails_instead_of_returning_empty() {
+    let server = RawServer::start(padded_response(40)).await;
+
+    let err = server
+        .provider()
+        .complete_streaming_with_tools(
+            &[Message::user("tag this atom")],
+            &[],
+            &LlmConfig::new("google/gemma-4-26b-a4b-it".to_string()),
+            Box::new(|_| {}),
+        )
+        .await
+        .expect_err("a stream that delivered no payload is not an empty answer");
+
+    assert!(matches!(err, ProviderError::Network(_)), "got {err:?}");
+    assert!(err.is_retryable());
+    assert_eq!(
+        classify_provider_failure(&err.to_string()),
+        ProviderFailureClass::Transient
+    );
+}
+
+/// The bug that actually lost work, end to end: auto-tagging used to burn ONE
+/// request and quit on a transport fault, so the atom went untagged. The same
+/// gateway behaviour must now recover on the following attempt.
+///
+/// The retry-budget arithmetic is covered by the paused-time unit tests in
+/// `providers::structured`; what only a socket can prove is that a real padded
+/// HTTP response is what gets retried. One real 2s backoff is the price.
+#[tokio::test]
+async fn a_padded_first_attempt_now_recovers_on_retry() {
+    let server = RawServer::start_sequence(vec![padded_response(232), ok_response()]).await;
+    let provider: Arc<dyn LlmProvider> = Arc::new(server.provider());
+
+    let config = ProviderConfig::from_settings(&Default::default());
+    let messages = [Message::user("tag this atom")];
+    let call = StructuredCall::<ExtractionResult>::new(
+        &config,
+        "google/gemma-4-26b-a4b-it",
+        &messages,
+        "extraction_result",
+        extraction_schema(),
+    )
+    .with_max_retries(1);
+
+    let tags = call_structured_with_provider(call, provider)
+        .await
+        .expect("the second attempt returns a real payload");
+
+    assert_eq!(tags.tags.len(), 1, "the work survived the padded attempt");
+    assert_eq!(
+        server.hits(),
+        2,
+        "one padded attempt, then a successful one"
+    );
+}
+
+/// Separate defect found while reproducing the above: the tagging path sent
+/// **no `max_tokens`**. `StructuredCall::new` sets a default, then
+/// `with_params(extraction_params())` replaced the whole struct and dropped it
+/// — the exact hazard `openrouter/llm.rs` warns about.
+///
+/// Not cosmetic: it changes *routing*. Live check on
+/// `google/gemma-4-26b-a4b-it` — with `max_tokens: 32000` OpenRouter returns
+/// 404 "No endpoints found" for DeepInfra (its endpoint caps completions at
+/// 16384); with the field omitted, DeepInfra serves the call and the ceiling
+/// becomes whatever the upstream picks. A cap must always be sent, and for
+/// tagging it must be small enough to keep the endpoint pool intact.
+#[tokio::test]
+async fn every_structured_call_sends_an_output_cap() {
+    let config = ProviderConfig::from_settings(&Default::default());
+    let messages = [Message::user("tag this atom")];
+
+    // A caller that builds its own params and forgets a cap, as tagging did.
+    let forgetful = RawServer::start(ok_response()).await;
+    let call = StructuredCall::<ExtractionResult>::new(
+        &config,
+        "google/gemma-4-26b-a4b-it",
+        &messages,
+        "extraction_result",
+        extraction_schema(),
+    )
+    .with_params(
+        atomic_core::providers::types::GenerationParams::new()
+            .with_temperature(0.1)
+            .with_minimize_reasoning(true),
+    );
+    call_structured_with_provider(call, Arc::new(forgetful.provider()) as Arc<dyn LlmProvider>)
+        .await
+        .expect("mock returns valid tags");
+    assert_eq!(
+        forgetful
+            .last_request()
+            .get("max_tokens")
+            .and_then(|v| v.as_u64()),
+        Some(DEFAULT_MAX_OUTPUT_TOKENS as u64),
+        "a forgotten cap must fall back to the default, never to nothing"
+    );
+
+    // An explicit smaller cap is honoured as-is.
+    let explicit = RawServer::start(ok_response()).await;
+    let call = StructuredCall::<ExtractionResult>::new(
+        &config,
+        "google/gemma-4-26b-a4b-it",
+        &messages,
+        "extraction_result",
+        extraction_schema(),
+    )
+    .with_params(atomic_core::providers::types::GenerationParams::new().with_max_tokens(8192));
+    call_structured_with_provider(call, Arc::new(explicit.provider()) as Arc<dyn LlmProvider>)
+        .await
+        .expect("mock returns valid tags");
+    assert_eq!(
+        explicit
+            .last_request()
+            .get("max_tokens")
+            .and_then(|v| v.as_u64()),
+        Some(8192),
+    );
+}

--- a/crates/atomic-core/tests/gateway_truncated_response_tests.rs
+++ b/crates/atomic-core/tests/gateway_truncated_response_tests.rs
@@ -1,68 +1,22 @@
-//! Regression cover for the 2026-08-09 auto-tagging failure on
-//! `google/gemma-4-26b-a4b-it`:
+//! Regression cover for a 2026-08-09 auto-tagging failure that surfaced as
+//! `EOF while parsing a value at line 233 column 0` with a blank body preview.
 //!
-//! ```text
-//! INFO  Starting auto-tagging atom_id=7922b646… model=google/gemma-4-26b-a4b-it   [15:00:19.103]
-//! ERROR OpenRouter LLM parse error error=EOF while parsing a value at line 233
-//!       column 0 model=google/gemma-4-26b-a4b-it body_preview=                    [15:01:08.232]
-//! ```
+//! OpenRouter commits `200 OK` before the upstream produces anything, then
+//! keeps the connection alive with JSON whitespace ([`PADDING_UNIT`], captured
+//! verbatim; the payload that follows is compact, so every line in that serde
+//! error was padding). After the status is committed a late failure can't be
+//! reported as 5xx, so the gateway ends the body instead — and the client is
+//! left with a complete, well-formed 200 containing nothing.
 //!
-//! ## What the wire actually carries
+//! Whether that arrives as `Network` (stream cut) or `ParseError` (stream
+//! ended cleanly) turns only on the terminating chunk. Treating the second as
+//! permanent is what dropped the work. Both are transport failures now.
 //!
-//! Verified against live OpenRouter traffic (2026-08-09, this exact model and
-//! the exact request the tagging path builds):
-//!
-//! - OpenRouter pads **non-streaming** `/chat/completions` responses with
-//!   whitespace while it waits on the upstream. The unit is
-//!   [`PADDING_UNIT`] — captured verbatim; the body's only byte values are
-//!   `0x0a` and `0x20`. Padding appeared on **every** observed call (6–112
-//!   newlines).
-//! - The real JSON payload that follows is **compact — zero newlines**.
-//!   Therefore every line counted in a serde error on this path came from
-//!   padding, and nothing else. `line 233` means 232 padding newlines.
-//! - The cadence is [`PADDING_NEWLINES_PER_SEC`] ≈ 4.66/s, stable across
-//!   calls from 4.5s to 8 minutes. 232 newlines ⇒ ~49.8s of waiting; the
-//!   report's own timestamps span 49.13s. The body shape and the wall-clock
-//!   agree independently.
-//! - When a call goes wrong, padding is *all* that ever arrives: one captured
-//!   call ran 8 minutes and delivered 12288 bytes / 2235 newlines / no JSON.
-//!
-//! ## Why the gateway can only fail this way
-//!
-//! OpenRouter commits `HTTP/2 200` and sends headers *before* the upstream has
-//! produced anything (verified: a request cut after 3s had already returned
-//! full headers and a body of nothing but padding). After that commit no
-//! failure can be expressed as an HTTP status — the only exits are a JSON
-//! error body or simply ending the body. Ending it leaves the client holding
-//! whitespace. So *any* late fault, on *any* upstream, degrades into this
-//! shape. It is a property of the gateway, not of one provider.
-//!
-//! Note what the failing body does NOT contain: a `provider` field. The
-//! upstream that served a failed call is therefore unknowable from the
-//! response — but `x-generation-id` is in the *headers*, arrives before the
-//! body, and resolves via `GET /api/v1/generation?id=…` to the provider,
-//! timings, finish reason, and cost. It is now captured into the error and
-//! the log line (`providers::error::gateway_trace_id`).
-//!
-//! ## What these tests hold in place
-//!
-//! Both errors in the report are the same event, differing only in whether
-//! the terminating chunk arrived: `Network` ("error decoding response body",
-//! stream cut) or `ParseError` ("EOF while parsing a value", stream ended on
-//! padding). Classifying the second as permanent is what dropped the work —
-//! one attempt of a three-attempt budget, on a fault a retry fixes. Both are
-//! now transport failures, retryable and `Transient`.
-//!
-//! Worth knowing when reading a future report: OpenRouter records these as
-//! **successes**. Three deliberately abandoned calls came back
-//! `finish_reason: stop`, `cancelled: false`, fully billed — delivery is not
-//! modelled in a generation record, so the client seeing nothing leaves no
-//! trace on their side. An absence of errors in their dashboard is consistent
-//! with this failure, not evidence against it.
-//!
-//! What is NOT established: what tipped that particular request over. The
-//! report's `upstream_provider="DeepInfra"` belongs to the *previous,
-//! successful* call for a different atom, not to the failure.
+//! Two things worth knowing before re-diagnosing this: OpenRouter records
+//! these as billed successes, so an absence of errors in their dashboard is
+//! consistent with the failure rather than evidence against it; and the
+//! failing body carries no `provider` field, so the upstream is unknowable
+//! from the response alone — hence capturing `x-generation-id`.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -307,14 +261,11 @@ async fn padded_body_is_a_retryable_transport_failure() {
 }
 
 /// One event, two framings — cut mid-stream, or ended politely on padding.
-/// Both of the report's error lines are this. Neither may be permanent.
+/// Neither may be permanent.
 ///
-/// This is also where "why not just wait for the body?" is answered: we *do*
-/// wait. In the terminated case the wait **succeeded** — reqwest read the
-/// message to completion and handed us the whole body. That the body was
-/// whitespace is not something more waiting fixes; the server already said
-/// "that's all". Waiting is only meaningful while a stream is open, and
-/// neither of these is.
+/// Also answers "why not just wait for the body?": in the terminated case the
+/// wait *succeeded*. We read the whole message; it was whitespace. More
+/// waiting can't fix a stream the server already closed.
 #[tokio::test]
 async fn both_framings_of_a_delivered_nothing_are_retryable() {
     let cut = RawServer::start(cut_mid_body_response()).await;
@@ -401,17 +352,10 @@ async fn a_padded_first_attempt_now_recovers_on_retry() {
     );
 }
 
-/// Separate defect found while reproducing the above: the tagging path sent
-/// **no `max_tokens`**. `StructuredCall::new` sets a default, then
-/// `with_params(extraction_params())` replaced the whole struct and dropped it
-/// — the exact hazard `openrouter/llm.rs` warns about.
-///
-/// Not cosmetic: it changes *routing*. Live check on
-/// `google/gemma-4-26b-a4b-it` — with `max_tokens: 32000` OpenRouter returns
-/// 404 "No endpoints found" for DeepInfra (its endpoint caps completions at
-/// 16384); with the field omitted, DeepInfra serves the call and the ceiling
-/// becomes whatever the upstream picks. A cap must always be sent, and for
-/// tagging it must be small enough to keep the endpoint pool intact.
+/// The tagging path used to send no `max_tokens` at all — `with_params`
+/// replaced the struct that carried the default. Not cosmetic: OpenRouter
+/// filters endpoints by `max_completion_tokens`, so an absent cap silently
+/// widens the routable pool and an oversized one empties it.
 #[tokio::test]
 async fn every_structured_call_sends_an_output_cap() {
     let config = ProviderConfig::from_settings(&Default::default());

--- a/crates/atomic-server/tests/e2e_wiki.rs
+++ b/crates/atomic-server/tests/e2e_wiki.rs
@@ -713,13 +713,30 @@ fn section_ops_system_prompts(ctx: &TestCtx) -> Vec<String> {
     ctx.mock
         .chat_request_bodies()
         .iter()
-        .filter(|body| {
-            body.pointer("/response_format/json_schema/name")
-                .and_then(Value::as_str)
-                == Some("wiki_update_section_ops")
-        })
+        .filter(|body| is_section_ops_call(body))
         .filter_map(system_prompt_of)
         .collect()
+}
+
+/// Section ops keeps the schema off the wire (see `GENERATIVE_CALL_ENFORCEMENT`),
+/// so recognise the call by the schema it states in the prompt — the same
+/// `after_heading` marker the mock routes on. The wire-name check stays for any
+/// caller that still sends `response_format`.
+fn is_section_ops_call(body: &Value) -> bool {
+    if body
+        .pointer("/response_format/json_schema/name")
+        .and_then(Value::as_str)
+        == Some("wiki_update_section_ops")
+    {
+        return true;
+    }
+    body["messages"].as_array().is_some_and(|messages| {
+        messages.iter().any(|m| {
+            m["content"]
+                .as_str()
+                .is_some_and(|c| c.contains("after_heading"))
+        })
+    })
 }
 
 fn system_prompt_of(body: &Value) -> Option<String> {

--- a/crates/atomic-test-support/src/mock_ai.rs
+++ b/crates/atomic-test-support/src/mock_ai.rs
@@ -956,17 +956,22 @@ impl Respond for ChatResponder {
             return with_delay(response);
         }
 
-        // Schema-less requests are routed by sniffing the schema JSON that the
-        // caller stated in the prompt. Two paths arrive this way: the
-        // prompt-based fallback, and callers that deliberately keep
-        // `response_format` off the wire entirely (tag extraction — see
-        // `SchemaEnforcement::PromptOnly`). Distinctive property names are the
-        // discriminator, so order matters where schemas overlap: the
-        // consolidation schema also carries `parent_name`, and must be tested
-        // before the extraction arm claims it.
+        // Schema-less requests are routed by sniffing the schema the caller
+        // stated in the prompt. Two paths arrive this way: the prompt-based
+        // fallback, and every generative caller, which keeps `response_format`
+        // off the wire entirely (see `GENERATIVE_CALL_ENFORCEMENT`).
+        //
+        // Distinctive property names are the discriminator, so order matters
+        // where schemas overlap — consolidation also carries `parent_name` and
+        // must be tested before extraction claims it. A schema that reaches
+        // the fallback arm here answers `{}`, which surfaces as an unhelpful
+        // "parse failed" far from the cause, so add an arm when adding a
+        // generative call.
         let schema_name = wire_schema.unwrap_or_else(|| {
             if request_text.contains("after_heading") {
                 "wiki_update_section_ops".to_string()
+            } else if request_text.contains("winner_name") {
+                "merge_result".to_string()
             } else if request_text.contains("tags_to_remove") {
                 "consolidation_result".to_string()
             } else if request_text.contains("parent_name") {

--- a/crates/atomic-test-support/src/mock_ai.rs
+++ b/crates/atomic-test-support/src/mock_ai.rs
@@ -956,9 +956,21 @@ impl Respond for ChatResponder {
             return with_delay(response);
         }
 
+        // Schema-less requests are routed by sniffing the schema JSON that the
+        // caller stated in the prompt. Two paths arrive this way: the
+        // prompt-based fallback, and callers that deliberately keep
+        // `response_format` off the wire entirely (tag extraction — see
+        // `SchemaEnforcement::PromptOnly`). Distinctive property names are the
+        // discriminator, so order matters where schemas overlap: the
+        // consolidation schema also carries `parent_name`, and must be tested
+        // before the extraction arm claims it.
         let schema_name = wire_schema.unwrap_or_else(|| {
             if request_text.contains("after_heading") {
                 "wiki_update_section_ops".to_string()
+            } else if request_text.contains("tags_to_remove") {
+                "consolidation_result".to_string()
+            } else if request_text.contains("parent_name") {
+                "extraction_result".to_string()
             } else {
                 String::new()
             }


### PR DESCRIPTION
Two provider failures that reach us **looking like successes**, found from one bug report. Neither raises an error, neither is retried, and both end with work silently missing — an atom with no tags, a wiki article that never updated, duplicate tags that never merged.

---

# 1. A padded 200 is a truncated transfer, not a parse failure

The report: auto-tagging failing on `google/gemma-4-26b-a4b-it` with `EOF while parsing a value at line 233 column 0`, a **blank** body preview, and nothing at all in the user's OpenRouter dashboard.

### What's on the wire

OpenRouter fronts slow upstreams with a Cloudflare Worker that must return a response object immediately, so it commits `200 OK` + `Transfer-Encoding: chunked` **before the upstream has produced anything**, then keeps the connection alive with insignificant JSON whitespace:

```
t=0.320s   HTTP/1.1 200 OK   Transfer-Encoding: chunked   X-Generation-Id: gen-…
t=0.487s   16 bytes of whitespace
t=0.912s   16 bytes of whitespace        <- every ~425ms
   …
t=4.721s   the actual JSON, all at once
```

Whitespace works because RFC 8259 permits it before the top-level value — a compliant parser cannot see it. Once that status is committed it can't be retracted, so a late failure can only be an error object in the body or an ended stream. **Ending it leaves a complete, well-formed 200 whose entire body is padding.**

That's a transport failure wearing a parse error's clothes. We classified it permanent, so auto-tagging spent one attempt of a three-attempt budget and dropped the atom. The identical event cut a moment earlier arrives as `Network` and is retried — only the politely-terminated form was fatal.

### Evidence

- Padding on **every** non-streaming call observed (15/15), 6–112 newlines.
- The JSON payload contains **zero** newlines, so every line in that serde error was padding. `line 233` = 232 padding newlines.
- Cadence 4.66 newlines/sec, stable from 4.5s calls to an 8-minute one ⇒ 232 newlines implies ~49.8s. The report's timestamps span **49.13s**.
- A real hang delivered 12288 bytes / 2235 newlines / no JSON over 8 minutes.
- Not our 300s timeout: that would have cut at ~1400 newlines.

**Why their dashboard was clean.** Three deliberately abandoned calls came back `finish_reason: stop`, `cancelled: false`, fully billed. A generation record models the upstream generation, not delivery, so this failure class is invisible there and lands as a billable success. An absence of errors is a *prediction* of this diagnosis, not a contradiction. The failing body also carries no `provider` field, so the report's `upstream_provider="DeepInfra"` belongs to the previous, successful call — **no upstream is implicated.**

### The fix

`decode_error` uses serde_json's `Category::Eof` as the line: input ran out (empty, all padding, or cut mid-JSON) ⇒ truncated transfer ⇒ retryable `Network` + `Transient` for schedulers. `Syntax`/`Data` mean bytes arrived and were wrong ⇒ still a permanent `ParseError`. Applied to both chat and both embedding paths, plus:

- **Both streaming parsers** returned `Ok` with empty content when a stream carried no payload, persisting silence as if the model chose it. Guarded on "no SSE payload *and* no terminator", so a legitimately empty completion is untouched.
- **The chat path** had no handling for a 200 carrying an error object — the gateway's other exit. `choices` is required, so it landed as a permanent parse failure. The embedding path's handling is now shared via `upstream_error`.
- **`x-generation-id` is captured** into the error and log line. It arrives in the headers, so it survives the failures the body doesn't, and resolves via `GET /api/v1/generation?id=…` to provider, timings, finish reason and cost.
- **Previews are no longer logged raw** — that's why the field was blank. Whitespace bodies are described (`<2552 bytes of gateway padding, 232 newlines, no payload>`), everything else escaped.
- **Tagging sent no `max_tokens` at all** (`with_params` replaced the struct carrying the default). This changes *routing* — OpenRouter filters endpoints by `max_completion_tokens`, so an absent cap widens the pool and an oversized one empties it (pinned to DeepInfra: 32000 → `404 No endpoints found`, 8192 → serves). `call_structured` now guarantees a cap; tagging sets 8192.

---

# 2. Generative structured calls come off wire-level schema enforcement

Chasing the first bug surfaced DeepInfra returning `{"tags": []}` for content every other endpoint tagged fine — 8 completion tokens, `finish_reason: stop`, zero reasoning tokens, no error signal anywhere.

It generalises by the *shape of the call*, not the endpoint. Where the model decides how much to emit and an empty result is legal, a constrained decoder can take the shortest grammar-valid path and return nothing. That parses, satisfies the schema, fires no fallback, and is indistinguishable from a considered "nothing to do".

### Measurements

Pinned to DeepInfra, `gemma-4-26b-a4b-it`, 6 calls per cell, on inputs whose correct answer is unambiguously non-empty (planted duplicates, planted new source material):

| call | wire-level | prompt-only |
|---|---|---|
| tag extraction | **5/6 empty** | 0/6 |
| tag merge | **2/6 empty** | 0/6 |
| wiki section ops | **3/6 no-op** | 0/6 |
| tag consolidation | 0/6 | 0/6 |

Pinning matters: an unpinned run showed almost none of this, because OpenRouter routes around the weak endpoint most of the time. That's also why it reaches users as rare, unreproducible gaps rather than as a bug.

The trade is a decoding guarantee for the tolerant parser, and the parser was measured never to be exercised — across `gpt-5-nano`, `gemma-4-26b-a4b-it`, `gpt-5-mini` and `glm-5.2`, all 24 prompt-mode replies parsed directly, no fences, no surrounding prose.

### The change

`SchemaEnforcement` makes the transport explicit — `Strict` and `Lenient` send `response_format`, `PromptOnly` sends none. `with_strict` remains shorthand over the two wire-level modes so it can't silently reach a different transport. One policy constant, `GENERATIVE_CALL_ENFORCEMENT`, covers all five generative call sites.

Consolidation never degraded and moves anyway: one rule beats four, prompt-only measured zero cost, and "didn't collapse on one input" isn't immunity. **Closed-shape calls are explicitly out of scope** — one enum choice, fixed-arity object — where there's no volume for a decoder to shorten and constrained decoding is free.

This also corrects a claim in `call_long_form_markdown`'s docs that short structured calls "genuinely benefit from constrained decoding". True of shaping, not of generating.

### The instruction had to be fixed first

Prompt-only originally stated the contract as "reply with a JSON object matching this schema" followed by the JSON Schema. A schema is itself JSON, so that has a literal reading and small models take it: `llama3.2` returned the *schema*, answer nested under `properties`, in half of replies.

`schema_instruction` now leads with a concrete example derived from the schema — leaves replaced by `<placeholder>` text from each field's description, enums rendered as their alternatives — keeping the schema behind it for constraints an example can't express. Placeholders rather than invented values on purpose: invented values get copied, and for an enum whose first variant is the do-nothing case (`wiki_update_section_ops`) a "realistic" example would point straight at the degenerate answer.

```
llama3.2, no grammar, first-attempt valid:
  schema document only    3–4 of 8
  example only            8 of 8
  example + schema        8 of 8
```

This improves every caller, not just the ones that moved: the prompt-based fallback is where wire-level calls land when a primary parse fails.

---

## Testing

- **535 tests pass** across 11 suites; workspace checks clean.
- Clippy and rustfmt verified **per file against `main`** — zero new diffs. `structured.rs` carries 8 rustfmt diffs and `wiki/mod.rs` one clippy warning that both pre-date this branch; left alone rather than buried in the diff.
- `gateway_truncated_response_tests.rs` — 5 tests built from **captured wire bytes** and real chunked framing, including the padding unit verbatim. Covers: padded body is transient; both framings agree; a payload-less stream fails instead of returning empty; a padded first attempt **recovers on retry**; every structured call sends a cap.
- Unit tests pin that `PromptOnly` puts no `response_format` on the wire, states the shape before the schema, never names a single enum variant, and absorbs a fenced reply without spending the fallback.
- Live end-to-end across all three provider families: `gemma-4-26b-a4b-it` and `gpt-5-nano` via OpenRouter, `llama3.2` via native Ollama (8/8 first-attempt valid), and the OpenAI-compatible provider against Ollama's `/v1` surface (6/6, no empty extractions).

One test-side consequence worth knowing: `MockAiServer` routed by wire schema name, so removing `response_format` made 8 tests fall through to `{}`. It now sniffs the schema stated in the prompt, with consolidation checked before extraction since both carry `parent_name`.

## Not addressed

- The 300s client timeout is untouched — nothing in the evidence implicates it.
- What tipped that specific request over is unknown and not determinable from the log, which is exactly what capturing the generation id fixes for next time.
- An empty extraction still records `tagging_status = complete`, so if a provider does return nothing the atom is silently untagged and never retried. Change 2 removes the cause we measured, not the blind spot. Worth a follow-up that records empties distinctly — `tagging_status` is plain TEXT with no CHECK constraint, so no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
