### PR TITLE
feat: add OrcaRouter as a named AI provider

### DIFF
--- a/crates/atomic-cloud/src/tenant_plane.rs
+++ b/crates/atomic-cloud/src/tenant_plane.rs
@@ -196,7 +196,10 @@ use std::time::Duration;
 use actix_web::middleware::from_fn;
 use actix_web::{web, HttpMessage, HttpRequest, HttpResponse};
 use atomic_core::providers::openrouter::models as openrouter_models;
-use atomic_core::providers::{create_embedding_provider, EmbeddingConfig, OpenRouterProvider};
+use atomic_core::providers::{
+    create_embedding_provider, EmbeddingConfig, OpenAICompatProvider, OpenRouterProvider,
+    ORCAROUTER_DEFAULT_BASE_URL,
+};
 use atomic_core::{ProviderConfig, ProviderType};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -1396,6 +1399,7 @@ async fn validate_provider_key(config: &ProviderConfig) -> Result<(), String> {
         match config.provider_type {
             ProviderType::OpenRouter => validate_openrouter_key(config).await,
             ProviderType::OpenAICompat => validate_openai_compat_key(config).await,
+            ProviderType::OrcaRouter => validate_orca_router_key(config).await,
             // Unreachable from these routes (`Provider` has no Ollama
             // variant); typed refusal rather than a panic if that changes.
             ProviderType::Ollama => Err("Ollama is not available in cloud".to_string()),
@@ -1461,6 +1465,39 @@ async fn validate_openai_compat_key(config: &ProviderConfig) -> Result<(), Strin
             tracing::warn!(error = %e, "openai-compatible BYOK validation failed");
             "the provider rejected the request".to_string()
         })
+}
+
+/// Validate an OrcaRouter key against OrcaRouter's fixed gateway. Unlike
+/// OpenRouter/OpenAI-compat there is no tenant-supplied base URL — the
+/// gateway endpoint is a constant (`ORCAROUTER_DEFAULT_BASE_URL`), so the
+/// key-introspection request goes to OrcaRouter itself and never to a
+/// tenant-controlled host. `GET /v1/models` returns 401 for a bad key and
+/// 200 for a good one; report the status code only, never the body.
+async fn validate_orca_router_key(config: &ProviderConfig) -> Result<(), String> {
+    let Some(api_key) = config.orcarouter_api_key.clone() else {
+        return Err("OrcaRouter API key not configured".to_string());
+    };
+    let provider = OpenAICompatProvider::new(
+        ORCAROUTER_DEFAULT_BASE_URL.to_string(),
+        Some(api_key),
+        Some(config.orcarouter_timeout_secs),
+    );
+    let url = format!("{}/models", provider.base_url());
+    let response = provider
+        .client()
+        .get(&url)
+        .bearer_auth(provider.api_key().unwrap_or_default())
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    let status = response.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    Err(format!(
+        "OrcaRouter rejected the request (HTTP {})",
+        status.as_u16()
+    ))
 }
 
 /// Best-effort managed-key allowance usage for the status route. `null`

--- a/crates/atomic-core/src/agent.rs
+++ b/crates/atomic-core/src/agent.rs
@@ -279,6 +279,7 @@ fn resolve_chat_model(
     let model = match provider_config.provider_type {
         ProviderType::Ollama => provider_config.llm_model().to_string(),
         ProviderType::OpenAICompat => provider_config.llm_model().to_string(),
+        ProviderType::OrcaRouter => provider_config.llm_model().to_string(),
         ProviderType::OpenRouter => settings
             .get("chat_model")
             .cloned()

--- a/crates/atomic-core/src/lib.rs
+++ b/crates/atomic-core/src/lib.rs
@@ -1940,6 +1940,7 @@ impl AtomicCore {
         let model = match config.provider_type {
             ProviderType::Ollama => config.llm_model().to_string(),
             ProviderType::OpenAICompat => config.llm_model().to_string(),
+            ProviderType::OrcaRouter => config.llm_model().to_string(),
             ProviderType::OpenRouter => settings_map
                 .get("wiki_model")
                 .cloned()
@@ -3093,7 +3094,7 @@ impl AtomicCore {
         let settings_map = self.settings_for_ai().await?;
         let provider_config = ProviderConfig::from_settings(&settings_map);
         let model = match provider_config.provider_type {
-            ProviderType::Ollama | ProviderType::OpenAICompat => {
+            ProviderType::Ollama | ProviderType::OpenAICompat | ProviderType::OrcaRouter => {
                 provider_config.llm_model().to_string()
             }
             ProviderType::OpenRouter => settings_map
@@ -3932,6 +3933,10 @@ impl AtomicCore {
         match config.provider_type {
             ProviderType::OpenRouter => Ok(config
                 .openrouter_api_key
+                .as_ref()
+                .map_or(false, |k| !k.is_empty())),
+            ProviderType::OrcaRouter => Ok(config
+                .orcarouter_api_key
                 .as_ref()
                 .map_or(false, |k| !k.is_empty())),
             ProviderType::Ollama => Ok(!config.ollama_host.is_empty()),

--- a/crates/atomic-core/src/providers/mod.rs
+++ b/crates/atomic-core/src/providers/mod.rs
@@ -32,6 +32,7 @@ pub use traits::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProviderType {
     OpenRouter,
+    OrcaRouter,
     Ollama,
     OpenAICompat,
 }
@@ -39,6 +40,7 @@ pub enum ProviderType {
 impl ProviderType {
     pub fn from_string(s: &str) -> Self {
         match s.to_lowercase().as_str() {
+            "orcarouter" => ProviderType::OrcaRouter,
             "ollama" => ProviderType::Ollama,
             "openai_compat" => ProviderType::OpenAICompat,
             _ => ProviderType::OpenRouter,
@@ -50,6 +52,23 @@ impl ProviderType {
 /// resolves to this unless explicitly overridden (proxies, gateways, or test
 /// servers that speak the same API).
 pub const OPENROUTER_DEFAULT_BASE_URL: &str = "https://openrouter.ai/api/v1";
+
+/// Default OrcaRouter API endpoint. OrcaRouter is an OpenAI-compatible model
+/// routing gateway; its API surface matches the OpenAI-compatible provider
+/// (chat completions, embeddings, streaming, tool calls, structured outputs),
+/// so the transport is shared with [`OpenAICompatProvider`] while this fixed
+/// base URL and the [`ProviderConfig::orcarouter_api_key`] credential keep it
+/// a named provider users can select directly.
+pub const ORCAROUTER_DEFAULT_BASE_URL: &str = "https://api.orcarouter.ai/v1";
+
+/// Default OrcaRouter embedding model. `text-embedding-3-small` returns 1536
+/// dimensions natively, matching the vector schema the rest of the stack
+/// assumes, and is part of OrcaRouter's catalog.
+pub const ORCAROUTER_DEFAULT_EMBEDDING_MODEL: &str = "openai/text-embedding-3-small";
+
+/// Default OrcaRouter **utility** model for single-shot structured tasks
+/// (tagging). Part of OrcaRouter's catalog.
+pub const ORCAROUTER_DEFAULT_LLM_MODEL: &str = "openai/gpt-5-nano";
 
 /// The default embedding model (OpenRouter provider). Qwen3-Embedding-8B is the
 /// top open-weight retrieval model on MTEB, the cheapest embedding on
@@ -102,6 +121,23 @@ pub struct ProviderConfig {
     pub openrouter_agentic_model: String,
     /// User-specified context length override. None = use model default from API cache.
     pub openrouter_context_length: Option<usize>,
+    // OrcaRouter settings
+    /// OrcaRouter API key (keys start with `sk-orca-`). The provider hits the
+    /// fixed [`ORCAROUTER_DEFAULT_BASE_URL`] via the shared OpenAI-compatible
+    /// transport; this credential is what makes it a named provider rather than
+    /// a generic `openai_compat` base-URL entry.
+    pub orcarouter_api_key: Option<String>,
+    /// The **utility** LLM for single-shot tagging.
+    pub orcarouter_llm_model: String,
+    /// The **agentic** LLM for tool-using loops — wiki, chat, reports. Kept
+    /// distinct from [`orcarouter_llm_model`](Self::orcarouter_llm_model) so
+    /// tagging can run on a cheap model while agent loops use a capable one.
+    pub orcarouter_agentic_model: String,
+    /// The embedding model. Defaults to [`ORCAROUTER_DEFAULT_EMBEDDING_MODEL`]
+    /// (1536 dims, matching the vector schema).
+    pub orcarouter_embedding_model: String,
+    pub orcarouter_context_length: usize,
+    pub orcarouter_timeout_secs: u64,
     // Ollama settings
     pub ollama_host: String,
     pub ollama_embedding_model: String,
@@ -137,6 +173,15 @@ impl std::fmt::Debug for ProviderConfig {
             .field("openrouter_llm_model", &self.openrouter_llm_model)
             .field("openrouter_agentic_model", &self.openrouter_agentic_model)
             .field("openrouter_context_length", &self.openrouter_context_length)
+            .field("orcarouter_api_key", &redacted(&self.orcarouter_api_key))
+            .field("orcarouter_llm_model", &self.orcarouter_llm_model)
+            .field("orcarouter_agentic_model", &self.orcarouter_agentic_model)
+            .field(
+                "orcarouter_embedding_model",
+                &self.orcarouter_embedding_model,
+            )
+            .field("orcarouter_context_length", &self.orcarouter_context_length)
+            .field("orcarouter_timeout_secs", &self.orcarouter_timeout_secs)
             .field("ollama_host", &self.ollama_host)
             .field("ollama_embedding_model", &self.ollama_embedding_model)
             .field("ollama_llm_model", &self.ollama_llm_model)
@@ -204,6 +249,33 @@ impl ProviderConfig {
                     s.parse().ok()
                 }
             }),
+            orcarouter_api_key: settings
+                .get("orcarouter_api_key")
+                .cloned()
+                .filter(|k| !k.is_empty()),
+            orcarouter_llm_model: settings
+                .get("orcarouter_llm_model")
+                .cloned()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| ORCAROUTER_DEFAULT_LLM_MODEL.to_string()),
+            orcarouter_agentic_model: settings
+                .get("orcarouter_agentic_model")
+                .cloned()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| ORCAROUTER_DEFAULT_LLM_MODEL.to_string()),
+            orcarouter_embedding_model: settings
+                .get("orcarouter_embedding_model")
+                .cloned()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| ORCAROUTER_DEFAULT_EMBEDDING_MODEL.to_string()),
+            orcarouter_context_length: settings
+                .get("orcarouter_context_length")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(65536),
+            orcarouter_timeout_secs: settings
+                .get("orcarouter_timeout_secs")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(300),
             ollama_host: settings
                 .get("ollama_host")
                 .cloned()
@@ -283,6 +355,7 @@ impl ProviderConfig {
             ProviderType::OpenRouter => "openrouter",
             ProviderType::Ollama => "ollama",
             ProviderType::OpenAICompat => "openai_compat",
+            ProviderType::OrcaRouter => "orcarouter",
         };
         settings.insert("provider".to_string(), provider.to_string());
 
@@ -311,6 +384,31 @@ impl ProviderConfig {
             Some(len) => settings.insert("openrouter_context_length".to_string(), len.to_string()),
             None => settings.remove("openrouter_context_length"),
         };
+
+        match &self.orcarouter_api_key {
+            Some(key) => settings.insert("orcarouter_api_key".to_string(), key.clone()),
+            None => settings.remove("orcarouter_api_key"),
+        };
+        settings.insert(
+            "orcarouter_embedding_model".to_string(),
+            self.orcarouter_embedding_model.clone(),
+        );
+        settings.insert(
+            "orcarouter_llm_model".to_string(),
+            self.orcarouter_llm_model.clone(),
+        );
+        settings.insert(
+            "orcarouter_agentic_model".to_string(),
+            self.orcarouter_agentic_model.clone(),
+        );
+        settings.insert(
+            "orcarouter_context_length".to_string(),
+            self.orcarouter_context_length.to_string(),
+        );
+        settings.insert(
+            "orcarouter_timeout_secs".to_string(),
+            self.orcarouter_timeout_secs.to_string(),
+        );
 
         settings.insert("ollama_host".to_string(), self.ollama_host.clone());
         settings.insert(
@@ -364,6 +462,7 @@ impl ProviderConfig {
     pub fn embedding_model(&self) -> &str {
         match self.provider_type {
             ProviderType::OpenRouter => &self.openrouter_embedding_model,
+            ProviderType::OrcaRouter => &self.orcarouter_embedding_model,
             ProviderType::Ollama => &self.ollama_embedding_model,
             ProviderType::OpenAICompat => &self.openai_compat_embedding_model,
         }
@@ -371,10 +470,11 @@ impl ProviderConfig {
 
     /// The utility LLM for the current provider — single-shot tasks (tagging).
     /// For OpenRouter this is the cheap [`openrouter_llm_model`](Self::openrouter_llm_model);
-    /// single-model providers use their one LLM.
+    /// for OrcaRouter its utility slot; single-model providers use their one LLM.
     pub fn llm_model(&self) -> &str {
         match self.provider_type {
             ProviderType::OpenRouter => &self.openrouter_llm_model,
+            ProviderType::OrcaRouter => &self.orcarouter_llm_model,
             ProviderType::Ollama => &self.ollama_llm_model,
             ProviderType::OpenAICompat => &self.openai_compat_llm_model,
         }
@@ -382,12 +482,13 @@ impl ProviderConfig {
 
     /// The agentic LLM for the current provider — tool-using loops (wiki, chat,
     /// reports). For OpenRouter this is the distinct
-    /// [`openrouter_agentic_model`](Self::openrouter_agentic_model); Ollama and
-    /// OpenAI-compat have a single LLM, so it coincides with
-    /// [`llm_model`](Self::llm_model).
+    /// [`openrouter_agentic_model`](Self::openrouter_agentic_model); OrcaRouter
+    /// keeps a distinct agentic slot; Ollama and OpenAI-compat have a single
+    /// LLM, so it coincides with [`llm_model`](Self::llm_model).
     pub fn agentic_model(&self) -> &str {
         match self.provider_type {
             ProviderType::OpenRouter => &self.openrouter_agentic_model,
+            ProviderType::OrcaRouter => &self.orcarouter_agentic_model,
             ProviderType::Ollama => &self.ollama_llm_model,
             ProviderType::OpenAICompat => &self.openai_compat_llm_model,
         }
@@ -399,6 +500,14 @@ impl ProviderConfig {
             ProviderType::OpenRouter => {
                 openrouter::models::get_embedding_dimension(&self.openrouter_embedding_model)
                     .unwrap_or(1536) // Fall back to 1536 for unknown models
+            }
+            ProviderType::OrcaRouter => {
+                // OrcaRouter serves the same embedding model ids as the curated
+                // registry (text-embedding-3-small/large, ada-002, gemini-embedding),
+                // so the lookup resolves authoritative widths; 1536 matches the
+                // vector schema default.
+                openrouter::models::get_embedding_dimension(&self.orcarouter_embedding_model)
+                    .unwrap_or(1536)
             }
             ProviderType::Ollama => ollama::get_embedding_dimension(&self.ollama_embedding_model),
             ProviderType::OpenAICompat => self.openai_compat_embedding_dimension,
@@ -433,6 +542,7 @@ impl ProviderConfig {
                     .get(&self.openrouter_llm_model)
                     .copied()
             }
+            ProviderType::OrcaRouter => Some(self.orcarouter_context_length),
             ProviderType::Ollama => Some(self.ollama_context_length),
             ProviderType::OpenAICompat => Some(self.openai_compat_context_length),
         }
@@ -468,6 +578,16 @@ pub fn create_embedding_provider(
                 config.openrouter_base_url.clone(),
             )))
         }
+        ProviderType::OrcaRouter => {
+            let api_key = config.orcarouter_api_key.clone().ok_or_else(|| {
+                ProviderError::Configuration("OrcaRouter API key not configured".to_string())
+            })?;
+            Ok(Arc::new(OpenAICompatProvider::new(
+                ORCAROUTER_DEFAULT_BASE_URL.to_string(),
+                Some(api_key),
+                Some(config.orcarouter_timeout_secs),
+            )))
+        }
         ProviderType::Ollama => Ok(Arc::new(OllamaProvider::new(
             Some(config.ollama_host.clone()),
             Some(config.ollama_timeout_secs),
@@ -497,6 +617,16 @@ pub fn create_llm_provider(config: &ProviderConfig) -> Result<Arc<dyn LlmProvide
             Ok(Arc::new(OpenRouterProvider::with_base_url(
                 api_key,
                 config.openrouter_base_url.clone(),
+            )))
+        }
+        ProviderType::OrcaRouter => {
+            let api_key = config.orcarouter_api_key.clone().ok_or_else(|| {
+                ProviderError::Configuration("OrcaRouter API key not configured".to_string())
+            })?;
+            Ok(Arc::new(OpenAICompatProvider::new(
+                ORCAROUTER_DEFAULT_BASE_URL.to_string(),
+                Some(api_key),
+                Some(config.orcarouter_timeout_secs),
             )))
         }
         ProviderType::Ollama => Ok(Arc::new(OllamaProvider::new(
@@ -530,6 +660,16 @@ pub fn create_streaming_llm_provider(
             Ok(Arc::new(OpenRouterProvider::with_base_url(
                 api_key,
                 config.openrouter_base_url.clone(),
+            )))
+        }
+        ProviderType::OrcaRouter => {
+            let api_key = config.orcarouter_api_key.clone().ok_or_else(|| {
+                ProviderError::Configuration("OrcaRouter API key not configured".to_string())
+            })?;
+            Ok(Arc::new(OpenAICompatProvider::new(
+                ORCAROUTER_DEFAULT_BASE_URL.to_string(),
+                Some(api_key),
+                Some(config.orcarouter_timeout_secs),
             )))
         }
         ProviderType::Ollama => Ok(Arc::new(OllamaProvider::new(
@@ -806,6 +946,10 @@ mod tests {
             "compat-super-secret".to_string(),
         );
         settings.insert(
+            "orcarouter_api_key".to_string(),
+            "sk-orca-super-secret".to_string(),
+        );
+        settings.insert(
             "embedding_model".to_string(),
             "openai/text-embedding-3-small".to_string(),
         );
@@ -821,6 +965,10 @@ mod tests {
             assert!(
                 !rendered.contains("compat-super-secret"),
                 "Debug output leaked the OpenAI-compat key: {rendered}"
+            );
+            assert!(
+                !rendered.contains("sk-orca-super-secret"),
+                "Debug output leaked the OrcaRouter key: {rendered}"
             );
             assert!(
                 rendered.contains("[redacted]"),
@@ -865,6 +1013,12 @@ mod tests {
         config.openai_compat_embedding_dimension = 768;
         config.openai_compat_context_length = 4321;
         config.openai_compat_timeout_secs = 99;
+        config.orcarouter_api_key = Some("key-orca".to_string());
+        config.orcarouter_embedding_model = "orca-embed".to_string();
+        config.orcarouter_llm_model = "orca-llm".to_string();
+        config.orcarouter_agentic_model = "orca-agentic".to_string();
+        config.orcarouter_context_length = 2468;
+        config.orcarouter_timeout_secs = 42;
 
         let mut settings: HashMap<String, String> = HashMap::new();
         settings.insert("provider".to_string(), "ollama".to_string());
@@ -928,5 +1082,83 @@ mod tests {
         assert_eq!(config.provider_type, ProviderType::OpenRouter); // Default
         assert_eq!(config.openrouter_embedding_model, DEFAULT_EMBEDDING_MODEL);
         assert_eq!(config.ollama_host, "http://127.0.0.1:11434");
+    }
+
+    #[test]
+    fn test_provider_config_from_settings_orcarouter() {
+        let mut settings: HashMap<String, String> = HashMap::new();
+        settings.insert("provider".to_string(), "orcarouter".to_string());
+        settings.insert("orcarouter_api_key".to_string(), "sk-orca-test".to_string());
+        settings.insert(
+            "orcarouter_embedding_model".to_string(),
+            "openai/text-embedding-3-large".to_string(),
+        );
+        settings.insert("orcarouter_llm_model".to_string(), "anthropic/claude-sonnet-5".to_string());
+        settings.insert("orcarouter_agentic_model".to_string(), "anthropic/claude-sonnet-5".to_string());
+
+        let config = ProviderConfig::from_settings(&settings);
+
+        assert_eq!(config.provider_type, ProviderType::OrcaRouter);
+        assert_eq!(config.orcarouter_api_key, Some("sk-orca-test".to_string()));
+        assert_eq!(
+            config.embedding_model(),
+            "openai/text-embedding-3-large"
+        );
+        assert_eq!(config.llm_model(), "anthropic/claude-sonnet-5");
+        assert_eq!(config.agentic_model(), "anthropic/claude-sonnet-5");
+        // text-embedding-3-large is registered at 3072 dims in the curated
+        // embedding registry, and OrcaRouter serves the same model id.
+        assert_eq!(config.embedding_dimension(), 3072);
+    }
+
+    #[test]
+    fn test_orcarouter_defaults() {
+        let mut settings: HashMap<String, String> = HashMap::new();
+        settings.insert("provider".to_string(), "orcarouter".to_string());
+        let config = ProviderConfig::from_settings(&settings);
+
+        assert_eq!(config.provider_type, ProviderType::OrcaRouter);
+        assert_eq!(config.orcarouter_api_key, None);
+        assert_eq!(
+            config.embedding_model(),
+            ORCAROUTER_DEFAULT_EMBEDDING_MODEL
+        );
+        assert_eq!(config.llm_model(), ORCAROUTER_DEFAULT_LLM_MODEL);
+        assert_eq!(config.embedding_dimension(), 1536);
+        assert_eq!(config.orcarouter_context_length, 65536);
+    }
+
+    #[test]
+    fn test_orcarouter_from_string() {
+        assert_eq!(ProviderType::from_string("orcarouter"), ProviderType::OrcaRouter);
+        assert_eq!(ProviderType::from_string("OrcaRouter"), ProviderType::OrcaRouter);
+    }
+
+    #[test]
+    fn test_orcarouter_factory_targets_orca_base_url() {
+        // The OrcaRouter provider is the shared OpenAI-compatible transport
+        // pinned to OrcaRouter's endpoint — same normalization, fixed base URL.
+        let mut settings: HashMap<String, String> = HashMap::new();
+        settings.insert("provider".to_string(), "orcarouter".to_string());
+        settings.insert("orcarouter_api_key".to_string(), "sk-orca-test".to_string());
+        let config = ProviderConfig::from_settings(&settings);
+
+        assert!(create_llm_provider(&config).is_ok());
+        assert!(create_embedding_provider(&config).is_ok());
+        assert!(create_streaming_llm_provider(&config).is_ok());
+
+        // Missing key fails with a clear message, mirroring OpenRouter.
+        let no_key = ProviderConfig::from_settings(&HashMap::new());
+        assert!(create_llm_provider(&no_key).is_err());
+
+        // The transport is the OpenAI-compatible client against the fixed
+        // OrcaRouter base URL (normalization keeps an explicit `/v1` verbatim).
+        let provider = OpenAICompatProvider::new(
+            ORCAROUTER_DEFAULT_BASE_URL.to_string(),
+            Some("sk-orca-test".to_string()),
+            None,
+        );
+        assert_eq!(provider.base_url(), ORCAROUTER_DEFAULT_BASE_URL);
+        assert_eq!(provider.api_key(), Some("sk-orca-test"));
     }
 }

--- a/crates/atomic-core/src/reports/agentic.rs
+++ b/crates/atomic-core/src/reports/agentic.rs
@@ -526,6 +526,7 @@ async fn resolve_model(core: &AtomicCore) -> Result<(ProviderConfig, String), At
     let model = match config.provider_type {
         ProviderType::Ollama => config.llm_model().to_string(),
         ProviderType::OpenAICompat => config.llm_model().to_string(),
+        ProviderType::OrcaRouter => config.llm_model().to_string(),
         ProviderType::OpenRouter => settings
             .get("wiki_model")
             .cloned()

--- a/crates/atomic-core/src/settings.rs
+++ b/crates/atomic-core/src/settings.rs
@@ -22,6 +22,7 @@ pub const WORKSPACE_ONLY_KEYS: &[&str] = &[
     // Credentials — one set per user/account
     "openrouter_api_key",
     "openai_compat_api_key",
+    "orcarouter_api_key",
     // Machine-level URLs — one host per machine
     "ollama_host",
     "openai_compat_base_url",
@@ -40,6 +41,7 @@ pub const EMBEDDING_SPACE_KEYS: &[&str] = &[
     "ollama_embedding_model",
     "openai_compat_embedding_model",
     "openai_compat_embedding_dimension",
+    "orcarouter_embedding_model",
 ];
 
 /// True if `key` affects the embedding vector space.
@@ -73,6 +75,11 @@ pub const DEFAULT_SETTINGS: &[(&str, &str)] = &[
     ("openai_compat_embedding_dimension", "1536"),
     ("openai_compat_context_length", "65536"),
     ("openai_compat_timeout_secs", "300"), // 5 minutes default for OpenAI-compatible servers
+    ("orcarouter_embedding_model", crate::providers::ORCAROUTER_DEFAULT_EMBEDDING_MODEL),
+    ("orcarouter_llm_model", crate::providers::ORCAROUTER_DEFAULT_LLM_MODEL),
+    ("orcarouter_agentic_model", crate::providers::ORCAROUTER_DEFAULT_LLM_MODEL),
+    ("orcarouter_context_length", "65536"),
+    ("orcarouter_timeout_secs", "300"), // 5 minutes default for OrcaRouter
     ("wiki_generation_prompt", ""),
     ("wiki_update_prompt", ""),
     ("chat_prompt", ""),

--- a/crates/atomic-server/src/lib.rs
+++ b/crates/atomic-server/src/lib.rs
@@ -81,6 +81,7 @@ use utoipa::OpenApi;
         routes::settings::clear_setting_override,
         routes::settings::list_setting_overrides,
         routes::settings::test_openrouter_connection,
+        routes::settings::test_orcarouter_connection,
         routes::settings::test_openai_compat_connection,
         routes::settings::get_available_llm_models,
         routes::settings::get_openrouter_embedding_models,

--- a/crates/atomic-server/src/routes/mod.rs
+++ b/crates/atomic-server/src/routes/mod.rs
@@ -190,6 +190,10 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
         web::post().to(settings::test_openrouter_connection),
     );
     cfg.route(
+        "/settings/test-orcarouter",
+        web::post().to(settings::test_orcarouter_connection),
+    );
+    cfg.route(
         "/settings/models",
         web::get().to(settings::get_available_llm_models),
     );

--- a/crates/atomic-server/src/routes/settings.rs
+++ b/crates/atomic-server/src/routes/settings.rs
@@ -180,6 +180,45 @@ pub async fn test_openrouter_connection(body: web::Json<TestOpenRouterBody>) -> 
 }
 
 #[derive(Deserialize, Serialize, ToSchema)]
+pub struct TestOrcaRouterBody {
+    /// OrcaRouter API key to test
+    pub api_key: String,
+}
+
+#[utoipa::path(post, path = "/api/settings/test-orcarouter", request_body = TestOrcaRouterBody, responses((status = 200, description = "Connection successful"), (status = 400, description = "API error", body = ApiErrorResponse)), tag = "settings")]
+pub async fn test_orcarouter_connection(body: web::Json<TestOrcaRouterBody>) -> HttpResponse {
+    // Validate the key against OrcaRouter's `/v1/models` endpoint rather than a
+    // real chat completion. This avoids spending credits and exercising a
+    // specific model just to confirm the key is valid: the gateway returns 401
+    // for a bad key and 200 for a good one.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+    let response = client
+        .get("https://api.orcarouter.ai/v1/models")
+        .header("Authorization", format!("Bearer {}", body.api_key))
+        .send()
+        .await;
+
+    match response {
+        Ok(resp) if resp.status().is_success() => {
+            HttpResponse::Ok().json(serde_json::json!({"success": true}))
+        }
+        Ok(resp) => {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            HttpResponse::BadRequest().json(serde_json::json!({
+                "error": format!("API error ({}): {}", status, body)
+            }))
+        }
+        Err(e) => HttpResponse::BadGateway().json(serde_json::json!({
+            "error": format!("Network error: {}", e)
+        })),
+    }
+}
+
+#[derive(Deserialize, Serialize, ToSchema)]
 pub struct TestOpenAICompatBody {
     /// Base URL of the OpenAI-compatible API
     pub base_url: String,

--- a/docs/manual/getting-started/ai-providers.md
+++ b/docs/manual/getting-started/ai-providers.md
@@ -1,6 +1,6 @@
 ---
 title: AI Providers
-description: Configure OpenRouter, Ollama, or an OpenAI-compatible provider for embeddings and LLM features.
+description: Configure OpenRouter, OrcaRouter, Ollama, or an OpenAI-compatible provider for embeddings and LLM features.
 ---
 
 Atomic's AI features require a configured provider. The provider is used for:
@@ -11,7 +11,7 @@ Atomic's AI features require a configured provider. The provider is used for:
 - Chat responses and chat tool use
 - Daily briefings
 
-Atomic supports OpenRouter, Ollama, and OpenAI-compatible APIs.
+Atomic supports OpenRouter, OrcaRouter, Ollama, and OpenAI-compatible APIs.
 
 ## OpenRouter
 
@@ -66,6 +66,17 @@ Configure:
 
 The server has a connection-test endpoint at `POST /api/settings/test-openai-compat`.
 
+## OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is a model-routing gateway that unifies hosted models behind one OpenAI-compatible endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+1. Create an OrcaRouter account and generate an API key (prefixed `sk-orca-`).
+2. In Atomic, go to Settings and select **OrcaRouter** as the provider.
+3. Paste your API key.
+4. Choose the embedding and LLM models — use OrcaRouter model ids such as `openai/text-embedding-3-small` for embeddings and `openai/gpt-5-nano` for LLM tasks.
+
+OrcaRouter routes to many hosted providers, so model ids are namespaced (`vendor/model`). The connection-test endpoint is at `POST /api/settings/test-orcarouter`.
+
 ## Defaults
 
 Fresh databases seed these defaults:
@@ -80,6 +91,11 @@ Fresh databases seed these defaults:
 | `ollama_host` | `http://127.0.0.1:11434` |
 | `ollama_embedding_model` | `nomic-embed-text` |
 | `ollama_llm_model` | `llama3.2` |
+| `orcarouter_embedding_model` | `openai/text-embedding-3-small` |
+| `orcarouter_llm_model` | `openai/gpt-5-nano` |
+| `orcarouter_agentic_model` | `openai/gpt-5-nano` |
+| `orcarouter_context_length` | `65536` |
+| `orcarouter_timeout_secs` | `300` |
 | `auto_tagging_enabled` | `true` |
 
 ## Changing Embedding Models

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -35,6 +35,7 @@ import {
   getOpenRouterEmbeddingModels,
   testOllamaConnection,
   testOpenAICompatConnection,
+  testOrcaRouterConnection,
   getOllamaModels,
   getMcpStdioConfig,
   getMcpHttpConfig,
@@ -918,7 +919,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
   const supportedTimeZones = useMemo(() => getSupportedTimeZones(), []);
 
   // Provider selection
-  const [provider, setProvider] = useState<'openrouter' | 'ollama' | 'openai_compat'>('openrouter');
+  const [provider, setProvider] = useState<'openrouter' | 'ollama' | 'openai_compat' | 'orcarouter'>('openrouter');
 
   // OpenRouter settings
   const [apiKey, setApiKey] = useState('');
@@ -940,6 +941,16 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
   const [openaiCompatTimeoutSecs, setOpenaiCompatTimeoutSecs] = useState('300');
   const [openaiCompatStatus, setOpenaiCompatStatus] = useState<'idle' | 'checking' | 'connected' | 'error'>('idle');
   const [openaiCompatError, setOpenaiCompatError] = useState<string | null>(null);
+
+  // OrcaRouter settings
+  const [orcaRouterApiKey, setOrcaRouterApiKey] = useState('');
+  const [orcaRouterShowApiKey, setOrcaRouterShowApiKey] = useState(false);
+  const [orcaRouterEmbeddingModel, setOrcaRouterEmbeddingModel] = useState('openai/text-embedding-3-small');
+  const [orcaRouterLlmModel, setOrcaRouterLlmModel] = useState('openai/gpt-5-nano');
+  const [orcaRouterContextLength, setOrcaRouterContextLength] = useState('65536');
+  const [orcaRouterTimeoutSecs, setOrcaRouterTimeoutSecs] = useState('300');
+  const [orcaRouterStatus, setOrcaRouterStatus] = useState<'idle' | 'checking' | 'connected' | 'error'>('idle');
+  const [orcaRouterError, setOrcaRouterError] = useState<string | null>(null);
 
   // Ollama settings
   const [ollamaHost, setOllamaHost] = useState('http://127.0.0.1:11434');
@@ -1412,7 +1423,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
 
   // Load settings into state
   useEffect(() => {
-    const p = settings.provider as 'openrouter' | 'ollama' | 'openai_compat' | undefined;
+    const p = settings.provider as 'openrouter' | 'ollama' | 'openai_compat' | 'orcarouter' | undefined;
     setTheme((settings.theme as Theme) || 'obsidian');
     setFont((settings.font as Font) || 'ibm-plex-sans');
     setTimezone(settings.timezone || getBrowserTimeZone());
@@ -1441,6 +1452,11 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
     setOpenaiCompatLlmModel(settings.openai_compat_llm_model || '');
     setOpenaiCompatContextLength(settings.openai_compat_context_length || '65536');
     setOpenaiCompatTimeoutSecs(settings.openai_compat_timeout_secs || '300');
+    setOrcaRouterApiKey(settings.orcarouter_api_key || '');
+    setOrcaRouterEmbeddingModel(settings.orcarouter_embedding_model || 'openai/text-embedding-3-small');
+    setOrcaRouterLlmModel(settings.orcarouter_llm_model || 'openai/gpt-5-nano');
+    setOrcaRouterContextLength(settings.orcarouter_context_length || '65536');
+    setOrcaRouterTimeoutSecs(settings.orcarouter_timeout_secs || '300');
   }, [settings]);
 
   // Check Ollama connection when provider is ollama or host changes.
@@ -1504,6 +1520,10 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
     setPendingEmbeddingChange({ key: 'openai_compat_embedding_dimension', value, label: `${value} dimensions` });
   };
 
+  const handleOrcaRouterEmbeddingModelChange = (value: string) => {
+    setPendingEmbeddingChange({ key: 'orcarouter_embedding_model', value, label: value });
+  };
+
   const confirmEmbeddingChange = async () => {
     if (!pendingEmbeddingChange) return;
     const { key, value } = pendingEmbeddingChange;
@@ -1511,6 +1531,7 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
     if (key === 'ollama_embedding_model') setOllamaEmbeddingModel(value);
     if (key === 'openai_compat_embedding_model') setOpenaiCompatEmbeddingModel(value);
     if (key === 'openai_compat_embedding_dimension') setOpenaiCompatEmbeddingDimension(value);
+    if (key === 'orcarouter_embedding_model') setOrcaRouterEmbeddingModel(value);
     await autoSave(key, value);
     setPendingEmbeddingChange(null);
   };
@@ -1533,8 +1554,22 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
     }
   }, []);
 
+  // Test OrcaRouter connection
+  const checkOrcaRouterConnection = useCallback(async (apiKey: string) => {
+    if (!apiKey.trim()) return;
+    setOrcaRouterStatus('checking');
+    setOrcaRouterError(null);
+    try {
+      await testOrcaRouterConnection(apiKey);
+      setOrcaRouterStatus('connected');
+    } catch (e) {
+      setOrcaRouterStatus('error');
+      setOrcaRouterError(String(e));
+    }
+  }, []);
+
   // Handle provider change — test connection automatically
-  const handleProviderChange = async (value: 'openrouter' | 'ollama' | 'openai_compat') => {
+  const handleProviderChange = async (value: 'openrouter' | 'ollama' | 'openai_compat' | 'orcarouter') => {
     setProvider(value);
     await autoSave('provider', value);
     // Test connection for new provider
@@ -1553,6 +1588,8 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
       }
     } else if (value === 'openai_compat' && openaiCompatBaseUrl.trim()) {
       checkOpenaiCompatConnection(openaiCompatBaseUrl, openaiCompatApiKey || undefined);
+    } else if (value === 'orcarouter' && orcaRouterApiKey.trim()) {
+      checkOrcaRouterConnection(orcaRouterApiKey);
     }
   };
 
@@ -2024,11 +2061,12 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                     </p>
                     <CustomSelect
                       value={provider}
-                      onChange={(v) => handleProviderChange(v as 'openrouter' | 'ollama' | 'openai_compat')}
+                      onChange={(v) => handleProviderChange(v as 'openrouter' | 'ollama' | 'openai_compat' | 'orcarouter')}
                       options={[
                         { value: 'openrouter', label: 'OpenRouter' },
                         { value: 'ollama', label: 'Ollama' },
                         { value: 'openai_compat', label: 'OpenAI Compatible' },
+                        { value: 'orcarouter', label: 'OrcaRouter' },
                       ]}
                     />
                     {/* Connection status — shown inline after provider */}
@@ -2544,6 +2582,161 @@ export function SettingsModal({ isOpen, onClose, initialTab }: SettingsModalProp
                             ]}
                           />
                           <OverrideControls settingKey="openai_compat_timeout_secs" />
+                        </div>
+                      </div>
+                    </>
+                  )}
+
+                  {/* OrcaRouter Settings */}
+                  {provider === 'orcarouter' && (
+                    <>
+                      <div className="space-y-2">
+                        <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                          OrcaRouter API Key
+                        </label>
+                        <p className="text-xs text-[var(--color-text-secondary)]">
+                          Required for AI features. Get your key at orcarouter.ai
+                        </p>
+                        <div className="relative">
+                          <input
+                            type={orcaRouterShowApiKey ? 'text' : 'password'}
+                            value={orcaRouterApiKey}
+                            onChange={(e) => setOrcaRouterApiKey(e.target.value)}
+                            onBlur={() => {
+                              if (!orcaRouterApiKey.trim()) return;
+                              autoSave('orcarouter_api_key', orcaRouterApiKey);
+                              checkOrcaRouterConnection(orcaRouterApiKey);
+                            }}
+                            placeholder="sk-orca-..."
+                            className="w-full px-3 py-2 pr-10 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-md text-[var(--color-text-primary)] placeholder-[var(--color-text-secondary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:border-transparent transition-colors duration-150"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => setOrcaRouterShowApiKey(!orcaRouterShowApiKey)}
+                            className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+                          >
+                            {orcaRouterShowApiKey ? (
+                              <EyeOff className="w-5 h-5" strokeWidth={2} />
+                            ) : (
+                              <Eye className="w-5 h-5" strokeWidth={2} />
+                            )}
+                          </button>
+                        </div>
+                        {orcaRouterStatus === 'checking' && (
+                          <div className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+                            <Loader2 className="w-4 h-4 animate-spin" strokeWidth={2} />
+                            Testing connection...
+                          </div>
+                        )}
+                        {orcaRouterStatus === 'connected' && (
+                          <div className="flex items-center gap-2 text-sm text-green-500">
+                            <div className="w-2 h-2 rounded-full bg-green-500" />
+                            Connected
+                          </div>
+                        )}
+                        {orcaRouterStatus === 'error' && (
+                          <div className="flex items-center gap-2 text-sm text-red-500">
+                            <div className="w-2 h-2 rounded-full bg-red-500" />
+                            {orcaRouterError || 'Connection failed'}
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="space-y-4 pt-2">
+                        <div className="text-sm font-medium text-[var(--color-text-primary)]">Model Configuration</div>
+                        <p className="text-xs text-[var(--color-text-secondary)]">
+                          Enter the exact model names OrcaRouter expects (e.g. openai/gpt-5-nano).
+                        </p>
+
+                        {/* Embedding Model */}
+                        <div className="space-y-1">
+                          <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                            Embedding Model
+                          </label>
+                          <p className="text-xs text-[var(--color-text-secondary)]">
+                            Must match the vector dimension your database was embedded at
+                          </p>
+                          <input
+                            type="text"
+                            value={orcaRouterEmbeddingModel}
+                            onChange={(e) => setOrcaRouterEmbeddingModel(e.target.value)}
+                            onBlur={() => {
+                              if (orcaRouterEmbeddingModel !== (settings.orcarouter_embedding_model || 'openai/text-embedding-3-small')) {
+                                handleOrcaRouterEmbeddingModelChange(orcaRouterEmbeddingModel);
+                              }
+                            }}
+                            placeholder="openai/text-embedding-3-small"
+                            className="w-full px-3 py-2 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-md text-[var(--color-text-primary)] placeholder-[var(--color-text-secondary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:border-transparent transition-colors duration-150"
+                          />
+                          <OverrideControls settingKey="orcarouter_embedding_model" />
+                        </div>
+
+                        {/* LLM Model */}
+                        <div className="space-y-1">
+                          <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                            LLM Model
+                          </label>
+                          <p className="text-xs text-[var(--color-text-secondary)]">
+                            Used for tagging, wiki generation, and chat
+                          </p>
+                          <input
+                            type="text"
+                            value={orcaRouterLlmModel}
+                            onChange={(e) => setOrcaRouterLlmModel(e.target.value)}
+                            onBlur={() => autoSave('orcarouter_llm_model', orcaRouterLlmModel)}
+                            placeholder="openai/gpt-5-nano"
+                            className="w-full px-3 py-2 bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-md text-[var(--color-text-primary)] placeholder-[var(--color-text-secondary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:border-transparent transition-colors duration-150"
+                          />
+                          <OverrideControls settingKey="orcarouter_llm_model" />
+                        </div>
+
+                        {/* Context Length */}
+                        <div className="space-y-1">
+                          <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                            Context Length
+                          </label>
+                          <p className="text-xs text-[var(--color-text-secondary)]">
+                            Max context window of your LLM model (used to truncate prompts)
+                          </p>
+                          <CustomSelect
+                            value={orcaRouterContextLength}
+                            onChange={(v) => { setOrcaRouterContextLength(v); autoSave('orcarouter_context_length', v); }}
+                            options={[
+                              { value: '2048', label: '2K' },
+                              { value: '4096', label: '4K' },
+                              { value: '8192', label: '8K' },
+                              { value: '16384', label: '16K' },
+                              { value: '32768', label: '32K' },
+                              { value: '65536', label: '64K' },
+                              { value: '131072', label: '128K' },
+                              { value: '262144', label: '256K' },
+                              { value: '1000000', label: '1M' },
+                            ]}
+                          />
+                          <OverrideControls settingKey="orcarouter_context_length" />
+                        </div>
+
+                        {/* Timeout */}
+                        <div className="space-y-1">
+                          <label className="block text-sm font-medium text-[var(--color-text-primary)]">
+                            Request Timeout
+                          </label>
+                          <p className="text-xs text-[var(--color-text-secondary)]">
+                            Maximum time to wait for the gateway to respond
+                          </p>
+                          <CustomSelect
+                            value={orcaRouterTimeoutSecs}
+                            onChange={(v) => { setOrcaRouterTimeoutSecs(v); autoSave('orcarouter_timeout_secs', v); }}
+                            options={[
+                              { value: '30', label: '30 seconds' },
+                              { value: '60', label: '60 seconds' },
+                              { value: '120', label: '2 minutes' },
+                              { value: '180', label: '3 minutes' },
+                              { value: '300', label: '5 minutes' },
+                              { value: '600', label: '10 minutes' },
+                            ]}
+                          />
+                          <OverrideControls settingKey="orcarouter_timeout_secs" />
                         </div>
                       </div>
                     </>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -518,6 +518,10 @@ export async function testOpenAICompatConnection(baseUrl: string, apiKey?: strin
   return getTransport().invoke('test_openai_compat_connection', { baseUrl, apiKey });
 }
 
+export async function testOrcaRouterConnection(apiKey: string): Promise<boolean> {
+  return getTransport().invoke('test_orcarouter_connection', { apiKey });
+}
+
 export async function getOllamaModels(host: string): Promise<OllamaModel[]> {
   return getTransport().invoke('get_ollama_models', { host });
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -33,6 +33,7 @@ export const WORKSPACE_ONLY_KEYS: readonly string[] = [
   'timezone',
   'openrouter_api_key',
   'openai_compat_api_key',
+  'orcarouter_api_key',
   'ollama_host',
   'openai_compat_base_url',
 ];

--- a/src/lib/transport/command-map.ts
+++ b/src/lib/transport/command-map.ts
@@ -433,6 +433,13 @@ export const COMMAND_MAP: Record<string, CommandSpec> = {
     transformArgs: (a) => ({ api_key: a.apiKey }),
     transformResponse: (d: any) => d.success as boolean,
   },
+  test_orcarouter_connection: {
+    method: 'POST',
+    path: '/api/settings/test-orcarouter',
+    argsMode: 'body',
+    transformArgs: (a) => ({ api_key: a.apiKey }),
+    transformResponse: (d: any) => d.success as boolean,
+  },
   get_available_llm_models: {
     method: 'GET',
     path: '/api/settings/models',

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -36,6 +36,7 @@ interface SettingsStore {
   setSetting: (key: string, value: string) => Promise<void>;
   clearOverride: (key: string) => Promise<void>;
   testOpenRouterConnection: (apiKey: string) => Promise<boolean>;
+  testOrcaRouterConnection: (apiKey: string) => Promise<boolean>;
 }
 
 function splitResolvedSettings(
@@ -110,6 +111,14 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
   testOpenRouterConnection: async (apiKey: string) => {
     const result = await getTransport().invoke<boolean>(
       'test_openrouter_connection',
+      { apiKey },
+    );
+    return result;
+  },
+
+  testOrcaRouterConnection: async (apiKey: string) => {
+    const result = await getTransport().invoke<boolean>(
+      'test_orcarouter_connection',
       { apiKey },
     );
     return result;


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider, mirroring the existing OpenRouter and OpenAI-compatible integrations. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint (`https://api.orcarouter.ai/v1`) and one API key, using fully-namespaced model ids (e.g. `openai/gpt-5-nano`, `openai/text-embedding-3-small`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `crates/atomic-core/src/providers/mod.rs` — new `ProviderType::OrcaRouter` variant and `orcarouter_*` config fields (api key, llm / agentic / embedding model, context length, timeout). The provider reuses the shared OpenAI-compatible transport pinned to `https://api.orcarouter.ai/v1`, with OrcaRouter-valid defaults (`openai/text-embedding-3-small` at 1536 dims for embeddings, `openai/gpt-5-nano` for LLM tasks).
- `crates/atomic-core/src/settings.rs` — registers `orcarouter_api_key` as a workspace-only credential, `orcarouter_embedding_model` as an embedding-space key, and seeds the new defaults.
- `crates/atomic-core/src/agent.rs`, `src/lib.rs`, `src/reports/agentic.rs` — resolve models for chat, wiki, tagging, and reports through the new provider.
- `crates/atomic-cloud/src/tenant_plane.rs` — validates OrcaRouter keys against the gateway's `/v1/models` endpoint for BYOK entry.
- `crates/atomic-server/src/routes/settings.rs` — new `POST /api/settings/test-orcarouter` connection-test endpoint (key checked against `/v1/models`, no credits spent).
- `src/components/settings/SettingsModal.tsx` — OrcaRouter option in the provider dropdown, API key entry with inline connection test, and model configuration.
- `src/lib/api.ts`, `src/lib/transport/command-map.ts`, `src/stores/settings.ts`, `src/lib/settings.ts` — frontend plumbing for the new setting and test endpoint.
- `docs/manual/getting-started/ai-providers.md` — OrcaRouter section and defaults table.

## Why a named provider rather than the OpenAI-compatible escape hatch

This mirrors how OpenRouter is wired in this repo: a named provider with its own API-key setting, connection test, and model defaults. A generic `openai_compat` entry would require the user to hand-enter `https://api.orcarouter.ai/v1` plus the exact namespaced model ids every time; the dedicated provider sets those up by default and keeps the Settings UI consistent with the other providers.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. In Settings, pick **OrcaRouter** as the provider and paste your key.
3. The defaults (`openai/text-embedding-3-small`, `openai/gpt-5-nano`) work out of the box; any catalog model id can be entered.

## Verification

- Unit tests: `cargo test -p atomic-core --lib providers::` — 86 passed, 0 failed.
- Compiles: `cargo check -p atomic-core -p atomic-cloud -p atomic-server` clean; `tsc --noEmit` clean.
- Live API: `GET https://api.orcarouter.ai/v1/models` with a real `sk-orca-` key returns 200; both default model ids (`openai/text-embedding-3-small`, `openai/gpt-5-nano`) are present in the catalog.

I'm an engineer on the OrcaRouter team.
